### PR TITLE
fix(chart): conditional MUTATE_ENABLED + rename /etc/robusta path

### DIFF
--- a/charts/nudgebee-agent/templates/_helpers.tpl
+++ b/charts/nudgebee-agent/templates/_helpers.tpl
@@ -87,10 +87,12 @@ Runner container template. Invoked with root context: include "nudgebee.runner.c
       value: {{ .Release.Namespace }}
     - name: SCANNER_SERVICE_ACCOUNT
       value: {{ include "nudgebee-agent.fullname" . }}-runner-service-account
+    {{- if .Values.rsa }}
     - name: MUTATE_ENABLED
       value: "true"
     - name: RSA_PRIVATE_KEY_PATH
-      value: /etc/robusta/auth/prv
+      value: /etc/nudgebee/auth/prv
+    {{- end }}
     {{- if or (index (default (dict) (index .Values "opentelemetry-collector")) "enabled") .Values.runner.clickhouse_enabled }}
     {{- $clickhouseSecret := .Values.runner.clickhouse_secret }}
     {{- if not $clickhouseSecret }}
@@ -129,7 +131,7 @@ Runner container template. Invoked with root context: include "nudgebee.runner.c
   {{- end }}
   volumeMounts:
     - name: auth-config-secret
-      mountPath: /etc/robusta/auth
+      mountPath: /etc/nudgebee/auth
     {{- with .Values.runner.extraVolumeMounts }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/nudgebee-agent/templates/openshift-scc-baseline.yaml
+++ b/charts/nudgebee-agent/templates/openshift-scc-baseline.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "nudgebee-agent.labels" . | nindent 4 }}
   annotations:
-    kubernetes.io/description: {{ include "nudgebee-agent.fullname" . }}-scc provides the features required to run robusta
+    kubernetes.io/description: {{ include "nudgebee-agent.fullname" . }}-scc provides the features required to run nudgebee-agent
 allowHostDirVolumePlugin: false
 allowHostIPC: false
 allowHostNetwork: false

--- a/charts/nudgebee-agent/templates/openshift-scc-privileged.yaml
+++ b/charts/nudgebee-agent/templates/openshift-scc-privileged.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "nudgebee-agent.labels" . | nindent 4 }}
   annotations:
-    kubernetes.io/description: {{ include "nudgebee-agent.fullname" . }}-scc provides the features required to run robusta enhanced debuggers for Java, Python, and node host capabilities
+    kubernetes.io/description: {{ include "nudgebee-agent.fullname" . }}-scc provides the features required to run nudgebee-agent debuggers and node host capabilities
 allowHostDirVolumePlugin: true
 allowHostIPC: false
 allowHostNetwork: false

--- a/charts/nudgebee-agent/templates/runner.yaml
+++ b/charts/nudgebee-agent/templates/runner.yaml
@@ -68,8 +68,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "nudgebee-agent.fullname" . }}-runner-service-monitor
   labels:
-    # this label is how the Prometheus installed with Robusta finds ServiceMonitors
-    # TODO: we probably need to add custom labels here for a Prometheus installed separately
+    # release label matches kube-prometheus-stack's default ServiceMonitor selector
     release: {{ .Release.Name }}
 spec:
   endpoints:

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -56,7 +56,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-05-15T05-43-44_2f82bbd62b53f8445de9bb7007de5c2b4b296bd3
+    tag: 2026-05-18T07-34-08_bb616ea340b11a941bac1ad2615df5b2f3284e65
   imagePullPolicy: IfNotPresent
   resources:
     requests:


### PR DESCRIPTION
Follow-up to #422.

## Problem

After the cutover to the Go nudgebee-agent, deploying the chart against a cluster without an RSA key configured (\`.Values.rsa: null\`, the default) caused the runner pod to crash on startup:

\`\`\`
load RSA private key: auth: read RSA key from /etc/robusta/auth/prv: open /etc/robusta/auth/prv: no such file or directory
\`\`\`

Root cause: the chart hardcoded \`MUTATE_ENABLED=true\` and \`RSA_PRIVATE_KEY_PATH=/etc/robusta/auth/prv\` in the runner container env. With no RSA key, the agent still tries to load it and fails fatally.

## Fix

- Wrap \`MUTATE_ENABLED\` and \`RSA_PRIVATE_KEY_PATH\` in \`{{- if .Values.rsa }}\`. When the customer provides an RSA key, mutations are enabled; otherwise the agent uses its safe-off default and mutations remain unreachable.
- Rename the mount path \`/etc/robusta/auth\` → \`/etc/nudgebee/auth\` (and matching \`RSA_PRIVATE_KEY_PATH\` value) — leftover Robusta-era naming.
- Drop "robusta" wording from the two OpenShift SCC descriptions and the runner ServiceMonitor selector comment.

## Validation

- helm render with \`rsa: null\` → no MUTATE_ENABLED, no RSA_PRIVATE_KEY_PATH (verified locally)
- helm render with \`rsa.prv\`/\`rsa.pub\` set → both env vars present, pointing at \`/etc/nudgebee/auth/prv\`
- Deployed to dev-gke from this branch — runner pod \`Running\`, dispatching actions (get_resource, logs_enricher, prometheus_queries_enricher, kubectl_command_executor) successfully.