### PR TITLE
fix: set loki datasource isDefault=false to prevent Grafana crash

### DIFF
--- a/charts/nudgebee-agent/Chart.yaml
+++ b/charts/nudgebee-agent/Chart.yaml
@@ -6,8 +6,8 @@ icon: https://nudgebee-documents.s3.amazonaws.com/images/Nudgebee-logo.png
 # these are set to the right value by .github/workflows/release.yaml
 # we use 0.0.1 as a placeholder for the version` because Helm wont allow `0.0.0` and we want to be able to run
 # `helm install` on development checkouts without updating this file. the version doesn't matter in that case anyway
-version: 0.0.116
-appVersion: 0.0.116
+version: 0.0.117
+appVersion: 0.0.117
 dependencies:
 - name: opencost
   version: 2.0.1

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -636,7 +636,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: registry.nudgebee.com/nudgebee-agent
-    tag: 2026-01-21T12-24-21_79e6d1636bbb39c92a9a7ad920bf5b289b4884ff
+    tag: 2026-02-23T11-40-46_a877fb4fba436266b3cb149653d0b608b0b16c52
   imagePullPolicy: IfNotPresent
   log_level: INFO
   resources:
@@ -746,7 +746,7 @@ nodeAgent:
   image:
     repository: registry.nudgebee.com/nudgebee-node-agent
     pullPolicy: IfNotPresent
-    tag: 2025-10-30T06-03-21_51d2a93f9e1d6a610034b3e6ff24cabb5f5c6e9e
+    tag: 2026-02-23T12-58-40_883beeae44deee8b4355f159e7b9e4898648b2aa
   resources:
     requests:
       cpu: "100m"

--- a/installation.sh
+++ b/installation.sh
@@ -250,7 +250,12 @@ if [ -z "$loki_url" ]; then
         # Add Helm installation command here or instructions
         helm repo add grafana https://grafana.github.io/helm-charts
         helm repo update
-        helm upgrade --install nudgebee-loki grafana/loki-stack -n $namespace --create-namespace --set loki.persistence.enabled=true --set loki.persistence.size=10Gi --set promtail.enabled=true --set loki.isDefault=false
+        helm upgrade --install nudgebee-loki grafana/loki-stack \
+            -n "$namespace" --create-namespace \
+            --set loki.persistence.enabled=true \
+            --set loki.persistence.size=10Gi \
+            --set promtail.enabled=true \
+            --set loki.isDefault=false
         loki_url="http://nudgebee-loki:3100"
     else
         echo "Loki installation not requested. Node Agent will still be installed."

--- a/installation.sh
+++ b/installation.sh
@@ -250,7 +250,7 @@ if [ -z "$loki_url" ]; then
         # Add Helm installation command here or instructions
         helm repo add grafana https://grafana.github.io/helm-charts
         helm repo update
-        helm upgrade --install nudgebee-loki grafana/loki-stack -n $namespace --create-namespace --set loki.persistence.enabled=true --set loki.persistence.size=10Gi --set promtail.enabled=true
+        helm upgrade --install nudgebee-loki grafana/loki-stack -n $namespace --create-namespace --set loki.persistence.enabled=true --set loki.persistence.size=10Gi --set promtail.enabled=true --set loki.isDefault=false
         loki_url="http://nudgebee-loki:3100"
     else
         echo "Loki installation not requested. Node Agent will still be installed."


### PR DESCRIPTION
## Summary

- loki-stack chart creates a Loki datasource ConfigMap with `isDefault: true` by default
- Combined with kube-prometheus-stack's Prometheus datasource (also `isDefault: true`), Grafana fails during provisioning with: `Only one datasource per organization can be marked as default`
- Fix: add `--set loki.isDefault=false` to the loki-stack helm install command

## Test plan

- [ ] Fresh install using `installation.sh` with both Prometheus and Loki — Grafana should start without datasource provisioning errors
- [ ] Verify Prometheus remains the default datasource in Grafana
- [ ] Verify Loki datasource is still available (just not default)