### PR TITLE
fix: expose rate_limit params for builtin playbook triggers

### DIFF
--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -640,7 +640,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: registry.nudgebee.com/nudgebee-agent
-    tag: 2026-03-20T13-39-48_7ec3f1ffdba8a3d44f793e716b52987af426d23c
+    tag: 2026-03-23T12-03-00_b5fb6a3dec070d497d8abe5c8957429d61363c5b
   imagePullPolicy: IfNotPresent
   log_level: INFO
   resources:

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -265,6 +265,8 @@ builtinPlaybooks:
   - triggers:
       - on_pod_crash_loop:
           restart_reason: "CrashLoopBackOff"
+          rate_limit: 14400 # 4 hours, per workload
+          restart_count: 2
     actions:
       - report_crash_loop: {}
       - resource_events_enricher: {}
@@ -273,7 +275,9 @@ builtinPlaybooks:
           previous: true
       - impacted_services_enricher: {}
   - triggers:
-      - on_image_pull_backoff: {}
+      - on_image_pull_backoff:
+          rate_limit: 14400 # 4 hours, per workload
+          fire_delay: 120 # seconds, avoids false positives on startup
     actions:
       - image_pull_backoff_reporter: {}
       - resource_events_enricher: {}
@@ -281,7 +285,7 @@ builtinPlaybooks:
   # playbooks for non-prometheus based monitoring that use prometheus for enrichment
   - triggers:
       - on_pod_oom_killed:
-          rate_limit: 3600
+          rate_limit: 3600 # 1 hour, per workload
     actions:
       - pod_oom_killer_enricher: {}
       - logs_enricher:


### PR DESCRIPTION
## Summary
- Expose `rate_limit` and `restart_count` params for `on_pod_crash_loop` trigger (defaults: 14400s, 2 restarts)
- Expose `rate_limit` and `fire_delay` params for `on_image_pull_backoff` trigger (defaults: 14400s, 120s)
- Add inline comment to existing `on_pod_oom_killed` rate_limit

No behavioral change — these are the same defaults from the Python trigger classes, just made visible in Helm values so customers can find and override them.

## Test plan
- [ ] Verify `helm template` renders correctly with default values
- [ ] Verify overriding rate_limit in custom values works as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Improved crash detection with intelligent rate limiting to reduce alert fatigue
  * Enhanced image pull failure detection with startup delay to prevent false positives
  * Updated core service component to latest version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->