### PR TITLE
fix: resolve kube-prometheus-stack CRD conflict in installation.sh

### DIFF
--- a/installation.sh
+++ b/installation.sh
@@ -8,13 +8,19 @@ openshift_enable=""
 additional_secret=""
 prometheus_url=""
 opencost_service_url=""
-namespace="nudgebee-agent" 
+namespace="nudgebee-agent"
 agent_name="nudgebee-agent"
 env="prod"
 disable_node_agent=""
 values=""
 alert_manager_url=""
 prometheus_org_id=""
+relay_address=""
+collector_endpoint=""
+image_registry=""
+disable_opencost=""
+disable_otel=""
+disable_prometheus_stack=""
 
 # Help function
 usage() {
@@ -33,12 +39,18 @@ usage() {
   echo "  -f <values> values yaml"
   echo "  -m <alert_manager_url> Alert manager URL"
   echo "  -r <prometheus-org-id> Prometheus org id"
+  echo "  -w <relay_address>    WebSocket relay address (self-hosted)"
+  echo "  -c <collector_endpoint> Collector endpoint URL (self-hosted)"
+  echo "  -i <image_registry>   Image registry (air-gapped/on-prem)"
+  echo "  -x <disable_opencost> Disable OpenCost (true/false)"
+  echo "  -t <disable_otel>     Disable OpenTelemetry Collector & ClickHouse (true/false)"
+  echo "  -g <disable_prometheus_stack> Disable Prometheus stack (true/false)"
   echo "Example:"
   echo "  $0 -a my_auth_key -k my_k8s_context -o true -p http://prometheus:9090 -s my_secret"
   exit 1
 }
 
-while getopts ":a:k:o:p:s:n:z:h:e:d:f:m:r:" opt; do
+while getopts ":a:k:o:p:s:n:z:h:e:d:f:m:r:w:c:i:x:t:g:" opt; do
   case $opt in
     a)
       auth_key="$OPTARG"
@@ -72,6 +84,24 @@ while getopts ":a:k:o:p:s:n:z:h:e:d:f:m:r:" opt; do
       ;;
     r)
       prometheus_org_id="$OPTARG"
+      ;;
+    w)
+      relay_address="$OPTARG"
+      ;;
+    c)
+      collector_endpoint="$OPTARG"
+      ;;
+    i)
+      image_registry="$OPTARG"
+      ;;
+    x)
+      disable_opencost="$OPTARG"
+      ;;
+    t)
+      disable_otel="$OPTARG"
+      ;;
+    g)
+      disable_prometheus_stack="$OPTARG"
       ;;
     h)
       usage
@@ -153,44 +183,47 @@ if ! command -v helm &> /dev/null; then
     exit 1
 fi
 
-# Check for existing Prometheus
-if [ -z "$prometheus_url" ]; then
-    prometheus_selectors=(
-            "app=kube-prometheus-stack-prometheus"
-            "app=prometheus,component=server,release!=kubecost"
-            "app=prometheus-server"
-            "app=prometheus-operator-prometheus"
-    )
-    prometheus_url=$(getPrometheusURL "${prometheus_selectors[@]}")
-fi
-
+# Check for existing Prometheus (skip if prometheus stack is disabled)
 existingPrometheus=false
 grafana_command=""
-# Check if service_url is empty
-if [ -z "$prometheus_url" ]; then
-   echo "Prometheus not found..!"
-   read -p "Installing Prometheus using helm, do you want to continue? (yes/no): " install_prometheus
-    if [ "$install_prometheus" == "yes" ]; then
-        # Add Helm installation command here or instructions
-        helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-        helm repo update
-        helm upgrade --install nudgebee-prometheus prometheus-community/kube-prometheus-stack \
-            -n $namespace --create-namespace \
-            --set nodeExporter.enabled=true \
-            --set nodeExporter.service.targetPort=9101 \
-            --set pushgateway.enabled=false \
-            --set alertmanager.enabled=true \
-            --set kubeStateMetrics.enabled=true \
-            --set grafana.enabled=true \
-            -f https://raw.githubusercontent.com/nudgebee/k8s-agent/main/extra-scrape-config.yaml
-        prometheus_url="http://nudgebee-prometheus-kube-p-prometheus:9090"  # Prometheus uses default port 9090
-        grafana_command=" --set runner.grafana.enabled=true --set runner.grafana.url=http://nudgebee-prometheus-grafana.${namespace}.svc --set runner.grafana.username=admin --set runner.grafana.password=admin "
-    else
-        echo "Prometheus installation not requested. Exiting."
-        exit 0
-    fi
+if [ "$disable_prometheus_stack" == "true" ]; then
+    echo "Prometheus stack disabled, skipping Prometheus discovery and installation."
 else
-    existingPrometheus=true
+    if [ -z "$prometheus_url" ]; then
+        prometheus_selectors=(
+                "app=kube-prometheus-stack-prometheus"
+                "app=prometheus,component=server,release!=kubecost"
+                "app=prometheus-server"
+                "app=prometheus-operator-prometheus"
+        )
+        prometheus_url=$(getPrometheusURL "${prometheus_selectors[@]}")
+    fi
+
+    # Check if service_url is empty
+    if [ -z "$prometheus_url" ]; then
+       echo "Prometheus not found..!"
+       read -p "Installing Prometheus using helm, do you want to continue? (yes/no): " install_prometheus
+        if [ "$install_prometheus" == "yes" ]; then
+            helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+            helm repo update
+            helm upgrade --install nudgebee-prometheus prometheus-community/kube-prometheus-stack \
+                -n $namespace --create-namespace \
+                --set nodeExporter.enabled=true \
+                --set nodeExporter.service.targetPort=9101 \
+                --set pushgateway.enabled=false \
+                --set alertmanager.enabled=true \
+                --set kubeStateMetrics.enabled=true \
+                --set grafana.enabled=true \
+                -f https://raw.githubusercontent.com/nudgebee/k8s-agent/main/extra-scrape-config.yaml
+            prometheus_url="http://nudgebee-prometheus-kube-p-prometheus:9090"
+            grafana_command=" --set runner.grafana.enabled=true --set runner.grafana.url=http://nudgebee-prometheus-grafana.${namespace}.svc --set runner.grafana.username=admin --set runner.grafana.password=admin "
+        else
+            echo "Prometheus installation not requested. Exiting."
+            exit 0
+        fi
+    else
+        existingPrometheus=true
+    fi
 fi
 
 echo "Discovered Prometheus URL: $prometheus_url"
@@ -228,8 +261,38 @@ if [ -n "$prometheus_org_id" ]; then
   prometheus_org_id_command=" --set globalConfig.prometheus_headers='X-Scope-OrgID: $prometheus_org_id' --set globalConfig.alertmanager_headers='X-Scope-OrgID: $prometheus_org_id' --set opencost.opencost.extraEnv.PROMETHEUS_HEADER_X_SCOPE_ORGID=$prometheus_org_id"
 fi
 
+relay_address_command=""
+if [ -n "$relay_address" ]; then
+  relay_address_command=" --set runner.relay_address=$relay_address"
+fi
+
+collector_endpoint_command=""
+if [ -n "$collector_endpoint" ]; then
+  collector_endpoint_command=" --set runner.nudgebee.endpoint=$collector_endpoint"
+fi
+
+image_registry_command=""
+if [ -n "$image_registry" ]; then
+  image_registry_command=" --set runner.image_registry=$image_registry"
+fi
+
+disable_opencost_command=""
+if [ "$disable_opencost" == "true" ]; then
+  disable_opencost_command=" --set opencost.enabled=false"
+fi
+
+disable_otel_command=""
+if [ "$disable_otel" == "true" ]; then
+  disable_otel_command=" --set opentelemetry-collector.enabled=false --set clickhouse.enabled=false"
+fi
+
+disable_prometheus_stack_command=""
+if [ "$disable_prometheus_stack" == "true" ]; then
+  disable_prometheus_stack_command=" --set enablePrometheusStack=false"
+fi
+
 # Use helm upgrade --install to either install or upgrade the Helm chart
-a="helm upgrade --install $agent_name nudgebee-agent/nudgebee-agent  --namespace $namespace --create-namespace --set runner.nudgebee.auth_secret_key=\"$auth_key\" --set globalConfig.prometheus_url=\"$prometheus_url\" --set opencost.opencost.prometheus.external.url=\"$prometheus_url\" $disable_node_agent_command $openshift_enable_command $addition_secret_command $values_command $grafana_command $alert_manager_url_command $prometheus_org_id_command"
+a="helm upgrade --install $agent_name nudgebee-agent/nudgebee-agent  --namespace $namespace --create-namespace --set runner.nudgebee.auth_secret_key=\"$auth_key\" --set globalConfig.prometheus_url=\"$prometheus_url\" --set opencost.opencost.prometheus.external.url=\"$prometheus_url\" $disable_node_agent_command $openshift_enable_command $addition_secret_command $values_command $grafana_command $alert_manager_url_command $prometheus_org_id_command $relay_address_command $collector_endpoint_command $image_registry_command $disable_opencost_command $disable_otel_command $disable_prometheus_stack_command"
 
 echo "Running command: $a"
 eval $a

--- a/installation.sh
+++ b/installation.sh
@@ -1,347 +1,515 @@
 #!/bin/bash
-set -e  # Enable error handling
+set -euo pipefail
 
-# Initialize variables with default values
+# ============================================================================
+# Defaults
+# ============================================================================
+
 auth_key=""
 k8s_context=""
-openshift_enable=""
+openshift_enable="false"
 additional_secret=""
 prometheus_url=""
-opencost_service_url=""
 namespace="nudgebee-agent"
 agent_name="nudgebee-agent"
-env="prod"
-disable_node_agent=""
+disable_node_agent="false"
 values=""
 alert_manager_url=""
 prometheus_org_id=""
 relay_address=""
 collector_endpoint=""
 image_registry=""
-disable_opencost=""
-disable_otel=""
-disable_prometheus_stack=""
+disable_opencost="false"
+disable_otel="false"
+disable_prometheus_stack="false"
+non_interactive="false"
+dry_run="false"
 
-# Help function
+# Release name we use for kube-prometheus-stack. Kept here so CRD preflight
+# and post-install URL generation stay in sync.
+PROMETHEUS_RELEASE_NAME="nudgebee-prometheus"
+
+# Pin chart version so repeated runs are reproducible and customers don't
+# silently get a new upstream CRD set. Bump deliberately.
+KUBE_PROMETHEUS_STACK_VERSION="82.9.0"
+
+# Pin the scrape-config overlay to a commit SHA instead of main, so customers
+# installing at different times don't pick up unrelated changes.
+EXTRA_SCRAPE_CONFIG_REF="f8c6ca8"
+
+# CRDs shipped by kube-prometheus-stack / prometheus-operator.
+PROM_OP_CRDS=(
+  alertmanagerconfigs
+  alertmanagers
+  podmonitors
+  probes
+  prometheusagents
+  prometheuses
+  prometheusrules
+  scrapeconfigs
+  servicemonitors
+  thanosrulers
+)
+
+# Populated by preflight_crds()
+CRD_POLICY=""            # "manage" or "skip"
+grafana_enabled_by_us="false"
+
+# ============================================================================
+# Usage
+# ============================================================================
+
 usage() {
-  echo "Usage: $0 [-a <auth_key>] [-k <k8s_context>] [-o <openshift_enable>] [-p <prometheus_url>] [-s <additional_secret>]"
-  echo ""
-  echo "Options:"
-  echo "  -a <auth_key>           Authentication key (required)"
-  echo "  -k <k8s_context>        Kubernetes context"
-  echo "  -o <openshift_enable>   OpenShift enable option"
-  echo "  -p <prometheus_url>     Prometheus URL"
-  echo "  -s <additional_secret>  Additional secret"
-  echo "  -n <namespace>          Namespace"
-  echo "  -z <agent_name>         Agent_name"
-  echo "  -h <help>               Help"
-  echo "  -d <disable_node_agent> Disable node agent"
-  echo "  -f <values> values yaml"
-  echo "  -m <alert_manager_url> Alert manager URL"
-  echo "  -r <prometheus-org-id> Prometheus org id"
-  echo "  -w <relay_address>    WebSocket relay address (self-hosted)"
-  echo "  -c <collector_endpoint> Collector endpoint URL (self-hosted)"
-  echo "  -i <image_registry>   Image registry (air-gapped/on-prem)"
-  echo "  -x <disable_opencost> Disable OpenCost (true/false)"
-  echo "  -t <disable_otel>     Disable OpenTelemetry Collector & ClickHouse (true/false)"
-  echo "  -g <disable_prometheus_stack> Disable Prometheus stack (true/false)"
-  echo "Example:"
-  echo "  $0 -a my_auth_key -k my_k8s_context -o true -p http://prometheus:9090 -s my_secret"
+  cat >&2 <<'EOF'
+Usage: installation.sh -a <auth_key> [options]
+
+Required:
+  -a <auth_key>             Authentication key
+
+Common:
+  -k <k8s_context>          Kubernetes context (used for this install only;
+                            does not change your default context)
+  -n <namespace>            Namespace (default: nudgebee-agent)
+  -z <agent_name>           Helm release name (default: nudgebee-agent)
+  -p <prometheus_url>       Existing Prometheus URL; skips auto-discovery
+  -m <alert_manager_url>    Alertmanager URL
+  -r <prometheus_org_id>    Prometheus X-Scope-OrgID header value
+  -f <values.yaml>          Extra Helm values file
+  -s <additional_secret>    Name of extra secret to mount as envFrom
+
+Self-hosted / air-gapped:
+  -w <relay_address>        WebSocket relay address
+  -c <collector_endpoint>   Collector endpoint URL
+  -i <image_registry>       Image registry override
+
+Toggles (pass 'true' to enable):
+  -o true                   Enable OpenShift SCC
+  -d true                   Disable node agent
+  -x true                   Disable OpenCost
+  -t true                   Disable OpenTelemetry Collector + ClickHouse
+  -g true                   Disable auto-install of kube-prometheus-stack
+
+Other:
+  -y                        Non-interactive mode (fail instead of prompting)
+  -D                        Dry-run (helm --dry-run; CRD preflight in report-only mode; no writes)
+  -h                        Show this help
+
+Example:
+  installation.sh -a MY_KEY -k my-ctx -p http://prom.mon.svc:9090
+EOF
   exit 1
 }
 
-while getopts ":a:k:o:p:s:n:z:h:e:d:f:m:r:w:c:i:x:t:g:" opt; do
+# ============================================================================
+# Flag parsing
+# ============================================================================
+
+while getopts ":a:k:o:p:s:n:z:d:f:m:r:w:c:i:x:t:g:yDh" opt; do
   case $opt in
-    a)
-      auth_key="$OPTARG"
-      ;;
-    k)
-      k8s_context="$OPTARG"
-      ;;
-    o)
-      openshift_enable="$OPTARG"
-      ;;
-    p)
-      prometheus_url="$OPTARG"
-      ;;
-    s)
-      additional_secret="$OPTARG"
-      ;;
-    n)
-      namespace="$OPTARG"
-      ;;
-    z)
-      agent_name="$OPTARG"
-      ;;
-    d) 
-      disable_node_agent="$OPTARG"
-      ;;
-    f) 
-      values="$OPTARG"
-      ;;
-    m)
-      alert_manager_url="$OPTARG"
-      ;;
-    r)
-      prometheus_org_id="$OPTARG"
-      ;;
-    w)
-      relay_address="$OPTARG"
-      ;;
-    c)
-      collector_endpoint="$OPTARG"
-      ;;
-    i)
-      image_registry="$OPTARG"
-      ;;
-    x)
-      disable_opencost="$OPTARG"
-      ;;
-    t)
-      disable_otel="$OPTARG"
-      ;;
-    g)
-      disable_prometheus_stack="$OPTARG"
-      ;;
-    h)
-      usage
-      ;;
-    \?)
-      echo "Invalid option: -$OPTARG" >&2
-      usage
-      ;;
-    :)
-      echo "Option -$OPTARG requires an argument." >&2
-      usage
-      ;;
+    a) auth_key="$OPTARG" ;;
+    k) k8s_context="$OPTARG" ;;
+    o) openshift_enable="$OPTARG" ;;
+    p) prometheus_url="$OPTARG" ;;
+    s) additional_secret="$OPTARG" ;;
+    n) namespace="$OPTARG" ;;
+    z) agent_name="$OPTARG" ;;
+    d) disable_node_agent="$OPTARG" ;;
+    f) values="$OPTARG" ;;
+    m) alert_manager_url="$OPTARG" ;;
+    r) prometheus_org_id="$OPTARG" ;;
+    w) relay_address="$OPTARG" ;;
+    c) collector_endpoint="$OPTARG" ;;
+    i) image_registry="$OPTARG" ;;
+    x) disable_opencost="$OPTARG" ;;
+    t) disable_otel="$OPTARG" ;;
+    g) disable_prometheus_stack="$OPTARG" ;;
+    y) non_interactive="true" ;;
+    D) dry_run="true" ;;
+    h) usage ;;
+    \?) echo "Invalid option: -$OPTARG" >&2; usage ;;
+    :)  echo "Option -$OPTARG requires an argument." >&2; usage ;;
   esac
 done
 
-# Check if an access key is provided
-if [ -z "$auth_key" ]; then
-  echo "Error: Access key not provided. Please provide an access key using -a or --auth-key."
-  exit 1
-fi
+# ============================================================================
+# Helpers
+# ============================================================================
 
-# Log the Kubernetes context that will be used
-if [ -n "$k8s_context" ]; then
-    echo "Using the specified Kubernetes context: $k8s_context"
-    kubectl config use-context "$k8s_context"
-else
-    current_context=$(kubectl config current-context)
-    echo "Using the current Kubernetes context: $current_context"
-fi
+die() { echo "Error: $*" >&2; exit 1; }
 
-# Function to get Prometheus URL
-getPrometheusURL() {
-    local selectors=("$@")
-    for selector in "${selectors[@]}"; do
-        service_info=$(kubectl get svc --all-namespaces -l "$selector" -o custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.namespace,PORT:.spec.ports[0].port --no-headers 2>/dev/null)
+is_true() { [[ "${1:-}" == "true" ]]; }
 
-        if [ -n "$service_info" ]; then
-            local name=$(echo "$service_info" | awk '{print $1}')
-            local namespace=$(echo "$service_info" | awk '{print $2}')
-            local port=$(echo "$service_info" | awk '{print $3}')
-
-            # Generate and return Prometheus URL
-            local service_url="http://${name}.${namespace}.svc:${port}"
-            echo "$service_url"
-            return
-        fi
-    done
-
-    # If no Prometheus service is found, return an empty string
-    echo ""
+# kubectl / helm wrappers that honour -k without mutating the user's default
+# kube context.
+kctl() {
+  if [ -n "$k8s_context" ]; then
+    kubectl --context="$k8s_context" "$@"
+  else
+    kubectl "$@"
+  fi
 }
 
-# Check Kubernetes node kernel versions
-echo "Checking Kubernetes node kernel versions..."
-NODE_KERNEL_VERSIONS=$(kubectl get nodes -o jsonpath='{.items[*].status.nodeInfo.kernelVersion}')
-MIN_KERNEL_VERSION="4.16"
+hlm() {
+  if [ -n "$k8s_context" ]; then
+    helm --kube-context="$k8s_context" "$@"
+  else
+    helm "$@"
+  fi
+}
 
-for kernel_version in $NODE_KERNEL_VERSIONS; do
-    KERNEL_MAJOR_MINOR=$(echo "$kernel_version" | cut -d. -f1-2)
-    if (( $(echo "$KERNEL_MAJOR_MINOR < $MIN_KERNEL_VERSION" | bc -l) )); then
-        echo "Error: Node with kernel version $kernel_version is less than $MIN_KERNEL_VERSION. Node Agent will not be installed on this node."
-        disable_node_agent="true"
-    else
-        echo "Node kernel version $kernel_version is compatible."
-    fi
+# 0 if $1 >= $2 semver-style ("4.19" >= "4.16" yes; "4.9" >= "4.16" no).
+version_ge() {
+  [ "$(printf '%s\n%s\n' "$2" "$1" | sort -V | head -n1)" = "$2" ]
+}
+
+# ============================================================================
+# Preflight: required binaries & auth_key
+# ============================================================================
+
+for bin in kubectl helm sort awk curl; do
+  command -v "$bin" >/dev/null 2>&1 || die "'$bin' is required but not installed."
 done
 
-# Check if kubectl is installed
-if ! command -v kubectl &> /dev/null; then
-    echo "Error: kubectl is not installed. You can install it by following the instructions at:"
-    echo "https://kubernetes.io/docs/tasks/tools/install-kubectl/"
-    exit 1
+if [ -z "$auth_key" ]; then
+  die "Authentication key not provided (use -a)."
 fi
 
-# Check if helm is installed
-if ! command -v helm &> /dev/null; then
-    echo "Error: Helm is not installed. You can install it by following the instructions at:"
-    echo "https://helm.sh/docs/intro/install/"
-    exit 1
-fi
-
-# Check for existing Prometheus (skip if prometheus stack is disabled)
-existingPrometheus=false
-grafana_command=""
-if [ "$disable_prometheus_stack" == "true" ]; then
-    echo "Prometheus stack disabled, skipping Prometheus discovery and installation."
+if [ -n "$k8s_context" ]; then
+  echo "Using Kubernetes context: $k8s_context (will not change your default context)"
 else
-    if [ -z "$prometheus_url" ]; then
-        prometheus_selectors=(
-                "app=kube-prometheus-stack-prometheus"
-                "app=prometheus,component=server,release!=kubecost"
-                "app=prometheus-server"
-                "app=prometheus-operator-prometheus"
-        )
-        prometheus_url=$(getPrometheusURL "${prometheus_selectors[@]}")
-    fi
+  echo "Using current Kubernetes context: $(kctl config current-context)"
+fi
 
-    # Check if service_url is empty
-    if [ -z "$prometheus_url" ]; then
-       echo "Prometheus not found..!"
-       read -p "Installing Prometheus using helm, do you want to continue? (yes/no): " install_prometheus
-        if [ "$install_prometheus" == "yes" ]; then
-            helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-            helm repo update
-            helm upgrade --install nudgebee-prometheus prometheus-community/kube-prometheus-stack \
-                -n $namespace --create-namespace \
-                --set nodeExporter.enabled=true \
-                --set nodeExporter.service.targetPort=9101 \
-                --set pushgateway.enabled=false \
-                --set alertmanager.enabled=true \
-                --set kubeStateMetrics.enabled=true \
-                --set grafana.enabled=true \
-                -f https://raw.githubusercontent.com/nudgebee/k8s-agent/main/extra-scrape-config.yaml
-            prometheus_url="http://nudgebee-prometheus-kube-p-prometheus:9090"
-            grafana_command=" --set runner.grafana.enabled=true --set runner.grafana.url=http://nudgebee-prometheus-grafana.${namespace}.svc --set runner.grafana.username=admin --set runner.grafana.password=admin "
-        else
-            echo "Prometheus installation not requested. Exiting."
-            exit 0
+# ============================================================================
+# Kernel version check (min 4.16 for nodeAgent eBPF probes)
+# ============================================================================
+
+echo "Checking node kernel versions (minimum 4.16 for node-agent)..."
+any_node_too_old="false"
+while IFS=$'\t' read -r node_name kernel; do
+  [ -z "${kernel:-}" ] && continue
+  if version_ge "$kernel" "4.16"; then
+    echo "  $node_name: $kernel OK"
+  else
+    echo "  $node_name: $kernel (too old; node-agent would fail on this node)" >&2
+    any_node_too_old="true"
+  fi
+done < <(kctl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.nodeInfo.kernelVersion}{"\n"}{end}')
+
+if is_true "$any_node_too_old" && ! is_true "$disable_node_agent"; then
+  echo "At least one node has kernel <4.16; disabling node-agent globally." >&2
+  disable_node_agent="true"
+fi
+
+# ============================================================================
+# Service URL discovery
+# ============================================================================
+
+# Return the first matching service as a DNS URL. Prefers port named 'web' or
+# 'http' (Prometheus convention) over ports[0].
+getServiceURL() {
+  local selectors=("$@")
+  for selector in "${selectors[@]}"; do
+    local svc ns port_web port_http port_first
+    read -r svc ns port_web port_http port_first < <(
+      kctl get svc --all-namespaces -l "$selector" \
+        -o jsonpath='{range .items[0]}{.metadata.name}{" "}{.metadata.namespace}{" "}{.spec.ports[?(@.name=="web")].port}{" "}{.spec.ports[?(@.name=="http")].port}{" "}{.spec.ports[0].port}{"\n"}{end}' \
+        2>/dev/null || echo ""
+    )
+    [ -z "${svc:-}" ] && continue
+    local port="${port_web:-${port_http:-${port_first:-}}}"
+    [ -z "$port" ] && continue
+    echo "http://${svc}.${ns}.svc:${port}"
+    return 0
+  done
+  return 0
+}
+
+# ============================================================================
+# CRD preflight for kube-prometheus-stack
+# ============================================================================
+#
+# kube-prometheus-stack renders its CRDs as regular Helm templates (via the
+# bundled `crds` subchart). If the cluster already has those CRDs under a
+# different field manager / Helm release, an upgrade triggers a server-side
+# apply field-ownership conflict.
+#
+# Decision tree:
+#   * All CRDs absent or already owned by our release → install normally.
+#   * CRDs owned by a DIFFERENT Helm release → skip CRD management
+#     (`--set crds.enabled=false`) and trust that release's CRDs.
+#   * CRDs owned by a non-Helm manager (kubectl, raw manifests, etc.) → adopt
+#     them into our Helm release: re-apply current content with field-manager
+#     `helm` and `--force-conflicts` to take over ownership, then stamp the
+#     standard Helm release annotations/labels. Helm will reconcile them on
+#     install and create any missing CRDs normally.
+
+preflight_crds() {
+  local other_helm_release=""
+  local adopt_list=() crd full release managers
+
+  for crd in "${PROM_OP_CRDS[@]}"; do
+    full="${crd}.monitoring.coreos.com"
+    if ! kctl get crd "$full" >/dev/null 2>&1; then
+      continue
+    fi
+    release=$(kctl get crd "$full" \
+      -o jsonpath='{.metadata.annotations.meta\.helm\.sh/release-name}' 2>/dev/null || echo "")
+    if [ "$release" = "$PROMETHEUS_RELEASE_NAME" ]; then
+      continue
+    fi
+    if [ -n "$release" ]; then
+      other_helm_release="$release"
+      echo "  $full: owned by Helm release '$release'" >&2
+      continue
+    fi
+    managers=$(kctl get crd "$full" \
+      -o jsonpath='{range .metadata.managedFields[*]}{.manager}{","}{end}' 2>/dev/null || echo "")
+    echo "  $full: non-Helm owner (managers: ${managers%,})" >&2
+    adopt_list+=("$full")
+  done
+
+  if [ -n "$other_helm_release" ]; then
+    echo "Some CRDs are owned by Helm release '$other_helm_release'." >&2
+    echo "Installing with --set crds.enabled=false to avoid fighting that release." >&2
+    echo "Ensure that release ships CRDs compatible with kube-prometheus-stack $KUBE_PROMETHEUS_STACK_VERSION." >&2
+    CRD_POLICY="skip"
+    return
+  fi
+
+  if [ ${#adopt_list[@]} -gt 0 ]; then
+    if is_true "$dry_run"; then
+      echo "[dry-run] Would adopt ${#adopt_list[@]} CRD(s) into Helm release '$PROMETHEUS_RELEASE_NAME':" >&2
+      for full in "${adopt_list[@]}"; do echo "  [dry-run] adopt $full" >&2; done
+    else
+      echo "Adopting ${#adopt_list[@]} existing CRD(s) into Helm release '$PROMETHEUS_RELEASE_NAME'..." >&2
+      for full in "${adopt_list[@]}"; do
+        kctl get crd "$full" -o yaml \
+          | kctl apply --server-side --force-conflicts --field-manager=helm -f - >/dev/null
+        kctl annotate crd "$full" \
+          "meta.helm.sh/release-name=$PROMETHEUS_RELEASE_NAME" \
+          "meta.helm.sh/release-namespace=$namespace" \
+          --overwrite >/dev/null
+        kctl label crd "$full" app.kubernetes.io/managed-by=Helm --overwrite >/dev/null
+        echo "  adopted $full" >&2
+      done
+    fi
+  fi
+
+  CRD_POLICY="manage"
+}
+
+# ============================================================================
+# Prometheus discovery / install
+# ============================================================================
+
+install_kube_prometheus_stack() {
+  preflight_crds
+  local extra=()
+  if [ "$CRD_POLICY" = "skip" ]; then
+    extra+=(--set crds.enabled=false)
+  fi
+
+  hlm repo add prometheus-community https://prometheus-community.github.io/helm-charts >/dev/null
+  hlm repo update >/dev/null
+
+  local dry=()
+  is_true "$dry_run" && dry=(--dry-run)
+
+  hlm upgrade --install "$PROMETHEUS_RELEASE_NAME" prometheus-community/kube-prometheus-stack \
+    --version "$KUBE_PROMETHEUS_STACK_VERSION" \
+    --namespace "$namespace" --create-namespace \
+    --wait --timeout 10m \
+    --set nodeExporter.enabled=true \
+    --set nodeExporter.service.targetPort=9101 \
+    --set pushgateway.enabled=false \
+    --set alertmanager.enabled=true \
+    --set kubeStateMetrics.enabled=true \
+    --set grafana.enabled=true \
+    ${extra[@]+"${extra[@]}"} ${dry[@]+"${dry[@]}"} \
+    -f "https://raw.githubusercontent.com/nudgebee/k8s-agent/${EXTRA_SCRAPE_CONFIG_REF}/extra-scrape-config.yaml"
+
+  prometheus_url="http://${PROMETHEUS_RELEASE_NAME}-kube-p-prometheus.${namespace}.svc:9090"
+  grafana_enabled_by_us="true"
+}
+
+discover_or_prompt_prometheus() {
+  if is_true "$disable_prometheus_stack"; then
+    echo "Prometheus stack disabled via -g; skipping Prometheus discovery and install."
+    return
+  fi
+
+  if [ -n "$prometheus_url" ]; then
+    echo "Using Prometheus URL from -p: $prometheus_url"
+    return
+  fi
+
+  local selectors=(
+    "app=kube-prometheus-stack-prometheus"
+    "app=prometheus,component=server,release!=kubecost"
+    "app=prometheus-server"
+    "app=prometheus-operator-prometheus"
+  )
+  prometheus_url=$(getServiceURL "${selectors[@]}")
+  if [ -n "$prometheus_url" ]; then
+    echo "Discovered existing Prometheus: $prometheus_url"
+    return
+  fi
+
+  echo "Prometheus was not auto-detected in this cluster."
+  if is_true "$non_interactive"; then
+    die "In non-interactive mode (-y) with no -p supplied and no Prometheus detected. Pass -p <url>, or -g true to skip the stack."
+  fi
+
+  echo "Options:"
+  echo "  1) I have an existing Prometheus — enter its URL"
+  echo "  2) Install kube-prometheus-stack now"
+  echo "  3) Abort"
+  local choice
+  read -r -p "Choose [1/2/3]: " choice
+  case "$choice" in
+    1)
+      read -r -p "Enter Prometheus URL (e.g. http://prometheus.monitoring.svc:9090): " prometheus_url
+      [ -z "$prometheus_url" ] && die "No URL provided."
+      # Best-effort reachability check. Cluster-internal names won't resolve
+      # from the local shell, so we only fail-loud for external-looking URLs.
+      if [[ "$prometheus_url" != *.svc* && "$prometheus_url" != *.local* ]]; then
+        if ! curl -sf --max-time 5 "${prometheus_url%/}/-/ready" >/dev/null 2>&1; then
+          echo "Warning: ${prometheus_url} not reachable from this shell; continuing anyway." >&2
         fi
-    else
-        existingPrometheus=true
+      fi
+      ;;
+    2)
+      install_kube_prometheus_stack
+      ;;
+    *)
+      die "Aborted."
+      ;;
+  esac
+}
+
+discover_or_prompt_prometheus
+echo "Prometheus URL in use: ${prometheus_url:-<none>}"
+
+# ============================================================================
+# nudgebee-agent install
+# ============================================================================
+
+install_agent() {
+  echo "Installing nudgebee-agent..."
+  hlm repo add nudgebee-agent https://nudgebee.github.io/k8s-agent/ >/dev/null
+  hlm repo update >/dev/null 2>&1 || true
+
+  local args=(
+    upgrade --install "$agent_name" nudgebee-agent/nudgebee-agent
+    --namespace "$namespace" --create-namespace
+    --set-string "runner.nudgebee.auth_secret_key=$auth_key"
+  )
+  is_true "$dry_run" && args+=(--dry-run)
+
+  # Only push a Prometheus URL if we actually have one. Leaving
+  # opencost.*.external.url empty causes opencost to report an invalid target.
+  if [ -n "$prometheus_url" ]; then
+    args+=(--set-string "globalConfig.prometheus_url=$prometheus_url")
+    if ! is_true "$disable_opencost"; then
+      args+=(--set-string "opencost.opencost.prometheus.external.url=$prometheus_url")
     fi
-fi
+  fi
 
-echo "Discovered Prometheus URL: $prometheus_url"
+  is_true "$disable_node_agent"       && args+=(--set nodeAgent.enabled=false)
+  is_true "$openshift_enable"         && args+=(--set openshift.enable=true --set openshift.createScc=true)
+  is_true "$disable_opencost"         && args+=(--set opencost.enabled=false)
+  is_true "$disable_otel"             && args+=(--set opentelemetry-collector.enabled=false --set clickhouse.enabled=false)
+  is_true "$disable_prometheus_stack" && args+=(--set enablePrometheusStack=false)
 
-echo "Installing nudgebee agent using helm"
-helm repo add nudgebee-agent https://nudgebee.github.io/k8s-agent/
-helm repo update > /dev/null 2>&1
+  if [ -n "$additional_secret" ]; then
+    args+=(
+      --set-string "runner.additional_env_froms[0].secretRef.name=$additional_secret"
+      --set-string "runner.additional_env_froms[0].secretRef.optional=true"
+    )
+  fi
+  [ -n "$values" ]             && args+=(-f "$values")
+  [ -n "$alert_manager_url" ]  && args+=(--set-string "globalConfig.alertmanager_url=$alert_manager_url")
+  [ -n "$relay_address" ]      && args+=(--set-string "runner.relay_address=$relay_address")
+  [ -n "$collector_endpoint" ] && args+=(--set-string "runner.nudgebee.endpoint=$collector_endpoint")
+  [ -n "$image_registry" ]     && args+=(--set-string "runner.image_registry=$image_registry")
 
-addition_secret_command=""
-if [ -n "$additional_secret" ]; then
-    addition_secret_command=" --set-string runner.additional_env_froms[0].secretRef.name=$additional_secret --set-string runner.additional_env_froms[0].secretRef.optional=true"
-fi
+  if [ -n "$prometheus_org_id" ]; then
+    args+=(
+      --set-string "globalConfig.prometheus_headers=X-Scope-OrgID: $prometheus_org_id"
+      --set-string "globalConfig.alertmanager_headers=X-Scope-OrgID: $prometheus_org_id"
+      --set-string "opencost.opencost.extraEnv.PROMETHEUS_HEADER_X_SCOPE_ORGID=$prometheus_org_id"
+    )
+  fi
 
-openshift_enable_command=""
-if [ -n "$openshift_enable" ]; then
-    openshift_enable_command=" --set-string openshift.enable=true --set-string openshift.createScc=true"
-fi
-disable_node_agent_command=""
-if [ -n "$disable_node_agent" ]; then
-  disable_node_agent_command=" --set nodeAgent.enabled=false"
-fi
+  if is_true "$grafana_enabled_by_us"; then
+    args+=(
+      --set runner.grafana.enabled=true
+      --set-string "runner.grafana.url=http://${PROMETHEUS_RELEASE_NAME}-grafana.${namespace}.svc"
+      --set-string "runner.grafana.username=admin"
+      --set-string "runner.grafana.password=admin"
+    )
+  fi
 
-values_command=""
-if [ -n "$values" ]; then
-  values_command=" -f $values"
-fi
+  # Print the command with the auth key redacted so log captures don't leak it.
+  local printable=()
+  for a in "${args[@]}"; do
+    case "$a" in
+      runner.nudgebee.auth_secret_key=*) printable+=("runner.nudgebee.auth_secret_key=***REDACTED***") ;;
+      *) printable+=("$a") ;;
+    esac
+  done
+  echo "Running: helm ${printable[*]}"
 
-alert_manager_url_command=""
-if [ -n "$alert_manager_url" ]; then
-  alert_manager_url_command=" --set globalConfig.alertmanager_url=$alert_manager_url"
-fi
+  hlm "${args[@]}"
+}
 
-prometheus_org_id_command=""
-if [ -n "$prometheus_org_id" ]; then
-  prometheus_org_id_command=" --set globalConfig.prometheus_headers='X-Scope-OrgID: $prometheus_org_id' --set globalConfig.alertmanager_headers='X-Scope-OrgID: $prometheus_org_id' --set opencost.opencost.extraEnv.PROMETHEUS_HEADER_X_SCOPE_ORGID=$prometheus_org_id"
-fi
+install_agent
 
-relay_address_command=""
-if [ -n "$relay_address" ]; then
-  relay_address_command=" --set runner.relay_address=$relay_address"
-fi
+# ============================================================================
+# Loki detection (informational)
+# ============================================================================
 
-collector_endpoint_command=""
-if [ -n "$collector_endpoint" ]; then
-  collector_endpoint_command=" --set runner.nudgebee.endpoint=$collector_endpoint"
-fi
-
-image_registry_command=""
-if [ -n "$image_registry" ]; then
-  image_registry_command=" --set runner.image_registry=$image_registry"
-fi
-
-disable_opencost_command=""
-if [ "$disable_opencost" == "true" ]; then
-  disable_opencost_command=" --set opencost.enabled=false"
-fi
-
-disable_otel_command=""
-if [ "$disable_otel" == "true" ]; then
-  disable_otel_command=" --set opentelemetry-collector.enabled=false --set clickhouse.enabled=false"
-fi
-
-disable_prometheus_stack_command=""
-if [ "$disable_prometheus_stack" == "true" ]; then
-  disable_prometheus_stack_command=" --set enablePrometheusStack=false"
-fi
-
-# Use helm upgrade --install to either install or upgrade the Helm chart
-a="helm upgrade --install $agent_name nudgebee-agent/nudgebee-agent  --namespace $namespace --create-namespace --set runner.nudgebee.auth_secret_key=\"$auth_key\" --set globalConfig.prometheus_url=\"$prometheus_url\" --set opencost.opencost.prometheus.external.url=\"$prometheus_url\" $disable_node_agent_command $openshift_enable_command $addition_secret_command $values_command $grafana_command $alert_manager_url_command $prometheus_org_id_command $relay_address_command $collector_endpoint_command $image_registry_command $disable_opencost_command $disable_otel_command $disable_prometheus_stack_command"
-
-echo "Running command: $a"
-eval $a
-
-# Discover Loki as log server if not found, then provide link to nudgebee doc to configure log provider
-loki_selectors=(
-        "app=loki"
-        "app.kubernetes.io/instance=loki"
-)
-
-RED='\033[0;31m'
-NC='\033[0m'
-loki_url=$(getPrometheusURL "${loki_selectors[@]}")
+loki_url=$(getServiceURL "app=loki" "app.kubernetes.io/instance=loki" || true)
 if [ -z "$loki_url" ]; then
-    echo "Log provider not found..!"
-    read -p "Installing Loki using helm, do you want to continue? (yes/no): " install_loki
-    if [ "$install_loki" == "yes" ]; then
-        # Add Helm installation command here or instructions
-        helm repo add grafana https://grafana.github.io/helm-charts
-        helm repo update
-        helm upgrade --install nudgebee-loki grafana/loki-stack \
-            -n "$namespace" --create-namespace \
-            --set loki.persistence.enabled=true \
-            --set loki.persistence.size=10Gi \
-            --set promtail.enabled=true \
-            --set loki.isDefault=false
-        loki_url="http://nudgebee-loki:3100"
-    else
-        echo "Loki installation not requested. Node Agent will still be installed."
+  echo "Log provider not detected in cluster."
+  if ! is_true "$non_interactive"; then
+    read -r -p "Install Loki (grafana/loki-stack) now? (yes/no): " install_loki
+    if [ "$install_loki" = "yes" ]; then
+      hlm repo add grafana https://grafana.github.io/helm-charts >/dev/null
+      hlm repo update >/dev/null 2>&1 || true
+      hlm upgrade --install nudgebee-loki grafana/loki-stack \
+        --namespace "$namespace" --create-namespace \
+        --set loki.persistence.enabled=true \
+        --set loki.persistence.size=10Gi \
+        --set promtail.enabled=true \
+        --set loki.isDefault=false
+      echo "Loki installed at http://nudgebee-loki.${namespace}.svc:3100"
+      echo "Configure NudgeBee's logging provider per the docs: https://app.nudgebee.com/help/docs/installation/agent/installation/logging/"
     fi
+  fi
 else
-    echo "Please configure NudgeBee to connect to your existing Loki instance by following the instructions at: https://app.nudgebee.com/help/docs/installation/agent/installation/logging/"
+  echo "Existing Loki detected at $loki_url"
+  echo "Configure NudgeBee to use it: https://app.nudgebee.com/help/docs/installation/agent/installation/logging/"
 fi
 
-# Check for ClickHouse PVC requirements
-echo "NudgeBee requires PVCs for ClickHouse. If your environment does not support automatic PVC creation, you will need to create them manually."
+# ============================================================================
+# Summary
+# ============================================================================
 
-# Check installation status of each component
-echo "Checking installation status..."
-components=("prometheus" "loki" "clickhouse" "$agent_name")
-for component in "${components[@]}"; do
-    if kubectl get pods -n $namespace | grep -q "$component"; then
-        echo "$component installed successfully."
-    else
-        echo "$component installation failed."
-        echo "Possible reasons for failure:"
-        echo "1. Insufficient resources."
-        echo "2. Missing dependencies."
-        echo "3. Configuration errors."
-        echo "Please refer to the NudgeBee documentation for troubleshooting: https://app.nudgebee.com/help/docs/installation/agent/installation/"
-    fi
-done
+echo
+echo "Installation summary:"
+echo "  Namespace:         $namespace"
+echo "  Agent release:     $agent_name"
+echo "  Prometheus URL:    ${prometheus_url:-<disabled>}"
+echo "  OpenCost:          $(is_true "$disable_opencost" && echo disabled || echo enabled)"
+echo "  OpenTelemetry/CH:  $(is_true "$disable_otel" && echo disabled || echo enabled)"
+echo "  Prometheus stack:  $(is_true "$disable_prometheus_stack" && echo disabled || echo enabled)"
+if ! is_true "$disable_otel"; then
+  echo "  Note: ClickHouse requires a PVC. If your cluster has no default storage class, provision one manually."
+fi
+echo
+echo "Checking pod status in namespace $namespace:"
+kctl -n "$namespace" get pods || true
+echo
+echo "Pods may still be starting. Monitor with: kubectl -n $namespace get pods -w"

--- a/installation.sh
+++ b/installation.sh
@@ -211,10 +211,14 @@ getServiceURL() {
   local selectors=("$@")
   for selector in "${selectors[@]}"; do
     local svc ns port_web port_http port_first
-    read -r svc ns port_web port_http port_first < <(
+    # Use comma delimiter so missing fields stay empty. With space-separated
+    # output and default IFS, `read` collapses consecutive whitespace and
+    # shifts later columns into earlier variables when an expected port name
+    # (e.g. "web") is absent — making port_web hold what should be port_first.
+    IFS=',' read -r svc ns port_web port_http port_first < <(
       kctl get svc --all-namespaces -l "$selector" \
-        -o jsonpath='{range .items[0]}{.metadata.name}{" "}{.metadata.namespace}{" "}{.spec.ports[?(@.name=="web")].port}{" "}{.spec.ports[?(@.name=="http")].port}{" "}{.spec.ports[0].port}{"\n"}{end}' \
-        2>/dev/null || echo ""
+        -o jsonpath='{range .items[0]}{.metadata.name}{","}{.metadata.namespace}{","}{.spec.ports[?(@.name=="web")].port}{","}{.spec.ports[?(@.name=="http")].port}{","}{.spec.ports[0].port}{"\n"}{end}' \
+        2>/dev/null || echo ",,,,"
     )
     [ -z "${svc:-}" ] && continue
     local port="${port_web:-${port_http:-${port_first:-}}}"


### PR DESCRIPTION
## Summary

- Fixes the server-side-apply field-ownership conflict customers hit on on-prem clusters when running `installation.sh` against a cluster that already has `monitoring.coreos.com` CRDs owned by a non-Helm manager (`kubectl` / `kubectl-client-side-apply`). The symptom was: `conflict occurred while applying object alertmanagerconfigs.monitoring.coreos.com — conflicts with "kubectl": .metadata.annotations.operator.prometheus.io/version and .spec.versions`.
- Adds a CRD preflight step that classifies existing CRDs (ours / other Helm release / non-Helm owner / absent) and either adopts them into our release via `kubectl apply --server-side --force-conflicts --field-manager=helm` (filling helm annotations/labels) or installs kube-prometheus-stack with `--set crds.enabled=false` when another Helm release owns them.
- Bundles a batch of correctness fixes around the CRD work — see the commit body for the full list. Highlights: chart version pinned (82.9.0), `extra-scrape-config.yaml` pinned to a commit SHA, 3-way Prometheus discovery prompt, new `-y` non-interactive and `-D` dry-run flags, `auth_key` redacted in logs, `--set-string` for URL-valued flags, `eval` removed in favour of a bash args array, `-k` no longer mutates the user's default kube context, FQDNs in computed service URLs, and the `4.9 < 4.16` kernel-compare bug fixed.

## Heads-up for reviewer — stacked on #415

This branch was cut from `fix/installation-script-new-flags-prod` (PR #415), which is still open. The PR diff against `prod` therefore shows **two** commits:

1. `235a4b9 feat: add new flags to installation script...` — already in review on #415
2. `7a9cfb7 fix: resolve CRD conflict and harden installation script` — the new work here

Recommend merging #415 first; this PR will auto-reduce to a single commit once that happens. Alternatively both can be merged together — the changes don't conflict, the fix commit just extends the flag surface from #415.

## Test plan

- [x] Validated end-to-end on `gke_nudgebee-dev_us-central1_nudgebee-dev`, which had 5 prometheus-operator CRDs owned by `kubectl` / `kubectl-client-side-apply` (exactly the customer's broken state).
- [x] CRD preflight detected the non-Helm owners and adopted all 5 into Helm release `nudgebee-prometheus`.
- [x] `helm upgrade --install kube-prometheus-stack 82.9.0` then created the 5 missing CRDs and came up cleanly.
- [x] Prometheus auto-discovery on re-run found the new service via the existing label selector and produced the FQDN `http://nudgebee-prometheus-kube-p-prometheus.<ns>.svc:9090`.
- [x] `nudgebee-agent` chart installed against the discovered Prometheus URL with `-z nudgebee-agent-crdtest` to avoid cluster-scoped resource collisions with existing `iteration-prod` / `iteration-test` installs.
- [x] Verified `auth_key` is redacted in the printed helm command (`***REDACTED***`).
- [x] Verified `-y` mode aborts cleanly when discovery fails and no `-p` is supplied.
- [x] Verified `-D` dry-run mode reports the preflight plan without mutating cluster state.
- [x] Cleaned up: both releases uninstalled, namespace deleted, adopted CRDs stripped of helm annotations, newly-created CRDs removed. Cluster returned to pre-test state.

## Notes

- One transient issue during the first kube-prometheus-stack install on the dev cluster: helm revision 1 failed with `prometheusrules.monitoring.coreos.com "nudgebee-prometheus-kube-p-kubernetes-apps" already exists` despite helm itself being the creator. Revision 2 (a re-run) succeeded. Looks like a chart-internal race rather than anything in our script; the `--wait --timeout 10m` we added made the failure loud where the original script would have swallowed it. Leaving `--wait` in place — a loud failure that self-resolves on re-run is better than a silent half-install.
- The 5 CRDs we adopted keep `helm` as field manager after the test (vs the original `kubectl`). Functionally equivalent; noted for the record.