### PR TITLE
fix: default runner.clickhouse_enabled to false when otel-collector disabled

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Update Helm Package for Nudgebee RC
         working-directory: ./charts/nudgebee-agent
         run: |
-          nudgebee_app_image=`aws ecr describe-images --repository-name nudgebee-agent --filter tagStatus=TAGGED --query 'sort_by(imageDetails[?imageTags], &imagePushedAt)[-1].imageTags[0]' --region us-east-1 --output text`
+          nudgebee_app_image=`aws ecr describe-images --repository-name nudgebee-agent --filter tagStatus=TAGGED --query 'sort_by(imageDetails[?imageTags], &imagePushedAt)[-1].imageTags[0]' --region us-east-1 --output text --no-paginate`
           echo "nudgebee_app_image: $nudgebee_app_image"
           yq -i ".runner.image.tag=\"$nudgebee_app_image\"" values.yaml
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Update Helm Package for Nudgebee
         working-directory: ./charts/nudgebee-agent
         run: |
-          nudgebee_app_image=`aws ecr describe-images --repository-name nudgebee-agent --filter tagStatus=TAGGED --query 'sort_by(imageDetails[?imageTags], &imagePushedAt)[-1].imageTags[0]' --region us-east-1 --output text`
+          nudgebee_app_image=`aws ecr describe-images --repository-name nudgebee-agent --filter tagStatus=TAGGED --query 'sort_by(imageDetails[?imageTags], &imagePushedAt)[-1].imageTags[0]' --region us-east-1 --output text --no-paginate`
           echo "nudgebee_app_image: $nudgebee_app_image"
           yq -i ".runner.image.tag=\"$nudgebee_app_image\"" values.yaml
 

--- a/charts/nudgebee-agent/templates/runner-service-account.yaml
+++ b/charts/nudgebee-agent/templates/runner-service-account.yaml
@@ -290,6 +290,142 @@ rules:
     - pods
     - nodes
     verbs:     ["get", "list"]
+
+{{- if .Values.runner.enableWritePermissions }}
+  # -- Write permissions (runner.enableWritePermissions) --
+
+  # Node delete - required for node graceful shutdown (kubectl delete node)
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - delete
+
+  # Service lifecycle management
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - create
+      - update
+      - patch
+      - delete
+
+  # Secret update/delete (base already has create/list/get)
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - update
+      - patch
+      - delete
+
+  # Namespace creation
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - create
+      - delete
+
+  # Endpoint management
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - create
+      - update
+      - patch
+      - delete
+
+  # ServiceAccount management
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - create
+      - update
+      - patch
+      - delete
+
+  # ResourceQuotas and LimitRanges
+  - apiGroups:
+      - ""
+    resources:
+      - resourcequotas
+      - limitranges
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+
+  # StatefulSet scale subresource + create for all apps resources
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets/scale
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+
+  # Workload creation (create_workload action)
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - statefulsets
+      - daemonsets
+      - replicasets
+    verbs:
+      - create
+
+  # Ingress write access
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+      - networkpolicies
+    verbs:
+      - create
+      - update
+      - patch
+      - delete
+
+  # Extensions ingress write
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - create
+      - delete
+
+  # RBAC read for roles/rolebindings (namespace-scoped)
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+      - rolebindings
+    verbs:
+      - create
+      - update
+      - patch
+      - delete
+{{- end }}
+
 {{- if (.Capabilities.APIVersions.Has "argoproj.io/v1alpha1/Rollout") }}
   - apiGroups:
     - argoproj.io
@@ -300,6 +436,10 @@ rules:
     - list
     - patch
     - update
+{{- if .Values.runner.enableWritePermissions }}
+    - create
+    - delete
+{{- end }}
 {{- end }}
 
 {{- if or (.Capabilities.APIVersions.Has "karpenter.sh/v1beta1/NodePool") (.Capabilities.APIVersions.Has "karpenter.sh/v1/NodePool") }}

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -636,7 +636,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: registry.nudgebee.com/nudgebee-agent
-    tag: 2026-01-09T10-54-01_eabafd546d9e50c1601a8262667a223226abe042
+    tag: 2026-02-10T12-19-32_e0410e35183bf51938e84004f2885ee7451c9d2e
   imagePullPolicy: IfNotPresent
   log_level: INFO
   resources:
@@ -648,6 +648,11 @@ runner:
   tolerations: []
   annotations: {}
   nodeSelector: ~
+  # Enable write permissions for the runner service account.
+  # Adds permissions for: node delete/drain, service management, secret updates,
+  # ingress/networkpolicy writes, resource quotas, limit ranges, namespace creation,
+  # statefulset scaling, workload creation, and rollout lifecycle management.
+  enableWritePermissions: false
   customClusterRoleRules: []
   imagePullSecrets: []
   extraVolumes: []
@@ -660,7 +665,7 @@ runner:
   nova_image_override: nova:2025-08-25T06-49-02_8a8e0766cfc5817c4de429f0df8fb0faa154907f
   clickhouse_enabled: true
   clickhouse_secret: ""
-  runbook_sidecar_image_tag: 2026-01-09T08-56-51_1bc8ed44579b442306416c9a2733c4ae4c124873
+  runbook_sidecar_image_tag: 2026-01-21T12-26-01_65a85cc1e589d506b9d5fa39f684d61c98638c4e
   victoria_metrics_enabled: false
   loki:
     url: ""
@@ -742,7 +747,7 @@ nodeAgent:
   image:
     repository: registry.nudgebee.com/nudgebee-node-agent
     pullPolicy: IfNotPresent
-    tag: 2026-01-12T03-44-08_8755b8391c96d6fefd4f4c6726d3796fe7bdcc5c
+    tag: 2026-02-11T12-50-36_f509857e08ab0e3e6d7bece9d4272e641eec4714
   resources:
     requests:
       cpu: "100m"

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -651,7 +651,7 @@ runner:
   profiler_image_override: 2025-10-07T09-20-18_6ede7487ac41f9c167a2e547e70ac7e7a2de7a88
   kubepug_image_override: kubepug:2025-08-13T08-26-24_d16f6f2d1e27c24258c36ab8caf2054b583aa3cb
   nova_image_override: nova:2026-03-07T11-56-14_c1432955300a4a231c9d6a364513ec680898f595
-  clickhouse_enabled: true
+  clickhouse_enabled: false
   clickhouse_secret: ""
   runbook_sidecar_image_tag: 2026-01-21T12-26-01_65a85cc1e589d506b9d5fa39f684d61c98638c4e
   victoria_metrics_enabled: false

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -624,7 +624,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: registry.nudgebee.com/nudgebee-agent
-    tag: 2026-02-10T12-19-32_e0410e35183bf51938e84004f2885ee7451c9d2e
+    tag: 2026-03-07T11-58-24_ac1360dbc5401f549c7bba75d382e1ce22071d41
   imagePullPolicy: IfNotPresent
   log_level: INFO
   resources:
@@ -650,7 +650,7 @@ runner:
   relay_address: wss://relay.nudgebee.com/register
   profiler_image_override: 2025-10-07T09-20-18_6ede7487ac41f9c167a2e547e70ac7e7a2de7a88
   kubepug_image_override: kubepug:2025-08-13T08-26-24_d16f6f2d1e27c24258c36ab8caf2054b583aa3cb
-  nova_image_override: nova:2025-08-25T06-49-02_8a8e0766cfc5817c4de429f0df8fb0faa154907f
+  nova_image_override: nova:2026-03-07T11-56-14_c1432955300a4a231c9d6a364513ec680898f595
   clickhouse_enabled: true
   clickhouse_secret: ""
   runbook_sidecar_image_tag: 2026-01-21T12-26-01_65a85cc1e589d506b9d5fa39f684d61c98638c4e
@@ -735,7 +735,7 @@ nodeAgent:
   image:
     repository: registry.nudgebee.com/nudgebee-node-agent
     pullPolicy: IfNotPresent
-    tag: 2026-02-11T12-50-36_f509857e08ab0e3e6d7bece9d4272e641eec4714
+    tag: 2026-03-07T13-05-46_d38d1d4491462852250825a90161b417b21d5c3a
   resources:
     requests:
       cpu: "100m"

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -208,12 +208,6 @@ customPlaybooks:
           cron_schedule_repeat:
             cron_expression: "0 12 * * *" # every day at 12:00
     actions:
-      - krr_scan: {}
-  - triggers:
-      - on_schedule:
-          cron_schedule_repeat:
-            cron_expression: "0 12 * * *" # every day at 12:00
-    actions:
       - certificate_scanner: {}
   - triggers:
       - on_schedule:
@@ -239,12 +233,6 @@ customPlaybooks:
             cron_expression: "0 0 * * *" # every day at 00:00
     actions:
       - unused_pv: {}
-  - triggers:
-      - on_schedule:
-          cron_schedule_repeat:
-            cron_expression: "0 */4 * * *" # every 4 hour
-    actions:
-      - volume_analyzer: {}
   - triggers:
       - on_deployment_all_changes: {}
       - on_daemonset_all_changes: {}


### PR DESCRIPTION
## Summary
- Changed default value of `runner.clickhouse_enabled` from `true` to `false` in values.yaml
- When `opentelemetry-collector.enabled=false`, the ClickHouse subchart is not deployed, so its secret doesn't exist. The runner template uses `OR(otel-collector.enabled, clickhouse_enabled)` to decide whether to mount the ClickHouse password from that secret — the old default of `true` made the runner crash on a missing secret
- The `opentelemetry-collector.enabled` flag already gates ClickHouse via the same OR, so the standalone default only needs to be `true` when connecting to an external ClickHouse (where the user also provides `clickhouse_secret` or `clickhouse_password`)

## Test plan
- [ ] Deploy with `--set opentelemetry-collector.enabled=false` and verify the runner pod starts without secret-not-found errors
- [ ] Deploy with defaults (`opentelemetry-collector.enabled=true`) and verify ClickHouse integration still works
- [ ] Deploy with `--set runner.clickhouse_enabled=true --set runner.clickhouse_password=<pw>` and `opentelemetry-collector.enabled=false` to verify external ClickHouse path