### PR TITLE
fix: remove invalid matchers field from AlertmanagerConfig receiver

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Update Helm Package for Nudgebee RC
         working-directory: ./charts/nudgebee-agent
         run: |
-          nudgebee_app_image=`aws ecr describe-images --repository-name nudgebee-agent --filter tagStatus=TAGGED --query 'sort_by(imageDetails[?imageTags], &imagePushedAt)[-1].imageTags[0]' --region us-east-1 --output text`
+          nudgebee_app_image=`aws ecr describe-images --repository-name nudgebee-agent --filter tagStatus=TAGGED --query 'sort_by(imageDetails[?imageTags], &imagePushedAt)[-1].imageTags[0]' --region us-east-1 --output text --no-paginate`
           echo "nudgebee_app_image: $nudgebee_app_image"
           yq -i ".runner.image.tag=\"$nudgebee_app_image\"" values.yaml
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Update Helm Package for Nudgebee
         working-directory: ./charts/nudgebee-agent
         run: |
-          nudgebee_app_image=`aws ecr describe-images --repository-name nudgebee-agent --filter tagStatus=TAGGED --query 'sort_by(imageDetails[?imageTags], &imagePushedAt)[-1].imageTags[0]' --region us-east-1 --output text`
+          nudgebee_app_image=`aws ecr describe-images --repository-name nudgebee-agent --filter tagStatus=TAGGED --query 'sort_by(imageDetails[?imageTags], &imagePushedAt)[-1].imageTags[0]' --region us-east-1 --output text --no-paginate`
           echo "nudgebee_app_image: $nudgebee_app_image"
           yq -i ".runner.image.tag=\"$nudgebee_app_image\"" values.yaml
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![CI](https://github.com/nudgebee/k8s-agent/actions/workflows/helm-test.yml/badge.svg?branch=main)](https://github.com/nudgebee/k8s-agent/actions/workflows/helm-test.yml) [![Release Charts](https://github.com/nudgebee/k8s-agent/actions/workflows/release.yml/badge.svg?branch=main)](https://github.com/nudgebee/k8s-agent/actions/workflows/release.yml)
-
 # NudgeBee Kubernetes agent
 Module to connect kubernetes to NudgeBee.
 

--- a/charts/nudgebee-agent/Chart.yaml
+++ b/charts/nudgebee-agent/Chart.yaml
@@ -6,8 +6,8 @@ icon: https://nudgebee-documents.s3.amazonaws.com/images/Nudgebee-logo.png
 # these are set to the right value by .github/workflows/release.yaml
 # we use 0.0.1 as a placeholder for the version` because Helm wont allow `0.0.0` and we want to be able to run
 # `helm install` on development checkouts without updating this file. the version doesn't matter in that case anyway
-version: 0.0.118
-appVersion: 0.0.118
+version: 0.0.119
+appVersion: 0.0.119
 dependencies:
 - name: opencost
   version: 2.0.1

--- a/charts/nudgebee-agent/Chart.yaml
+++ b/charts/nudgebee-agent/Chart.yaml
@@ -6,8 +6,8 @@ icon: https://nudgebee-documents.s3.amazonaws.com/images/Nudgebee-logo.png
 # these are set to the right value by .github/workflows/release.yaml
 # we use 0.0.1 as a placeholder for the version` because Helm wont allow `0.0.0` and we want to be able to run
 # `helm install` on development checkouts without updating this file. the version doesn't matter in that case anyway
-version: 0.0.116
-appVersion: 0.0.116
+version: 0.0.117
+appVersion: 0.0.117
 dependencies:
 - name: opencost
   version: 2.0.1

--- a/charts/nudgebee-agent/Chart.yaml
+++ b/charts/nudgebee-agent/Chart.yaml
@@ -6,8 +6,8 @@ icon: https://nudgebee-documents.s3.amazonaws.com/images/Nudgebee-logo.png
 # these are set to the right value by .github/workflows/release.yaml
 # we use 0.0.1 as a placeholder for the version` because Helm wont allow `0.0.0` and we want to be able to run
 # `helm install` on development checkouts without updating this file. the version doesn't matter in that case anyway
-version: 0.0.119
-appVersion: 0.0.119
+version: 0.0.120
+appVersion: 0.0.120
 dependencies:
 - name: opencost
   version: 2.0.1

--- a/charts/nudgebee-agent/Chart.yaml
+++ b/charts/nudgebee-agent/Chart.yaml
@@ -6,8 +6,8 @@ icon: https://nudgebee-documents.s3.amazonaws.com/images/Nudgebee-logo.png
 # these are set to the right value by .github/workflows/release.yaml
 # we use 0.0.1 as a placeholder for the version` because Helm wont allow `0.0.0` and we want to be able to run
 # `helm install` on development checkouts without updating this file. the version doesn't matter in that case anyway
-version: 0.0.120
-appVersion: 0.0.120
+version: 0.0.121
+appVersion: 0.0.121
 dependencies:
 - name: opencost
   version: 2.0.1

--- a/charts/nudgebee-agent/Chart.yaml
+++ b/charts/nudgebee-agent/Chart.yaml
@@ -6,8 +6,8 @@ icon: https://nudgebee-documents.s3.amazonaws.com/images/Nudgebee-logo.png
 # these are set to the right value by .github/workflows/release.yaml
 # we use 0.0.1 as a placeholder for the version` because Helm wont allow `0.0.0` and we want to be able to run
 # `helm install` on development checkouts without updating this file. the version doesn't matter in that case anyway
-version: 0.0.115
-appVersion: 0.0.115
+version: 0.0.116
+appVersion: 0.0.116
 dependencies:
 - name: opencost
   version: 2.0.1

--- a/charts/nudgebee-agent/Chart.yaml
+++ b/charts/nudgebee-agent/Chart.yaml
@@ -6,8 +6,8 @@ icon: https://nudgebee-documents.s3.amazonaws.com/images/Nudgebee-logo.png
 # these are set to the right value by .github/workflows/release.yaml
 # we use 0.0.1 as a placeholder for the version` because Helm wont allow `0.0.0` and we want to be able to run
 # `helm install` on development checkouts without updating this file. the version doesn't matter in that case anyway
-version: 0.0.117
-appVersion: 0.0.117
+version: 0.0.118
+appVersion: 0.0.118
 dependencies:
 - name: opencost
   version: 2.0.1

--- a/charts/nudgebee-agent/templates/daemonset.yaml
+++ b/charts/nudgebee-agent/templates/daemonset.yaml
@@ -90,3 +90,34 @@ spec:
             path: /sys/kernel/debug
           name: debugfs
 {{- end }}
+{{- if (and .Values.nodeAgent.enabled .Values.nodeAgent.service.enabled) }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "nudgebee-agent.fullname" . }}-node-agent
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "80"
+    prometheus.io/path: /metrics
+    {{- with .Values.nodeAgent.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  labels:
+    {{- include "nudgebee-agent.labels" . | nindent 4 }}
+    component: node-agent
+    {{- with .Values.nodeAgent.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  clusterIP: None
+  selector:
+    {{- include "node-agent.selectorLabels" . | nindent 4 }}
+    component: node-agent
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+    protocol: TCP
+{{- end }}

--- a/charts/nudgebee-agent/templates/prometheus-alert-manager-config.yaml
+++ b/charts/nudgebee-agent/templates/prometheus-alert-manager-config.yaml
@@ -14,8 +14,6 @@ spec:
     receiver: 'nudgebee-agent'
   receivers:
   - name: 'nudgebee-agent'
-    matchers:
-    - severity=~".*"
     webhookConfigs:
     - url: 'http://{{ include "nudgebee-agent.fullname" . }}-runner.{{ .Release.Namespace }}.svc/api/alerts'
       sendResolved: true

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -559,7 +559,7 @@ builtinPlaybooks:
 kubewatch:
   image:
     repository: registry.nudgebee.com/kubewatch
-    tag: 2025-08-05T15-21-58_244b8879e108cf4b12313d400cd3716265869344
+    tag: 2025-07-04T04-38-00_2e61c1792218b6f0e6d9da6b9bd596e7ca4095df
   imagePullPolicy: IfNotPresent
   pprof: true
   resources:
@@ -635,7 +635,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: registry.nudgebee.com/nudgebee-agent
-    tag: 2025-11-03T07-22-29_7e4b11192d99d1e9a7456b09f54e15d578edb14f
+    tag: 2025-10-03T18-16-22_9f4528d40aae29f249adc0fcdfcb2c4901f63424
   imagePullPolicy: IfNotPresent
   log_level: INFO
   resources:
@@ -652,14 +652,14 @@ runner:
   extraVolumes: []
   extraVolumeMounts: []
   image_registry: registry.nudgebee.com
-  krr_image_override: krr-public:2025-07-10T07-36-19_9195d324fdcde4e2f4724ba270c4351ed2366a1d
+  krr_image_override: krr-public:2025-06-16T04-25-05_93361fa666f6eabe55ece9c9c918c080e38b73ab
   relay_address: wss://relay.nudgebee.com/register
-  profiler_image_override: 2025-10-07T09-20-18_6ede7487ac41f9c167a2e547e70ac7e7a2de7a88
-  kubepug_image_override: kubepug:2025-08-13T08-26-24_d16f6f2d1e27c24258c36ab8caf2054b583aa3cb
-  nova_image_override: nova:2025-08-25T06-49-02_8a8e0766cfc5817c4de429f0df8fb0faa154907f
+  profiler_image_override: 2025-05-06T10-08-00_1a1779d4166a81b292375a950aeb49b86ed10b33
+  kubepug_image_override: kubepug:2025-08-14T05-16-09_6da6481b63b699ab4c61e86e1c611a182319d3de
+  nova_image_override: nova:2025-07-04T04-12-43_76ed8fffc46f03f798e9dd6a975890064807d6e2
   clickhouse_enabled: true
   clickhouse_secret: ""
-  runbook_sidecar_image_tag: 2025-07-21T07-51-41_d58044c5b587a02d37c8da4579637c78774c1a45
+  runbook_sidecar_image_tag: 2025-07-28T08-03-26_3123b6ef14ea32bf8bd435036dd21c00cfe2f0d7
   victoria_metrics_enabled: false
   loki:
     url: ""
@@ -741,7 +741,7 @@ nodeAgent:
   image:
     repository: registry.nudgebee.com/nudgebee-node-agent
     pullPolicy: IfNotPresent
-    tag: 2025-10-29T05-16-46_692d7442f139a17c6aa975d7fa9373d576cc628f
+    tag: 2025-10-30T06-03-21_51d2a93f9e1d6a610034b3e6ff24cabb5f5c6e9e
   resources:
     requests:
       cpu: "100m"

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -636,7 +636,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: registry.nudgebee.com/nudgebee-agent
-    tag: 2025-10-03T18-16-22_9f4528d40aae29f249adc0fcdfcb2c4901f63424
+    tag: 2026-01-21T12-24-21_79e6d1636bbb39c92a9a7ad920bf5b289b4884ff
   imagePullPolicy: IfNotPresent
   log_level: INFO
   resources:
@@ -653,14 +653,14 @@ runner:
   extraVolumes: []
   extraVolumeMounts: []
   image_registry: registry.nudgebee.com
-  krr_image_override: krr-public:2025-06-16T04-25-05_93361fa666f6eabe55ece9c9c918c080e38b73ab
+  krr_image_override: krr-public:2025-11-12T10-27-20_05e19006ab7b743e092267132d3b40e2c0b7b43c
   relay_address: wss://relay.nudgebee.com/register
   profiler_image_override: 2025-05-06T10-08-00_1a1779d4166a81b292375a950aeb49b86ed10b33
   kubepug_image_override: kubepug:2025-08-14T05-16-09_6da6481b63b699ab4c61e86e1c611a182319d3de
   nova_image_override: nova:2025-07-04T04-12-43_76ed8fffc46f03f798e9dd6a975890064807d6e2
   clickhouse_enabled: true
   clickhouse_secret: ""
-  runbook_sidecar_image_tag: 2026-01-09T08-56-51_1bc8ed44579b442306416c9a2733c4ae4c124873
+  runbook_sidecar_image_tag: 2026-01-20T13-53-59_402c0a7377afb3ba12fb7c5cba2c1d389175c24e
   victoria_metrics_enabled: false
   loki:
     url: ""
@@ -742,7 +742,7 @@ nodeAgent:
   image:
     repository: registry.nudgebee.com/nudgebee-node-agent
     pullPolicy: IfNotPresent
-    tag: 2026-01-12T03-44-08_8755b8391c96d6fefd4f4c6726d3796fe7bdcc5c
+    tag: 2025-10-30T06-03-21_51d2a93f9e1d6a610034b3e6ff24cabb5f5c6e9e
   resources:
     requests:
       cpu: "100m"

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -641,7 +641,7 @@ runner:
   image:
     repository: registry.nudgebee.com/nudgebee-agent
     tag: |-
-      2026-03-24T17-16-49_7617e780e26fe1f430bc6c74826cf41eb68fe11a
+      2026-03-27T12-08-19_a6f2ef26c0dfbca5d64d837c72f5f681f27650b8
       2025-11-12T06-00-45_8ab57887ffd3ee0611c8b3e1a51413d1e0660445
   imagePullPolicy: IfNotPresent
   log_level: INFO

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -640,7 +640,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: registry.nudgebee.com/nudgebee-agent
-    tag: 2026-03-20T13-39-48_7ec3f1ffdba8a3d44f793e716b52987af426d23c
+    tag: 2026-03-23T12-03-00_b5fb6a3dec070d497d8abe5c8957429d61363c5b
   imagePullPolicy: IfNotPresent
   log_level: INFO
   resources:

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -636,7 +636,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: registry.nudgebee.com/nudgebee-agent
-    tag: 2026-01-21T12-24-21_79e6d1636bbb39c92a9a7ad920bf5b289b4884ff
+    tag: 2026-02-23T11-40-46_a877fb4fba436266b3cb149653d0b608b0b16c52
   imagePullPolicy: IfNotPresent
   log_level: INFO
   resources:
@@ -746,7 +746,7 @@ nodeAgent:
   image:
     repository: registry.nudgebee.com/nudgebee-node-agent
     pullPolicy: IfNotPresent
-    tag: 2025-10-30T06-03-21_51d2a93f9e1d6a610034b3e6ff24cabb5f5c6e9e
+    tag: 2026-02-23T12-58-40_883beeae44deee8b4355f159e7b9e4898648b2aa
   resources:
     requests:
       cpu: "100m"

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -660,7 +660,7 @@ runner:
   nova_image_override: nova:2025-07-04T04-12-43_76ed8fffc46f03f798e9dd6a975890064807d6e2
   clickhouse_enabled: true
   clickhouse_secret: ""
-  runbook_sidecar_image_tag: 2026-01-20T13-53-59_402c0a7377afb3ba12fb7c5cba2c1d389175c24e
+  runbook_sidecar_image_tag: 2026-01-30T07-39-18_68169ef8bece3b4d3ccb6e80a12023d2ab305181-arm64
   victoria_metrics_enabled: false
   loki:
     url: ""
@@ -738,6 +738,10 @@ nodeAgent:
   podmonitor:
     enabled: true
     azuremanaged: false
+  service:
+    enabled: false
+    labels: {}
+    annotations: {}
   podAnnotations: {}
   image:
     repository: registry.nudgebee.com/nudgebee-node-agent

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -265,6 +265,8 @@ builtinPlaybooks:
   - triggers:
       - on_pod_crash_loop:
           restart_reason: "CrashLoopBackOff"
+          rate_limit: 14400 # 4 hours, per workload
+          restart_count: 2
     actions:
       - report_crash_loop: {}
       - resource_events_enricher: {}
@@ -273,7 +275,9 @@ builtinPlaybooks:
           previous: true
       - impacted_services_enricher: {}
   - triggers:
-      - on_image_pull_backoff: {}
+      - on_image_pull_backoff:
+          rate_limit: 14400 # 4 hours, per workload
+          fire_delay: 120 # seconds, avoids false positives on startup
     actions:
       - image_pull_backoff_reporter: {}
       - resource_events_enricher: {}
@@ -281,7 +285,7 @@ builtinPlaybooks:
   # playbooks for non-prometheus based monitoring that use prometheus for enrichment
   - triggers:
       - on_pod_oom_killed:
-          rate_limit: 3600
+          rate_limit: 3600 # 1 hour, per workload
     actions:
       - pod_oom_killer_enricher: {}
       - logs_enricher:

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -664,7 +664,7 @@ runner:
   profiler_image_override: 2025-05-06T10-08-00_1a1779d4166a81b292375a950aeb49b86ed10b33
   kubepug_image_override: kubepug:2025-08-14T05-16-09_6da6481b63b699ab4c61e86e1c611a182319d3de
   nova_image_override: nova:2025-07-04T04-12-43_76ed8fffc46f03f798e9dd6a975890064807d6e2
-  clickhouse_enabled: true
+  clickhouse_enabled: false
   clickhouse_secret: ""
   runbook_sidecar_image_tag: 2026-01-30T07-39-18_68169ef8bece3b4d3ccb6e80a12023d2ab305181-arm64
   victoria_metrics_enabled: false

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -560,7 +560,7 @@ builtinPlaybooks:
 kubewatch:
   image:
     repository: registry.nudgebee.com/kubewatch
-    tag: 2025-08-05T15-21-58_244b8879e108cf4b12313d400cd3716265869344
+    tag: 2025-07-04T04-38-00_2e61c1792218b6f0e6d9da6b9bd596e7ca4095df
   imagePullPolicy: IfNotPresent
   pprof: true
   resources:
@@ -636,7 +636,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: registry.nudgebee.com/nudgebee-agent
-    tag: 2026-01-09T10-54-01_eabafd546d9e50c1601a8262667a223226abe042
+    tag: 2026-01-21T12-24-21_79e6d1636bbb39c92a9a7ad920bf5b289b4884ff
   imagePullPolicy: IfNotPresent
   log_level: INFO
   resources:
@@ -653,14 +653,14 @@ runner:
   extraVolumes: []
   extraVolumeMounts: []
   image_registry: registry.nudgebee.com
-  krr_image_override: krr-public:2025-07-10T07-36-19_9195d324fdcde4e2f4724ba270c4351ed2366a1d
+  krr_image_override: krr-public:2025-11-12T10-27-20_05e19006ab7b743e092267132d3b40e2c0b7b43c
   relay_address: wss://relay.nudgebee.com/register
-  profiler_image_override: 2025-10-07T09-20-18_6ede7487ac41f9c167a2e547e70ac7e7a2de7a88
-  kubepug_image_override: kubepug:2025-08-13T08-26-24_d16f6f2d1e27c24258c36ab8caf2054b583aa3cb
-  nova_image_override: nova:2025-08-25T06-49-02_8a8e0766cfc5817c4de429f0df8fb0faa154907f
+  profiler_image_override: 2025-05-06T10-08-00_1a1779d4166a81b292375a950aeb49b86ed10b33
+  kubepug_image_override: kubepug:2025-08-14T05-16-09_6da6481b63b699ab4c61e86e1c611a182319d3de
+  nova_image_override: nova:2025-07-04T04-12-43_76ed8fffc46f03f798e9dd6a975890064807d6e2
   clickhouse_enabled: true
   clickhouse_secret: ""
-  runbook_sidecar_image_tag: 2026-01-09T08-56-51_1bc8ed44579b442306416c9a2733c4ae4c124873
+  runbook_sidecar_image_tag: 2026-01-30T07-39-18_68169ef8bece3b4d3ccb6e80a12023d2ab305181-arm64
   victoria_metrics_enabled: false
   loki:
     url: ""
@@ -742,7 +742,7 @@ nodeAgent:
   image:
     repository: registry.nudgebee.com/nudgebee-node-agent
     pullPolicy: IfNotPresent
-    tag: 2026-01-12T03-44-08_8755b8391c96d6fefd4f4c6726d3796fe7bdcc5c
+    tag: 2025-10-30T06-03-21_51d2a93f9e1d6a610034b3e6ff24cabb5f5c6e9e
   resources:
     requests:
       cpu: "100m"

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -858,7 +858,7 @@ opentelemetry-collector:
         send_batch_size: 25000
     exporters:
       clickhouse:
-        endpoint: "tcp://nudgebee-agent-clickhouse:9000?dial_timeout=10s&compress=lz4" # Default endpoint, can be overridden
+        endpoint: "http://nudgebee-agent-clickhouse:8123?dial_timeout=10s" # Default endpoint, can be overridden
         database: default
         ttl_days: 7
         username: default

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -636,7 +636,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: registry.nudgebee.com/nudgebee-agent
-    tag: 2026-02-23T11-40-46_a877fb4fba436266b3cb149653d0b608b0b16c52
+    tag: 2026-03-20T13-39-48_7ec3f1ffdba8a3d44f793e716b52987af426d23c
   imagePullPolicy: IfNotPresent
   log_level: INFO
   resources:
@@ -746,7 +746,7 @@ nodeAgent:
   image:
     repository: registry.nudgebee.com/nudgebee-node-agent
     pullPolicy: IfNotPresent
-    tag: 2026-02-23T12-58-40_883beeae44deee8b4355f159e7b9e4898648b2aa
+    tag: 2026-03-08T10-10-12_4c2599ad0f8267bee4360ac0d66176e882d917e6
   resources:
     requests:
       cpu: "100m"

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -640,7 +640,9 @@ runnerServiceAccount:
 runner:
   image:
     repository: registry.nudgebee.com/nudgebee-agent
-    tag: 2026-03-23T12-03-00_b5fb6a3dec070d497d8abe5c8957429d61363c5b
+    tag: |-
+      2026-03-24T17-16-49_7617e780e26fe1f430bc6c74826cf41eb68fe11a
+      2025-11-12T06-00-45_8ab57887ffd3ee0611c8b3e1a51413d1e0660445
   imagePullPolicy: IfNotPresent
   log_level: INFO
   resources:

--- a/installation.sh
+++ b/installation.sh
@@ -250,7 +250,12 @@ if [ -z "$loki_url" ]; then
         # Add Helm installation command here or instructions
         helm repo add grafana https://grafana.github.io/helm-charts
         helm repo update
-        helm upgrade --install nudgebee-loki grafana/loki-stack -n $namespace --create-namespace --set loki.persistence.enabled=true --set loki.persistence.size=10Gi --set promtail.enabled=true --set loki.isDefault=false
+        helm upgrade --install nudgebee-loki grafana/loki-stack \
+            -n "$namespace" --create-namespace \
+            --set loki.persistence.enabled=true \
+            --set loki.persistence.size=10Gi \
+            --set promtail.enabled=true \
+            --set loki.isDefault=false
         loki_url="http://nudgebee-loki:3100"
     else
         echo "Loki installation not requested. Node Agent will still be installed."

--- a/installation.sh
+++ b/installation.sh
@@ -250,7 +250,7 @@ if [ -z "$loki_url" ]; then
         # Add Helm installation command here or instructions
         helm repo add grafana https://grafana.github.io/helm-charts
         helm repo update
-        helm upgrade --install nudgebee-loki grafana/loki-stack -n $namespace --create-namespace --set loki.persistence.enabled=true --set loki.persistence.size=10Gi --set promtail.enabled=true
+        helm upgrade --install nudgebee-loki grafana/loki-stack -n $namespace --create-namespace --set loki.persistence.enabled=true --set loki.persistence.size=10Gi --set promtail.enabled=true --set loki.isDefault=false
         loki_url="http://nudgebee-loki:3100"
     else
         echo "Loki installation not requested. Node Agent will still be installed."


### PR DESCRIPTION
## Summary
- Removes the `matchers` field from the AlertmanagerConfig receiver spec, which is not a valid field in `monitoring.coreos.com/v1alpha1` and causes Helm install to fail with "field not declared in schema"
- The route already directs all alerts to this receiver, so no matching logic is lost

## Test plan
- [ ] Verify `helm install` / `helm upgrade` succeeds without the schema validation error