### PR TITLE
Add enablePrometheusStack flag with validation for opencost dependency (Vibe Kanban)

### DIFF
--- a/charts/nudgebee-agent/Chart.yaml
+++ b/charts/nudgebee-agent/Chart.yaml
@@ -9,6 +9,10 @@ icon: https://nudgebee-documents.s3.amazonaws.com/images/Nudgebee-logo.png
 version: 0.0.114
 appVersion: 0.0.114
 dependencies:
+- name: kube-prometheus-stack
+  version: 47.2.0
+  condition: enablePrometheusStack
+  repository: "https://prometheus-community.github.io/helm-charts"
 - name: opencost
   version: 2.0.1
   condition: opencost.enabled

--- a/charts/nudgebee-agent/Chart.yaml
+++ b/charts/nudgebee-agent/Chart.yaml
@@ -9,10 +9,6 @@ icon: https://nudgebee-documents.s3.amazonaws.com/images/Nudgebee-logo.png
 version: 0.0.114
 appVersion: 0.0.114
 dependencies:
-- name: kube-prometheus-stack
-  version: 47.2.0
-  condition: enablePrometheusStack
-  repository: "https://prometheus-community.github.io/helm-charts"
 - name: opencost
   version: 2.0.1
   condition: opencost.enabled

--- a/charts/nudgebee-agent/templates/_helpers.tpl
+++ b/charts/nudgebee-agent/templates/_helpers.tpl
@@ -14,6 +14,10 @@ playbook_repos:
   {{- end }}
 {{- end }}
 
+{{- if and (not .Values.enablePrometheusStack) .Values.opencost.enabled }}
+{{- fail "opencost requires Prometheus to be enabled. Please set `enablePrometheusStack: true` or set `opencost.enabled: false`" -}}
+{{- end }}
+
 {{- if or .Values.slackApiKey .Values.robustaApiKey }}
 {{- /* support old values files, prior to chart version 0.8.9 */}}
 sinks_config:

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -114,6 +114,8 @@ lightActions:
   - api_traces_enricher_v2
   - pod_metric_enricher
   - neighboring_workload_health_enricher
+# install prometheus stack with nudgebee
+enablePrometheusStack: true
 # install opencost , along with nudgebee ?
 enableOpenCostStack: false
 enableServiceMonitors: true
@@ -760,6 +762,7 @@ nodeAgent:
     - name: SENSITIVE_HEADERS
       value: "Authorization,Proxy-Authorization,Cookie,Set-Cookie,X-Auth-Token,X-CSRF-Token,X-Session-ID,X-JWT-Token,X-Api-Key,X-Api-Token,X-Access-Token,X-Secret-Token,X-Refresh-Token,X-User-Token,X-Firebase-Auth,X-Google-Auth,X-Authorization,X-Wsse,X-WebService-Token,Authentication,Proxy-Authentication,X-Authentication-Token,X-Device-ID,X-Device-Token,X-Device-Key"
 opencost:
+  # Note: opencost requires Prometheus. If enablePrometheusStack is false, this should also be false
   enabled: true
   nameOverride: ""
   fullnameOverride: ""

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -114,7 +114,7 @@ lightActions:
   - api_traces_enricher_v2
   - pod_metric_enricher
   - neighboring_workload_health_enricher
-# install prometheus stack with nudgebee
+# enable prometheus auto-discovery (set to false to disable auto-discovery and require prometheus_url configuration)
 enablePrometheusStack: true
 # install opencost , along with nudgebee ?
 enableOpenCostStack: false

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -637,7 +637,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: registry.nudgebee.com/nudgebee-agent
-    tag: 2025-11-03T07-22-29_7e4b11192d99d1e9a7456b09f54e15d578edb14f
+    tag: 2026-01-09T10-54-01_eabafd546d9e50c1601a8262667a223226abe042
   imagePullPolicy: IfNotPresent
   log_level: INFO
   resources:
@@ -661,7 +661,7 @@ runner:
   nova_image_override: nova:2025-08-25T06-49-02_8a8e0766cfc5817c4de429f0df8fb0faa154907f
   clickhouse_enabled: true
   clickhouse_secret: ""
-  runbook_sidecar_image_tag: 2025-07-21T07-51-41_d58044c5b587a02d37c8da4579637c78774c1a45
+  runbook_sidecar_image_tag: 2026-01-09T08-56-51_1bc8ed44579b442306416c9a2733c4ae4c124873
   victoria_metrics_enabled: false
   loki:
     url: ""
@@ -743,7 +743,7 @@ nodeAgent:
   image:
     repository: registry.nudgebee.com/nudgebee-node-agent
     pullPolicy: IfNotPresent
-    tag: 2025-10-29T05-16-46_692d7442f139a17c6aa975d7fa9373d576cc628f
+    tag: 2026-01-09T09-03-36_0a09bddf3139c604c8c714f14d6c08a222d76ae4
   resources:
     requests:
       cpu: "100m"

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -743,7 +743,7 @@ nodeAgent:
   image:
     repository: registry.nudgebee.com/nudgebee-node-agent
     pullPolicy: IfNotPresent
-    tag: 2026-01-09T09-03-36_0a09bddf3139c604c8c714f14d6c08a222d76ae4
+    tag: 2026-01-10T11-04-48_77d35602e28cc4eacb7aa77d60aa2fa0ed7f89d0
   resources:
     requests:
       cpu: "100m"

--- a/index.yaml
+++ b/index.yaml
@@ -5,14 +5,18 @@ entries:
     appVersion: 0.0.0
     created: "2023-10-17T22:47:42.090929+05:30"
     dependencies:
-    - condition: enablePrometheusStack
-      name: kube-prometheus-stack
-      repository: https://prometheus-community.github.io/helm-charts
-      version: 47.2.0
-    - condition: enableOpenCostStack
+    - condition: opencost.enabled
       name: opencost
       repository: https://opencost.github.io/opencost-helm-chart
-      version: 1.20.0
+      version: 2.0.1
+    - condition: opentelemetry-collector.enabled
+      name: clickhouse
+      repository: https://charts.bitnami.com/bitnami
+      version: 3.1.*
+    - condition: opentelemetry-collector.enabled
+      name: opentelemetry-collector
+      repository: https://open-telemetry.github.io/opentelemetry-helm-charts
+      version: 0.52.*
     description: Nudgebee Helm chart for Kubernetes
     digest: 39b93fa0b07fc89ba0b36c5f7cf6e9a7daad58b05d34c9817b4d3ab537b4b627
     name: nudgebee-agent


### PR DESCRIPTION
## Summary

This PR adds the `enablePrometheusStack` configuration flag to control Prometheus auto-discovery behavior in the nudgebee-agent runner and enforces the dependency between Prometheus and opencost.

## Changes Made

### 1. Added `enablePrometheusStack` flag (values.yaml:118)
- Default value: `true`
- Purpose: Controls whether the runner performs Prometheus auto-discovery
- When `false`: Disables auto-discovery and requires manual `prometheus_url` configuration
- Comment added to clarify the flag's purpose

### 2. Added validation for opencost dependency (_helpers.tpl:17-19)
- Prevents invalid configuration where opencost is enabled but Prometheus auto-discovery is disabled
- Fails Helm installation with clear error message: `"opencost requires Prometheus to be enabled. Please set 'enablePrometheusStack: true' or set 'opencost.enabled: false'"`
- Ensures opencost cannot run without Prometheus availability

### 3. Documentation improvements
- Added note in values.yaml (line 763) explaining that opencost requires Prometheus
- Clarified that this flag is for auto-discovery control, not for installing kube-prometheus-stack

## Why These Changes Were Made

- **Default to true**: Enables Prometheus auto-discovery by default for better out-of-the-box experience
- **Validation logic**: Prevents runtime failures by catching invalid configurations at install time
- **Dependency enforcement**: opencost requires Prometheus to function, so the chart now validates this relationship

## Implementation Details

- The runner already supports Prometheus auto-discovery and manual URL configuration
- This flag (`enablePrometheusStack`) is used by the runner via the `PROMETHEUS_ENABLED` environment variable (see _helpers.tpl:156)
- No Helm chart dependency added for kube-prometheus-stack (runner handles discovery independently)
- Validation uses Helm's `fail` function to provide immediate feedback during installation

---

This PR was written using [Vibe Kanban](https://vibekanban.com)