### PR TITLE
fix(otel): make filter/drop_health_check OTTL conditions parse

### DIFF
--- a/charts/nudgebee-agent/Chart.yaml
+++ b/charts/nudgebee-agent/Chart.yaml
@@ -6,8 +6,8 @@ icon: https://nudgebee-documents.s3.amazonaws.com/images/Nudgebee-logo.png
 # these are set to the right value by .github/workflows/release.yaml
 # we use 0.0.1 as a placeholder for the version` because Helm wont allow `0.0.0` and we want to be able to run
 # `helm install` on development checkouts without updating this file. the version doesn't matter in that case anyway
-version: 0.0.123
-appVersion: 0.0.123
+version: 0.0.124
+appVersion: 0.0.124
 dependencies:
 - name: opencost
   version: 2.0.1

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -641,7 +641,7 @@ runner:
   image:
     repository: registry.nudgebee.com/nudgebee-agent
     tag: |-
-      2026-03-27T12-08-19_a6f2ef26c0dfbca5d64d837c72f5f681f27650b8
+      2026-04-29T06-02-05_5678ecd5b0955fbf7cadf4306e17d056903a12dc
       2025-11-12T06-00-45_8ab57887ffd3ee0611c8b3e1a51413d1e0660445
   imagePullPolicy: IfNotPresent
   log_level: INFO
@@ -752,7 +752,7 @@ nodeAgent:
   image:
     repository: registry.nudgebee.com/nudgebee-node-agent
     pullPolicy: IfNotPresent
-    tag: 2026-04-09T04-23-32_8102b4ec69bb0ba14c1a0a5ebc36ced6bab2497e
+    tag: 2026-04-29T06-15-05_7fd20886980a75b7b9c8ca561621a19e1ff0976f
   resources:
     requests:
       cpu: "100m"

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -856,9 +856,9 @@ opentelemetry-collector:
         error_mode: ignore
         traces:
           span:
-            - 'IsMatch(attributes["http.route"], "^/(healthz?|livez?|readyz?|ping|metrics|status)(/.*)?$")'
-            - 'IsMatch(attributes["http.target"], "^/(healthz?|livez?|readyz?|ping|metrics|status)(/.*)?$")'
-            - 'IsMatch(attributes["url.path"], "^/(healthz?|livez?|readyz?|ping|metrics|status)(/.*)?$")'
+            - 'IsMatch(attributes["http.route"], "^/(healthz?|livez?|readyz?|ping|metrics|status)(/.*)?$") == true'
+            - 'IsMatch(attributes["http.target"], "^/(healthz?|livez?|readyz?|ping|metrics|status)(/.*)?$") == true'
+            - 'IsMatch(attributes["url.path"], "^/(healthz?|livez?|readyz?|ping|metrics|status)(/.*)?$") == true'
       # Drop spans with malformed timestamps (zero, or end before start). These
       # come from broken upstream instrumentation and waste storage.
       filter/drop_invalid_timestamps:


### PR DESCRIPTION
## Summary
- Bare `IsMatch()` calls introduced in chart 0.0.123 (PR #417) fail to parse with the otel-collector's OTTL grammar — the filterprocessor expects `<expr> <op> <value>` conditions, not bare boolean function calls. Result: collector pod crash-loops on upgrade.
- Appends `== true` to each `IsMatch()` condition in `filter/drop_health_check` to satisfy the parser. Behavior is unchanged from PR #417's intent.
- Bumps chart to `0.0.124`.

## Reproduction
Upgrading the rackspace cluster to chart 0.0.123 produced:

```
Error: invalid configuration: processors::filter/drop_health_check:
unable to parse OTTL statement:
1:105: unexpected token "<EOF>" (expected <opcomparison> Value)
```

The new pod entered `CrashLoopBackOff`. Old pod kept serving (rollout stuck), then we rolled back to 0.0.120.

## Test plan
- [ ] CI helm-template / kubeconform jobs pass
- [ ] After release, redeploy `nudgebee-agent` chart 0.0.124 to `prod-rackspace` and confirm `nudgebee-agent-opentelemetry-collector-*` pod reaches `1/1 Running`
- [ ] Verify health-check / metrics spans are still being dropped (count drops in clickhouse `otel_traces` for paths matching the regex)