### PR TITLE
fix: add --no-paginate to nudgebee-agent ECR query

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Update Helm Package for Nudgebee RC
         working-directory: ./charts/nudgebee-agent
         run: |
-          nudgebee_app_image=`aws ecr describe-images --repository-name nudgebee-agent --filter tagStatus=TAGGED --query 'sort_by(imageDetails[?imageTags], &imagePushedAt)[-1].imageTags[0]' --region us-east-1 --output text`
+          nudgebee_app_image=`aws ecr describe-images --repository-name nudgebee-agent --filter tagStatus=TAGGED --query 'sort_by(imageDetails[?imageTags], &imagePushedAt)[-1].imageTags[0]' --region us-east-1 --output text --no-paginate`
           echo "nudgebee_app_image: $nudgebee_app_image"
           yq -i ".runner.image.tag=\"$nudgebee_app_image\"" values.yaml
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Update Helm Package for Nudgebee
         working-directory: ./charts/nudgebee-agent
         run: |
-          nudgebee_app_image=`aws ecr describe-images --repository-name nudgebee-agent --filter tagStatus=TAGGED --query 'sort_by(imageDetails[?imageTags], &imagePushedAt)[-1].imageTags[0]' --region us-east-1 --output text`
+          nudgebee_app_image=`aws ecr describe-images --repository-name nudgebee-agent --filter tagStatus=TAGGED --query 'sort_by(imageDetails[?imageTags], &imagePushedAt)[-1].imageTags[0]' --region us-east-1 --output text --no-paginate`
           echo "nudgebee_app_image: $nudgebee_app_image"
           yq -i ".runner.image.tag=\"$nudgebee_app_image\"" values.yaml
 


### PR DESCRIPTION
## Summary
- The `nudgebee-agent` ECR image query in `release.yml` and `release-rc.yml` was missing `--no-paginate`, unlike every other ECR query in the same step.
- Without it, the JMESPath query runs per-page, returning one "latest" image per page. This produces a multi-line variable with two tags, which is an invalid image tag.
- This caused `InvalidImageTag` errors when installing the helm chart.

## Test plan
- [ ] Trigger the release workflow and verify `nudgebee_app_image` resolves to a single tag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional write permissions configuration for the runner service account (disabled by default for security).

* **Chores**
  * Updated container image versions to latest builds.
  * Removed deprecated scheduled playbooks from default configuration.
  * Improved release workflow reliability with enhanced image lookup handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->