### PR TITLE
fix: remove invalid matchers field from AlertmanagerConfig receiver

### DIFF
--- a/.github/configs/ct.yaml
+++ b/.github/configs/ct.yaml
@@ -6,7 +6,7 @@ target-branch: prod
 chart-dirs:
   - charts
 chart-repos: []
-validate-chart-schema: false
+validate-chart-schema: true
 validate-maintainers: false
 validate-yaml: true
 exclude-deprecated: true

--- a/.github/workflows/helm-dev-lint.yml
+++ b/.github/workflows/helm-dev-lint.yml
@@ -1,43 +1,60 @@
 # CI Workflow for Agent Helm chart
 name: CI
 
-# Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the "main" branch
   push:
     branches: [ "main" ]
   pull_request:
     branches: [ "main"]
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  helm-test:
+  helm-lint-and-validate:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      
+
       - name: Add dependency chart repos
         run: |
           helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
           helm repo add opencost https://opencost.github.io/opencost-helm-chart
+          helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+          helm repo add bitnami https://charts.bitnami.com/bitnami
 
-      - uses: azure/setup-helm@v3
+      - uses: azure/setup-helm@v4
         with:
-          version: v3.10.0
+          version: v3.14.0
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
-          check-latest: true
+          python-version: '3.12'
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.3.1
+        uses: helm/chart-testing-action@v2.7.0
 
       - name: Run chart-testing (lint)
         run: ct lint --debug --config ./.github/configs/ct.yaml --lint-conf ./.github/configs/lintconf.yaml --check-version-increment=false
+
+      - name: Build chart dependencies
+        run: helm dependency build charts/nudgebee-agent
+
+      - name: Render templates
+        run: helm template nudgebee-agent charts/nudgebee-agent --namespace nudgebee-agent > /tmp/rendered.yaml
+
+      - name: Install kubeconform
+        run: |
+          curl -sSLo /tmp/kubeconform.tar.gz https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz
+          tar -xzf /tmp/kubeconform.tar.gz -C /usr/local/bin kubeconform
+
+      - name: Validate rendered templates
+        run: |
+          kubeconform \
+            -strict \
+            -summary \
+            -schema-location default \
+            -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+            -skip SecurityContextConstraints \
+            /tmp/rendered.yaml

--- a/.github/workflows/helm-prod-test.yml
+++ b/.github/workflows/helm-prod-test.yml
@@ -1,48 +1,43 @@
 # CI Workflow for Agent Helm chart
 name: CI
 
-# Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the "main" branch
   push:
     branches: [ "prod" ]
   pull_request:
     branches: [ "prod"]
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  helm-test:
+  helm-lint-and-validate:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      
+
       - name: Add dependency chart repos
         run: |
           helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
           helm repo add opencost https://opencost.github.io/opencost-helm-chart
+          helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+          helm repo add bitnami https://charts.bitnami.com/bitnami
 
-      - uses: azure/setup-helm@v3
+      - uses: azure/setup-helm@v4
         with:
-          version: v3.10.0
+          version: v3.14.0
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
-          check-latest: true
+          python-version: '3.12'
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.3.1
+        uses: helm/chart-testing-action@v2.7.0
 
       - name: List changed charts
         id: list-changed
         run: |
-          ## If executed with debug this won't work anymore.
           changed=$(ct --config ./.github/configs/ct.yaml list-changed)
           charts=$(echo "$changed" | tr '\n' ' ' | xargs)
           if [[ -n "$changed" ]]; then
@@ -52,3 +47,24 @@ jobs:
 
       - name: Run chart-testing (lint)
         run: ct lint --debug --config ./.github/configs/ct.yaml --lint-conf ./.github/configs/lintconf.yaml
+
+      - name: Build chart dependencies
+        run: helm dependency build charts/nudgebee-agent
+
+      - name: Render templates
+        run: helm template nudgebee-agent charts/nudgebee-agent --namespace nudgebee-agent > /tmp/rendered.yaml
+
+      - name: Install kubeconform
+        run: |
+          curl -sSLo /tmp/kubeconform.tar.gz https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz
+          tar -xzf /tmp/kubeconform.tar.gz -C /usr/local/bin kubeconform
+
+      - name: Validate rendered templates
+        run: |
+          kubeconform \
+            -strict \
+            -summary \
+            -schema-location default \
+            -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+            -skip SecurityContextConstraints \
+            /tmp/rendered.yaml

--- a/charts/nudgebee-agent/Chart.yaml
+++ b/charts/nudgebee-agent/Chart.yaml
@@ -6,8 +6,8 @@ icon: https://nudgebee-documents.s3.amazonaws.com/images/Nudgebee-logo.png
 # these are set to the right value by .github/workflows/release.yaml
 # we use 0.0.1 as a placeholder for the version` because Helm wont allow `0.0.0` and we want to be able to run
 # `helm install` on development checkouts without updating this file. the version doesn't matter in that case anyway
-version: 0.0.121
-appVersion: 0.0.121
+version: 0.0.122
+appVersion: 0.0.122
 dependencies:
 - name: opencost
   version: 2.0.1

--- a/charts/nudgebee-agent/templates/prometheus-alert-manager-config.yaml
+++ b/charts/nudgebee-agent/templates/prometheus-alert-manager-config.yaml
@@ -14,8 +14,6 @@ spec:
     receiver: 'nudgebee-agent'
   receivers:
   - name: 'nudgebee-agent'
-    matchers:
-    - severity=~".*"
     webhookConfigs:
     - url: 'http://{{ include "nudgebee-agent.fullname" . }}-runner.{{ .Release.Namespace }}.svc/api/alerts'
       sendResolved: true

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -971,4 +971,4 @@ clickhouse:
             description: "Average query duration is above 1 second over last 5 minutes."
 alertmanager:
   create_nb_default_rules: true
-  create_nb_alert_config: true
+  create_nb_alert_config: false

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -752,7 +752,7 @@ nodeAgent:
   image:
     repository: registry.nudgebee.com/nudgebee-node-agent
     pullPolicy: IfNotPresent
-    tag: 2026-03-08T10-10-12_4c2599ad0f8267bee4360ac0d66176e882d917e6
+    tag: 2026-04-09T04-23-32_8102b4ec69bb0ba14c1a0a5ebc36ced6bab2497e
   resources:
     requests:
       cpu: "100m"


### PR DESCRIPTION
## Summary
- Remove `matchers` field from AlertmanagerConfig receiver — it's not part of the receiver schema in `monitoring.coreos.com/v1alpha1`, causing helm upgrade to fail with "field not declared in schema"
- Bump chart version to 0.0.122

## Test plan
- [ ] `helm upgrade --install` succeeds without the schema validation error