### PR TITLE
fix: add --no-paginate to nudgebee-agent ECR query

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Update Helm Package for Nudgebee RC
         working-directory: ./charts/nudgebee-agent
         run: |
-          nudgebee_app_image=`aws ecr describe-images --repository-name nudgebee-agent --filter tagStatus=TAGGED --query 'sort_by(imageDetails[?imageTags], &imagePushedAt)[-1].imageTags[0]' --region us-east-1 --output text`
+          nudgebee_app_image=`aws ecr describe-images --repository-name nudgebee-agent --filter tagStatus=TAGGED --query 'sort_by(imageDetails[?imageTags], &imagePushedAt)[-1].imageTags[0]' --region us-east-1 --output text --no-paginate`
           echo "nudgebee_app_image: $nudgebee_app_image"
           yq -i ".runner.image.tag=\"$nudgebee_app_image\"" values.yaml
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Update Helm Package for Nudgebee
         working-directory: ./charts/nudgebee-agent
         run: |
-          nudgebee_app_image=`aws ecr describe-images --repository-name nudgebee-agent --filter tagStatus=TAGGED --query 'sort_by(imageDetails[?imageTags], &imagePushedAt)[-1].imageTags[0]' --region us-east-1 --output text`
+          nudgebee_app_image=`aws ecr describe-images --repository-name nudgebee-agent --filter tagStatus=TAGGED --query 'sort_by(imageDetails[?imageTags], &imagePushedAt)[-1].imageTags[0]' --region us-east-1 --output text --no-paginate`
           echo "nudgebee_app_image: $nudgebee_app_image"
           yq -i ".runner.image.tag=\"$nudgebee_app_image\"" values.yaml
 

--- a/charts/nudgebee-agent/templates/runner-service-account.yaml
+++ b/charts/nudgebee-agent/templates/runner-service-account.yaml
@@ -290,6 +290,142 @@ rules:
     - pods
     - nodes
     verbs:     ["get", "list"]
+
+{{- if .Values.runner.enableWritePermissions }}
+  # -- Write permissions (runner.enableWritePermissions) --
+
+  # Node delete - required for node graceful shutdown (kubectl delete node)
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - delete
+
+  # Service lifecycle management
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - create
+      - update
+      - patch
+      - delete
+
+  # Secret update/delete (base already has create/list/get)
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - update
+      - patch
+      - delete
+
+  # Namespace creation
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - create
+      - delete
+
+  # Endpoint management
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - create
+      - update
+      - patch
+      - delete
+
+  # ServiceAccount management
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - create
+      - update
+      - patch
+      - delete
+
+  # ResourceQuotas and LimitRanges
+  - apiGroups:
+      - ""
+    resources:
+      - resourcequotas
+      - limitranges
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+
+  # StatefulSet scale subresource + create for all apps resources
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets/scale
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+
+  # Workload creation (create_workload action)
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - statefulsets
+      - daemonsets
+      - replicasets
+    verbs:
+      - create
+
+  # Ingress write access
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+      - networkpolicies
+    verbs:
+      - create
+      - update
+      - patch
+      - delete
+
+  # Extensions ingress write
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - create
+      - delete
+
+  # RBAC read for roles/rolebindings (namespace-scoped)
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+      - rolebindings
+    verbs:
+      - create
+      - update
+      - patch
+      - delete
+{{- end }}
+
 {{- if (.Capabilities.APIVersions.Has "argoproj.io/v1alpha1/Rollout") }}
   - apiGroups:
     - argoproj.io
@@ -300,6 +436,10 @@ rules:
     - list
     - patch
     - update
+{{- if .Values.runner.enableWritePermissions }}
+    - create
+    - delete
+{{- end }}
 {{- end }}
 
 {{- if or (.Capabilities.APIVersions.Has "karpenter.sh/v1beta1/NodePool") (.Capabilities.APIVersions.Has "karpenter.sh/v1/NodePool") }}

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -636,7 +636,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: registry.nudgebee.com/nudgebee-agent
-    tag: 2026-01-09T10-54-01_eabafd546d9e50c1601a8262667a223226abe042
+    tag: 2026-02-10T12-19-32_e0410e35183bf51938e84004f2885ee7451c9d2e
   imagePullPolicy: IfNotPresent
   log_level: INFO
   resources:
@@ -648,6 +648,11 @@ runner:
   tolerations: []
   annotations: {}
   nodeSelector: ~
+  # Enable write permissions for the runner service account.
+  # Adds permissions for: node delete/drain, service management, secret updates,
+  # ingress/networkpolicy writes, resource quotas, limit ranges, namespace creation,
+  # statefulset scaling, workload creation, and rollout lifecycle management.
+  enableWritePermissions: false
   customClusterRoleRules: []
   imagePullSecrets: []
   extraVolumes: []
@@ -660,7 +665,7 @@ runner:
   nova_image_override: nova:2025-08-25T06-49-02_8a8e0766cfc5817c4de429f0df8fb0faa154907f
   clickhouse_enabled: true
   clickhouse_secret: ""
-  runbook_sidecar_image_tag: 2026-01-09T08-56-51_1bc8ed44579b442306416c9a2733c4ae4c124873
+  runbook_sidecar_image_tag: 2026-01-21T12-26-01_65a85cc1e589d506b9d5fa39f684d61c98638c4e
   victoria_metrics_enabled: false
   loki:
     url: ""
@@ -742,7 +747,7 @@ nodeAgent:
   image:
     repository: registry.nudgebee.com/nudgebee-node-agent
     pullPolicy: IfNotPresent
-    tag: 2026-01-12T03-44-08_8755b8391c96d6fefd4f4c6726d3796fe7bdcc5c
+    tag: 2026-02-11T12-50-36_f509857e08ab0e3e6d7bece9d4272e641eec4714
   resources:
     requests:
       cpu: "100m"

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -624,7 +624,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: registry.nudgebee.com/nudgebee-agent
-    tag: 2026-02-10T12-19-32_e0410e35183bf51938e84004f2885ee7451c9d2e
+    tag: 2026-03-07T11-58-24_ac1360dbc5401f549c7bba75d382e1ce22071d41
   imagePullPolicy: IfNotPresent
   log_level: INFO
   resources:
@@ -650,7 +650,7 @@ runner:
   relay_address: wss://relay.nudgebee.com/register
   profiler_image_override: 2025-10-07T09-20-18_6ede7487ac41f9c167a2e547e70ac7e7a2de7a88
   kubepug_image_override: kubepug:2025-08-13T08-26-24_d16f6f2d1e27c24258c36ab8caf2054b583aa3cb
-  nova_image_override: nova:2025-08-25T06-49-02_8a8e0766cfc5817c4de429f0df8fb0faa154907f
+  nova_image_override: nova:2026-03-07T11-56-14_c1432955300a4a231c9d6a364513ec680898f595
   clickhouse_enabled: true
   clickhouse_secret: ""
   runbook_sidecar_image_tag: 2026-01-21T12-26-01_65a85cc1e589d506b9d5fa39f684d61c98638c4e
@@ -735,7 +735,7 @@ nodeAgent:
   image:
     repository: registry.nudgebee.com/nudgebee-node-agent
     pullPolicy: IfNotPresent
-    tag: 2026-02-11T12-50-36_f509857e08ab0e3e6d7bece9d4272e641eec4714
+    tag: 2026-03-07T13-05-46_d38d1d4491462852250825a90161b417b21d5c3a
   resources:
     requests:
       cpu: "100m"

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -208,12 +208,6 @@ customPlaybooks:
           cron_schedule_repeat:
             cron_expression: "0 12 * * *" # every day at 12:00
     actions:
-      - krr_scan: {}
-  - triggers:
-      - on_schedule:
-          cron_schedule_repeat:
-            cron_expression: "0 12 * * *" # every day at 12:00
-    actions:
       - certificate_scanner: {}
   - triggers:
       - on_schedule:
@@ -239,12 +233,6 @@ customPlaybooks:
             cron_expression: "0 0 * * *" # every day at 00:00
     actions:
       - unused_pv: {}
-  - triggers:
-      - on_schedule:
-          cron_schedule_repeat:
-            cron_expression: "0 */4 * * *" # every 4 hour
-    actions:
-      - volume_analyzer: {}
   - triggers:
       - on_deployment_all_changes: {}
       - on_daemonset_all_changes: {}

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -628,7 +628,9 @@ runnerServiceAccount:
 runner:
   image:
     repository: registry.nudgebee.com/nudgebee-agent
-    tag: 2026-03-07T11-58-24_ac1360dbc5401f549c7bba75d382e1ce22071d41
+    tag: |-
+      2026-03-27T12-08-19_a6f2ef26c0dfbca5d64d837c72f5f681f27650b8
+      2025-11-12T06-00-45_8ab57887ffd3ee0611c8b3e1a51413d1e0660445
   imagePullPolicy: IfNotPresent
   log_level: INFO
   resources:
@@ -743,7 +745,7 @@ nodeAgent:
   image:
     repository: registry.nudgebee.com/nudgebee-node-agent
     pullPolicy: IfNotPresent
-    tag: 2026-03-07T13-05-46_d38d1d4491462852250825a90161b417b21d5c3a
+    tag: 2026-03-08T10-10-12_4c2599ad0f8267bee4360ac0d66176e882d917e6
   resources:
     requests:
       cpu: "100m"


### PR DESCRIPTION
## Summary
- The `nudgebee-agent` ECR image query in `release.yml` and `release-rc.yml` was missing `--no-paginate`, unlike every other ECR query in the same step.
- Without it, the JMESPath query runs per-page, returning one "latest" image per page. This produces a multi-line variable with two tags, which is an invalid image tag.
- This caused `InvalidImageTag` errors when installing the helm chart.

## Test plan
- [ ] Trigger the release workflow and verify `nudgebee_app_image` resolves to a single tag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional runner write-permissions can be enabled to grant additional create/update/delete capabilities to the runner.

* **Chores**
  * Updated runner image to a newer build.
  * Removed two scheduled custom playbooks (daily scan and periodic volume analysis).
  * CI: adjusted image lookup command to disable pagination for releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->