### PR TITLE
feat: add enableWritePermissions flag for runner service account

### DIFF
--- a/charts/nudgebee-agent/templates/runner-service-account.yaml
+++ b/charts/nudgebee-agent/templates/runner-service-account.yaml
@@ -290,6 +290,142 @@ rules:
     - pods
     - nodes
     verbs:     ["get", "list"]
+
+{{- if .Values.runner.enableWritePermissions }}
+  # -- Write permissions (runner.enableWritePermissions) --
+
+  # Node delete - required for node graceful shutdown (kubectl delete node)
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - delete
+
+  # Service lifecycle management
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - create
+      - update
+      - patch
+      - delete
+
+  # Secret update/delete (base already has create/list/get)
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - update
+      - patch
+      - delete
+
+  # Namespace creation
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - create
+      - delete
+
+  # Endpoint management
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - create
+      - update
+      - patch
+      - delete
+
+  # ServiceAccount management
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - create
+      - update
+      - patch
+      - delete
+
+  # ResourceQuotas and LimitRanges
+  - apiGroups:
+      - ""
+    resources:
+      - resourcequotas
+      - limitranges
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+
+  # StatefulSet scale subresource + create for all apps resources
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets/scale
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+
+  # Workload creation (create_workload action)
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - statefulsets
+      - daemonsets
+      - replicasets
+    verbs:
+      - create
+
+  # Ingress write access
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+      - networkpolicies
+    verbs:
+      - create
+      - update
+      - patch
+      - delete
+
+  # Extensions ingress write
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - create
+      - delete
+
+  # RBAC read for roles/rolebindings (namespace-scoped)
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+      - rolebindings
+    verbs:
+      - create
+      - update
+      - patch
+      - delete
+{{- end }}
+
 {{- if (.Capabilities.APIVersions.Has "argoproj.io/v1alpha1/Rollout") }}
   - apiGroups:
     - argoproj.io
@@ -300,6 +436,10 @@ rules:
     - list
     - patch
     - update
+{{- if .Values.runner.enableWritePermissions }}
+    - create
+    - delete
+{{- end }}
 {{- end }}
 
 {{- if or (.Capabilities.APIVersions.Has "karpenter.sh/v1beta1/NodePool") (.Capabilities.APIVersions.Has "karpenter.sh/v1/NodePool") }}

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -636,7 +636,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: registry.nudgebee.com/nudgebee-agent
-    tag: 2026-01-09T10-54-01_eabafd546d9e50c1601a8262667a223226abe042
+    tag: 2026-02-10T12-19-32_e0410e35183bf51938e84004f2885ee7451c9d2e
   imagePullPolicy: IfNotPresent
   log_level: INFO
   resources:
@@ -665,7 +665,7 @@ runner:
   nova_image_override: nova:2025-08-25T06-49-02_8a8e0766cfc5817c4de429f0df8fb0faa154907f
   clickhouse_enabled: true
   clickhouse_secret: ""
-  runbook_sidecar_image_tag: 2026-01-09T08-56-51_1bc8ed44579b442306416c9a2733c4ae4c124873
+  runbook_sidecar_image_tag: 2026-01-21T12-26-01_65a85cc1e589d506b9d5fa39f684d61c98638c4e
   victoria_metrics_enabled: false
   loki:
     url: ""
@@ -747,7 +747,7 @@ nodeAgent:
   image:
     repository: registry.nudgebee.com/nudgebee-node-agent
     pullPolicy: IfNotPresent
-    tag: 2026-01-12T03-44-08_8755b8391c96d6fefd4f4c6726d3796fe7bdcc5c
+    tag: 2026-02-11T12-50-36_f509857e08ab0e3e6d7bece9d4272e641eec4714
   resources:
     requests:
       cpu: "100m"

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -648,6 +648,11 @@ runner:
   tolerations: []
   annotations: {}
   nodeSelector: ~
+  # Enable write permissions for the runner service account.
+  # Adds permissions for: node delete/drain, service management, secret updates,
+  # ingress/networkpolicy writes, resource quotas, limit ranges, namespace creation,
+  # statefulset scaling, workload creation, and rollout lifecycle management.
+  enableWritePermissions: false
   customClusterRoleRules: []
   imagePullSecrets: []
   extraVolumes: []


### PR DESCRIPTION
# Description

Adds a new `runner.enableWritePermissions` flag (default: `false`) to the runner ClusterRole that grants additional write permissions required for kubectl executor tool calls, workload lifecycle management, and node operations.

## Permissions added when `enableWritePermissions: true`

| Resource | Verbs Added | Use Case |
|----------|-------------|----------|
| nodes | delete | Node graceful shutdown (`kubectl delete node`) |
| services | create, update, patch, delete | Service lifecycle management |
| secrets | update, patch, delete | Secret management (base has create/list/get) |
| namespaces | create, delete | Namespace management |
| endpoints | create, update, patch, delete | Endpoint management |
| serviceaccounts | create, update, patch, delete | SA management |
| resourcequotas, limitranges | full CRUD | Quota/limit management |
| statefulsets/scale (apps) | get, list, watch, patch, update | StatefulSet scaling |
| deployments, statefulsets, daemonsets, replicasets (apps) | create | Workload creation |
| ingresses, networkpolicies (networking.k8s.io) | create, update, patch, delete | Network resource management |
| ingresses (extensions) | create, delete | Legacy ingress management |
| roles, rolebindings (rbac) | create, update, patch, delete | RBAC management |
| rollouts (argoproj.io) | create, delete | Rollout lifecycle (added to existing block) |

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Helm template renders correctly with `enableWritePermissions=true`
- [x] Helm template renders correctly with `enableWritePermissions=false` (no extended permissions present)
- [x] Verified against actual tool call implementations in llm-server and runbook-server