### PR TITLE
fix: default runner.clickhouse_enabled to false when otel-collector disabled

### DIFF
--- a/charts/nudgebee-agent/Chart.yaml
+++ b/charts/nudgebee-agent/Chart.yaml
@@ -6,8 +6,8 @@ icon: https://nudgebee-documents.s3.amazonaws.com/images/Nudgebee-logo.png
 # these are set to the right value by .github/workflows/release.yaml
 # we use 0.0.1 as a placeholder for the version` because Helm wont allow `0.0.0` and we want to be able to run
 # `helm install` on development checkouts without updating this file. the version doesn't matter in that case anyway
-version: 0.0.120
-appVersion: 0.0.120
+version: 0.0.121
+appVersion: 0.0.121
 dependencies:
 - name: opencost
   version: 2.0.1

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -664,7 +664,7 @@ runner:
   profiler_image_override: 2025-05-06T10-08-00_1a1779d4166a81b292375a950aeb49b86ed10b33
   kubepug_image_override: kubepug:2025-08-14T05-16-09_6da6481b63b699ab4c61e86e1c611a182319d3de
   nova_image_override: nova:2025-07-04T04-12-43_76ed8fffc46f03f798e9dd6a975890064807d6e2
-  clickhouse_enabled: true
+  clickhouse_enabled: false
   clickhouse_secret: ""
   runbook_sidecar_image_tag: 2026-01-30T07-39-18_68169ef8bece3b4d3ccb6e80a12023d2ab305181-arm64
   victoria_metrics_enabled: false


### PR DESCRIPTION
## Summary
- Changed default value of `runner.clickhouse_enabled` from `true` to `false`
- When `opentelemetry-collector.enabled=false`, the ClickHouse subchart isn't deployed (no secret created), but the runner template OR condition still evaluated to true, causing a missing secret error
- The `opentelemetry-collector.enabled` flag already gates ClickHouse via the same OR, so this default only needs to be `true` for external ClickHouse setups

## Test plan
- [ ] Deploy with `--set opentelemetry-collector.enabled=false` — runner pod should start without secret-not-found errors
- [ ] Deploy with defaults (`opentelemetry-collector.enabled=true`) — ClickHouse integration works as before