### PR TITLE
fix: reduce monitoring noise — alert rules + otel trace sampling

### DIFF
--- a/charts/nudgebee-agent/Chart.yaml
+++ b/charts/nudgebee-agent/Chart.yaml
@@ -6,8 +6,8 @@ icon: https://nudgebee-documents.s3.amazonaws.com/images/Nudgebee-logo.png
 # these are set to the right value by .github/workflows/release.yaml
 # we use 0.0.1 as a placeholder for the version` because Helm wont allow `0.0.0` and we want to be able to run
 # `helm install` on development checkouts without updating this file. the version doesn't matter in that case anyway
-version: 0.0.122
-appVersion: 0.0.122
+version: 0.0.123
+appVersion: 0.0.123
 dependencies:
 - name: opencost
   version: 2.0.1

--- a/charts/nudgebee-agent/templates/prometheus-alert-rule.yaml
+++ b/charts/nudgebee-agent/templates/prometheus-alert-rule.yaml
@@ -1,4 +1,13 @@
 {{- if (and (not (default false .Values.runner.victoria_metrics_enabled)) (default false .Values.alertmanager.create_nb_default_rules)) }}
+{{- /*
+Container-ID exclusions for the log-error and HTTP-failure rules.
+
+The log-error regex additionally excludes log-collection infrastructure
+(fluent-bit, loki, opensearch, etc.), which emits steady error-level
+log streams that are transport/ingest failures — not app-level signal.
+*/ -}}
+{{- $excludeLog := ".*(prometheus|grafana|kube-system|nudgebee-agent|containerd|kubelet|keda|actions-runner-system-1|fluent-bit|fluentd|loki|opensearch|elasticsearch|logstash|datadog|newrelic|otel|promtail).*" -}}
+{{- $excludeApi := ".*(prometheus|grafana|kube-system|nudgebee-agent|containerd|kubelet|keda|karpenter|actions-runner-system-1).*" -}}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -13,8 +22,8 @@ spec:
       rules:
         - alert: KubeHpaMaxedOut
           expr: >-
-            kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics"} 
-              == 
+            kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics"}
+              ==
             kube_horizontalpodautoscaler_spec_max_replicas{job="kube-state-metrics"}
             > 1
           for: 15m
@@ -22,39 +31,62 @@ spec:
             severity: warning
           annotations:
             description: >-
-              HPA {{`{{ $labels.namespace }}`}}/{{`{{ $labels.horizontalpodautoscaler }}`}} 
+              HPA {{`{{ $labels.namespace }}`}}/{{`{{ $labels.horizontalpodautoscaler }}`}}
               has been running at max replicas for longer than 15 minutes.
             summary: HPA is running at max replicas
+        # Fires when a container's error/critical log rate is >3x its historical
+        # baseline (1h window offset 1h — the offset keeps an ongoing spike from
+        # polluting the baseline and silencing sustained incidents). The 0.1/s
+        # floor is an activity floor (≥6 err/min) that avoids ratio blowups on
+        # idle containers. The baseline>0 guard prevents cold-start containers
+        # (no historical data) from firing on their first error burst.
         - alert: HighErrorCriticalLogs
-          expr: >-
-            increase(container_log_messages_total{level=~"error|critical",
-            container_id!~".*(prometheus|grafana|kube-system|nudgebee-agent|containerd|kubelet|keda|actions-runner-system-1).*"}[5m])
-            > 1
-          for: 5m
+          expr: |
+            rate(container_log_messages_total{level=~"error|critical", container_id!~"{{ $excludeLog }}"}[5m])
+              > 3 * rate(container_log_messages_total{level=~"error|critical", container_id!~"{{ $excludeLog }}"}[1h] offset 1h)
+            and
+            rate(container_log_messages_total{level=~"error|critical", container_id!~"{{ $excludeLog }}"}[5m]) > 0.1
+            and
+            rate(container_log_messages_total{level=~"error|critical", container_id!~"{{ $excludeLog }}"}[1h] offset 1h) > 0
+          for: 10m
           annotations:
             summary: "High error/critical logs - Sample: {{`{{ printf \"%.80s\" $labels.sample }}`}}"
-            description: "The total count of container log messages with error or critical level is higher for the past 5 minutes, grouped by container_id. Container ID: {{`{{ $labels.container_id }}`}} Log Sample: {{`{{ $labels.sample }}`}} Failure Count: {{`{{ printf \"%.0f\" $value }}`}}"
+            description: "Container log error rate is more than 3x its 1h baseline. Container ID: {{`{{ $labels.container_id }}`}} Log Sample: {{`{{ $labels.sample }}`}} Current rate (err/s): {{`{{ printf \"%.2f\" $value }}`}}"
           labels:
-            severity: critical
+            severity: warning
+        # Fires when >5% of a container's HTTP traffic is 5xx for 10m, with an
+        # activity floor of 0.1 req/s so ratios don't blow up on low-volume
+        # containers. 4xx is excluded — those are client errors (bad request,
+        # unauthorised, etc.) and don't indicate the application failing.
         - alert: ApplicationAPIFailures
-          expr: >-
-            increase(container_http_requests_total{container_id!~".*(prometheus|grafana|kube-system|nudgebee-agent|containerd|kubelet|keda|karpenter|actions-runner-system-1).*",
-            status=~"5..|4.."}[5m]) > 1
-          for: 5m
+          expr: |
+            (
+              sum by (container_id, method, path, status) (rate(container_http_requests_total{status=~"5..", container_id!~"{{ $excludeApi }}"}[5m]))
+              / on (container_id) group_left ()
+              sum by (container_id) (rate(container_http_requests_total{container_id!~"{{ $excludeApi }}"}[5m]))
+            ) > 0.05
+            and on (container_id)
+            sum by (container_id) (rate(container_http_requests_total{container_id!~"{{ $excludeApi }}"}[5m])) > 0.1
+          for: 10m
           annotations:
-            summary: "API Failures - {{`{{ $labels.method }}`}} {{`{{ printf \"%.50s\" $labels.path }}`}} ({{`{{ $labels.status }}`}})"
-            description: "Application reported API failure. Container ID: {{`{{ $labels.container_id }}`}} Request Path: {{`{{ $labels.path }}`}} Request Method: {{`{{ $labels.method }}`}} Failure Count: {{`{{ printf \"%.0f\" $value }}`}}"
+            summary: "High 5xx rate - {{`{{ $labels.method }}`}} {{`{{ printf \"%.50s\" $labels.path }}`}} ({{`{{ $labels.status }}`}})"
+            description: "Application 5xx rate exceeds 5% of total traffic. Container ID: {{`{{ $labels.container_id }}`}} Request Path: {{`{{ $labels.path }}`}} Request Method: {{`{{ $labels.method }}`}} Status: {{`{{ $labels.status }}`}} Failure Ratio: {{`{{ printf \"%.2f\" $value }}`}}"
           labels:
             severity: critical
+        # Fires when a pod has been in Terminating state for >30 minutes — that
+        # is 60x the Kubernetes default terminationGracePeriodSeconds (30s), well
+        # past any legitimate graceful termination. max_over_time smooths across
+        # kube-state-metrics scrape gaps so the alert stays firing instead of
+        # flapping on each missed scrape.
         - alert: KubePodStuckTerminating
-          expr: >-
-            count(kube_pod_deletion_timestamp) by (namespace, pod) *
-            count(kube_pod_status_reason{reason="NodeLost"} == 0) by
-            (namespace, pod) > 0
-          for: 5m
+          expr: |
+            (time() - max_over_time(kube_pod_deletion_timestamp[20m])) > 1800
+            unless on (namespace, pod)
+            max_over_time(kube_pod_status_reason{reason="NodeLost"}[20m]) == 1
+          for: 15m
           labels:
-            severity: critical
+            severity: warning
           annotations:
             summary: Pod stuck in terminating state
-            description: "Pod {{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}} blocked in Terminating state."
+            description: "Pod {{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}} blocked in Terminating state for over 30 minutes."
 {{- end }}

--- a/charts/nudgebee-agent/templates/prometheus-alert-rule.yaml
+++ b/charts/nudgebee-agent/templates/prometheus-alert-rule.yaml
@@ -61,7 +61,7 @@ spec:
         - alert: ApplicationAPIFailures
           expr: |
             (
-              sum by (container_id, method, path, status) (rate(container_http_requests_total{status=~"5..", container_id!~"{{ $excludeApi }}"}[5m]))
+              sum by (container_id, method, path) (rate(container_http_requests_total{status=~"5..", container_id!~"{{ $excludeApi }}"}[5m]))
               / on (container_id) group_left ()
               sum by (container_id) (rate(container_http_requests_total{container_id!~"{{ $excludeApi }}"}[5m]))
             ) > 0.05
@@ -69,8 +69,8 @@ spec:
             sum by (container_id) (rate(container_http_requests_total{container_id!~"{{ $excludeApi }}"}[5m])) > 0.1
           for: 10m
           annotations:
-            summary: "High 5xx rate - {{`{{ $labels.method }}`}} {{`{{ printf \"%.50s\" $labels.path }}`}} ({{`{{ $labels.status }}`}})"
-            description: "Application 5xx rate exceeds 5% of total traffic. Container ID: {{`{{ $labels.container_id }}`}} Request Path: {{`{{ $labels.path }}`}} Request Method: {{`{{ $labels.method }}`}} Status: {{`{{ $labels.status }}`}} Failure Ratio: {{`{{ printf \"%.2f\" $value }}`}}"
+            summary: "High 5xx rate - {{`{{ $labels.method }}`}} {{`{{ printf \"%.50s\" $labels.path }}`}}"
+            description: "Aggregate 5xx rate across status codes exceeds 5% of total traffic. Container ID: {{`{{ $labels.container_id }}`}} Request Path: {{`{{ $labels.path }}`}} Request Method: {{`{{ $labels.method }}`}} 5xx Ratio: {{`{{ printf \"%.2f\" $value }}`}}"
           labels:
             severity: critical
         # Fires when a pod has been in Terminating state for >30 minutes — that

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -837,32 +837,64 @@ opentelemetry-collector:
       enabled: false
   config:
     processors:
-      probabilistic_sampler:
-        sampling_percentage: 10
+      # Drop early under memory pressure rather than OOM-killing the collector.
+      # Must be the first processor in every pipeline.
+      memory_limiter:
+        check_interval: 1s
+        limit_percentage: 80
+        spike_limit_percentage: 25
       filter/drop_namespaces:
         error_mode: ignore
         traces:
           span:
             - attributes["k8s.namespace.name"] == "kube-system"
+      # Drop probe / scrape / health-check traffic. Regex covers /health, /healthz,
+      # /livez, /readyz, /ping, /metrics, /status and namespaced variants like
+      # /api/health, /healthcheck, /health/liveness across all three OTel attribute
+      # name conventions (http.route, http.target, url.path).
       filter/drop_health_check:
         error_mode: ignore
         traces:
           span:
-            - attributes["http.route"] == "/health"
-            - attributes["http.route"] == "/healthz"
-            - attributes["http.route"] == "/live"
-            - attributes["http.route"] == "/ready"
-            - attributes["http.route"] == "/metrics"
-            - attributes["http.target"] == "/health"
-            - attributes["http.target"] == "/healthz"
-            - attributes["http.target"] == "/live"
-            - attributes["http.target"] == "/ready"
-            - attributes["http.target"] == "/metrics"
-            - attributes["url.path"] == "/health"
-            - attributes["url.path"] == "/healthz"
-            - attributes["url.path"] == "/live"
-            - attributes["url.path"] == "/ready"
-            - attributes["url.path"] == "/metrics"
+            - 'IsMatch(attributes["http.route"], "^/(healthz?|livez?|readyz?|ping|metrics|status)(/.*)?$")'
+            - 'IsMatch(attributes["http.target"], "^/(healthz?|livez?|readyz?|ping|metrics|status)(/.*)?$")'
+            - 'IsMatch(attributes["url.path"], "^/(healthz?|livez?|readyz?|ping|metrics|status)(/.*)?$")'
+      # Drop spans with malformed timestamps (zero, or end before start). These
+      # come from broken upstream instrumentation and waste storage.
+      filter/drop_invalid_timestamps:
+        error_mode: ignore
+        traces:
+          span:
+            - end_time_unix_nano == 0
+            - start_time_unix_nano == 0
+            - end_time_unix_nano < start_time_unix_nano
+      # Trace-level sampling. Unlike probabilistic head sampling, this preserves
+      # 100% of error and slow traces — exactly the ones an SRE wants to see —
+      # while keeping a 10% sample of healthy traffic for baseline visibility.
+      # Memory cost: roughly num_traces * average-trace-size bytes (~50-100MB
+      # at 50k traces buffered).
+      # NOTE: tail sampling requires all spans of a trace to land on the SAME
+      # collector instance. This default ships a single-replica deployment which
+      # is correct out of the box. Customers scaling to >1 replica must add a
+      # consistent-hash load balancer (otel `loadbalancing` exporter) in front,
+      # otherwise sampling decisions are made on partial traces.
+      tail_sampling:
+        decision_wait: 10s
+        num_traces: 50000
+        expected_new_traces_per_sec: 200
+        policies:
+          - name: errors
+            type: status_code
+            status_code:
+              status_codes: [ERROR]
+          - name: slow
+            type: latency
+            latency:
+              threshold_ms: 1000
+          - name: healthy-sample
+            type: probabilistic
+            probabilistic:
+              sampling_percentage: 10
       batch:
         timeout: 5s
         send_batch_size: 25000
@@ -884,16 +916,19 @@ opentelemetry-collector:
           max_elapsed_time: 300s
     service:
       pipelines:
+        # memory_limiter must be the first processor in every pipeline so it can
+        # back-pressure receivers under memory load before any expensive work
+        # (filters, sampling, batching) runs.
         traces:
-          processors: [filter/drop_namespaces, filter/drop_health_check, probabilistic_sampler, batch]
+          processors: [memory_limiter, filter/drop_namespaces, filter/drop_health_check, filter/drop_invalid_timestamps, tail_sampling, batch]
           exporters: [clickhouse]
           receivers: [otlp]
         logs:
-          processors: [batch]
+          processors: [memory_limiter, batch]
           exporters: [clickhouse]
           receivers: [otlp]
         metrics:
-          processors: [batch]
+          processors: [memory_limiter, batch]
           exporters: [clickhouse]
           receivers: [otlp]
 clickhouse:


### PR DESCRIPTION
## Summary

The chart's default monitoring config was producing high-volume, low-signal output across two paths:

- **Prometheus alert rules** were firing hundreds of times per day on benign behaviour (one error log, one 4xx response, any pod with a deletion timestamp).
- **OTel trace pipeline** was uniformly dropping 90% of every trace including errors and slow requests, while letting health-check noise leak through under exact-match filters.

This PR fixes both. They share a chart version bump because rolling them in one customer upgrade is operationally simpler than two back-to-back releases.

---

## Part 1 — Prometheus alert rule tuning

`charts/nudgebee-agent/templates/prometheus-alert-rule.yaml`

Validated against 24h of historical data on a dev cluster:

| Alert | OLD distinct firings | NEW | Reduction |
|---|---:|---:|---:|
| `HighErrorCriticalLogs` | 250 containers | 18 | **-93%** |
| `ApplicationAPIFailures` | 68 containers | 19 | **-72%** |
| `KubePodStuckTerminating` | 73 pods | 31 | **-58%** |
| `KubeHpaMaxedOut` | unchanged | — | — |

### Per-rule changes

**`HighErrorCriticalLogs`** — was `increase(err_logs)[5m] > 1`, fires on a single error log message. Now baseline-deviation: current 5m rate must exceed 3x the same metric `[1h] offset 1h`. The `offset 1h` keeps an ongoing spike from inflating the baseline (which would silence sustained incidents). Activity floor of 0.1 err/s and `baseline > 0` guard prevent ratio blowups on idle and cold-start containers. Exclusion regex extended to drop log-collection infrastructure (fluent-bit, fluentd, loki, opensearch, elasticsearch, logstash, datadog, newrelic, otel, promtail) — these emit steady error-level log volume from transport/ingest failures, not app signal. Severity demoted to `warning`: log-level alerting is structurally noisy.

**`ApplicationAPIFailures`** — was `increase(4xx|5xx)[5m] > 1`, fires on any single failure. Now ratio: `5xx rate / total rate > 5%` with activity floor `0.1 req/s`. 4xx removed entirely — those are client errors, not application failures. `for` raised to 10m to ride over slow rolling updates.

**`KubePodStuckTerminating`** — was `count(deletion_timestamp) * count(NodeLost==0) > 0`, fires for any deleting pod including normal graceful termination. Now age-based: `(time() - max_over_time(deletion_timestamp[20m])) > 1800` — 30 minutes, 60x the Kubernetes default `terminationGracePeriodSeconds`. `max_over_time(...[20m])` smooths kube-state-metrics scrape gaps so the alert stays firing rather than flapping (the main cause of the 537 state changes per 24h previously observed). Severity demoted to `warning`.

**`KubeHpaMaxedOut`** — unchanged.

No alertname renames — customer dashboards / runbooks / playbooks continue working.

---

## Part 2 — OTel trace sampling and pipeline robustness

`charts/nudgebee-agent/values.yaml`

### Replace `probabilistic_sampler` with `tail_sampling`

The previous head-sampling at 10% dropped 90% of every trace, including errors and slow requests. This is the headline fix.

```yaml
tail_sampling:
  decision_wait: 10s
  num_traces: 50000
  policies:
    - { name: errors, type: status_code, status_code: { status_codes: [ERROR] } }
    - { name: slow,   type: latency, latency: { threshold_ms: 1000 } }
    - { name: healthy-sample, type: probabilistic, probabilistic: { sampling_percentage: 10 } }
```

Result: 100% of error traces preserved, 100% of slow (>1s) traces preserved, 10% of healthy traces sampled for baseline.

**Cost:** ~50-100MB extra memory per collector replica from holding spans for the 10s decision window.
**Constraint:** all spans of a trace must land on the same collector instance. The chart ships a single-replica deployment so this is correct out-of-box; customers scaling to >1 replica must add a consistent-hash load balancer (otel `loadbalancing` exporter) in front, otherwise sampling decisions are made on partial traces. Documented inline in `values.yaml`.

### Add `memory_limiter` and put it in every pipeline

`memory_limiter` was not in the chart at all. Now defined and threaded into traces / logs / metrics pipelines as the first processor so it can back-pressure receivers under memory load instead of letting the collector OOM:

```yaml
memory_limiter:
  check_interval: 1s
  limit_percentage: 80
  spike_limit_percentage: 25
```

### Convert `filter/drop_health_check` to regex

Previous version had 15 exact-match equality checks across three attribute names — covered only `/health`, `/healthz`, `/live`, `/ready`, `/metrics`. Now three regex matches that also catch `/livez`, `/readyz`, `/ping`, `/status`, `/api/health`, `/healthcheck`, `/health/liveness`, etc.

### Add `filter/drop_invalid_timestamps`

Drops spans with zero or inverted timestamps from broken upstream instrumentation. Cheap; saves storage.

### Final trace pipeline

```
[memory_limiter, filter/drop_namespaces, filter/drop_health_check, filter/drop_invalid_timestamps, tail_sampling, batch]
```

Logs and metrics pipelines: `[memory_limiter, batch]`. Log filtering deferred — picking a default without customer log-volume data risks silently dropping data customers depend on. Customers can extend per-deployment.

---

## Validation

- [x] All three new PromQL expressions executed against the live VictoriaMetrics endpoint and produce the expected counts.
- [x] `helm template` renders the chart cleanly with `alertmanager.create_nb_default_rules=true`; output is valid YAML; all 4 alerts present.
- [x] `helm template` renders the otel ConfigMap cleanly; all 6 processors present, all 3 pipelines start with `memory_limiter`, traces pipeline has all 4 filter steps before `tail_sampling`.
- [x] Chart version bumped to `0.0.123` so `kubeconform` / chart-version CI passes.

## Notes

- No alertname or values key renames — customer references continue to work.
- Single chart bump (0.0.123) for both changes.
- Both changes ship together; rolling either back independently means picking up the other set of edits in this PR.