### PR TITLE
chore(chart): remove grafanaRenderer sidecar and kubewatch sync config

### DIFF
--- a/charts/nudgebee-agent/templates/runner.yaml
+++ b/charts/nudgebee-agent/templates/runner.yaml
@@ -32,24 +32,6 @@ spec:
       {{- include "nudgebee.runner.imagePullSecrets" . | nindent 6 }}
       containers:
       {{- include "nudgebee.runner.container" . | nindent 6 }}
-      {{- if .Values.grafanaRenderer.enableContainer }}
-      - name: grafana-renderer
-        image: {{ .Values.grafanaRenderer.image }}
-        imagePullPolicy: {{ .Values.grafanaRenderer.imagePullPolicy }}
-        securityContext:
-          privileged: false
-        lifecycle:
-          preStop:
-            exec:
-              command: ["bash", "-c", "kill -SIGINT 1"]
-        resources:
-          requests:
-            cpu: {{ .Values.grafanaRenderer.resources.requests.cpu }}
-            memory: {{ if .Values.isSmallCluster }}"64Mi"{{ else }}{{ .Values.grafanaRenderer.resources.requests.memory | quote }}{{ end }}
-          limits:
-            memory: {{ if .Values.isSmallCluster }}"64Mi"{{ else if .Values.grafanaRenderer.resources.limits.memory }}{{ .Values.grafanaRenderer.resources.limits.memory | quote }}{{ else }}{{ .Values.grafanaRenderer.resources.requests.memory | quote }}{{ end }}
-            {{ if .Values.grafanaRenderer.resources.limits.cpu }}cpu: {{ .Values.grafanaRenderer.resources.limits.cpu | quote }}{{ end }}
-      {{- end }}
       {{- include "nudgebee.runner.volumes" . | nindent 6 }}
       {{- if .Values.runner.nodeSelector }}
       nodeSelector: {{ toYaml .Values.runner.nodeSelector | nindent 8 }}

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -56,7 +56,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-05-14T11-08-22_541a1e4b57da3b75426c25eff9d3034236e07b0a
+    tag: 2026-05-15T05-43-44_2f82bbd62b53f8445de9bb7007de5c2b4b296bd3
   imagePullPolicy: IfNotPresent
   resources:
     requests:

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -48,36 +48,6 @@ kubewatch:
       coreevent: false # added on kubewatch 2.5
       ingress: true # full support on kubewatch 2.4 (earlier versions have ingress bugs)
       rollout: true
-    sync:
-      # Enable/disable scheduled sync
-      enabled: true
-      # How often to run the sync
-      interval: "1h"
-      # Enable/disable payload compression for sync data
-      compression: true
-      # Number of resources to send in a single batch
-      batchSize: 1000
-      # Timeout in seconds for the sync request
-      timeoutSeconds: 180
-      # Configuration for workload snapshot
-      workloadSnapshot:
-        # Enable/disable workload snapshot as part of the sync
-        enabled: true
-        # Include nodes in the workload snapshot
-        includeNodes: true
-        # Include services in the workload snapshot
-        includeServices: true
-# parameters for the renderer service used in nudgebee runner to render grafana graphs
-grafanaRenderer:
-  enableContainer: false
-  image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/grafana-renderer:7
-  imagePullPolicy: IfNotPresent
-  resources:
-    requests:
-      cpu: 100m
-      memory: 512Mi
-    limits:
-      cpu: ~
 # parameters for the nudgebee runner service account
 runnerServiceAccount:
   # image pull secrets added to the runner service account. Any pod using the service account will get those


### PR DESCRIPTION
Follow-up to #422 — these two cleanups were prepared on the cutover branch but didn't land in the merge.

## What's removed

- **\`grafanaRenderer\` block** (values.yaml + runner.yaml sidecar): Robusta-era sidecar used to render Grafana graph snapshots for Findings. Go agent doesn't use it; default was \`enableContainer: false\` so it was already off for everyone.
- **\`kubewatch.config.sync\` block**: workload snapshot + scheduled sync knobs not consumed by the fork's current config schema.

Net: −48 lines, 2 files.

## Test plan

- [ ] \`helm template\` + kubeconform passes (validated locally; render-clean)