### PR TITLE
chore(chart): drop redundant clickhouse volume-init initContainer

### DIFF
--- a/charts/nudgebee-agent/templates/forwarder.yaml
+++ b/charts/nudgebee-agent/templates/forwarder.yaml
@@ -32,7 +32,7 @@ spec:
       {{- end }}
       containers:
       - name: kubewatch
-        # this is a custom version of kubewatch built from https://github.com/aantn/kubewatch
+        # nudgebee fork of kubewatch — github.com/nudgebee/kubewatch
         image: {{ .Values.kubewatch.image.repository }}:{{ .Values.kubewatch.image.tag | default "latest" }}
         imagePullPolicy: {{ .Values.kubewatch.imagePullPolicy }}
         env:

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -282,30 +282,6 @@ clickhouse:
       memory: 2000Mi
     limits:
       memory: 2000Mi
-  initContainers:
-    - name: volume-init
-      image: registry.nudgebee.com/bitnami-os-shell:12-debian-12-r46
-      command:
-        - /bin/sh
-        - -ec
-        - |
-          mkdir -p /bitnami/clickhouse/data
-          chmod 700 /bitnami/clickhouse/data
-          chown 1001:1001 /bitnami/clickhouse
-          find /bitnami/clickhouse -mindepth 1 -maxdepth 1 -not -name ".snapshot" -not -name "lost+found" | \
-          xargs -r chown -R 1001:1001
-          echo "ClickHouse data directory initialized"
-      securityContext:
-        runAsUser: 0
-      volumeMounts:
-        - name: data
-          mountPath: /bitnami/clickhouse
-        - name: empty-dir
-          mountPath: /tmp
-          subPath: tmp-dir
-  extraVolumes:
-    - name: empty-dir
-      emptyDir: {}
   metrics:
     enabled: true
     serviceMonitor:


### PR DESCRIPTION
Recovers a commit that didn't make it into the final merge of #425.

The bitnami clickhouse pod already sets \`fsGroup: 1001\` in podSecurityContext. K8s applies fsGroup via the CSI driver before the main container starts, which chowns the mounted volume to GID 1001. The chart's \`volume-init\` initContainer (running \`registry.nudgebee.com/bitnami-os-shell\` as root) was doing the same chown manually — leftover defensive shim for storage backends that don't honor fsGroup.

Modern CSI drivers (GKE PD, EBS, Azure Disk, etc.) all honor fsGroup. Validated by deploying to dev-gke from a local chart with this fix applied — \`nudgebee-agent-clickhouse-shard0-0\` came up \`Running\` and \`Ready for connections\` without the init container.

Also drops the \`empty-dir\` extraVolume that existed solely to give the init container a /tmp scratch space — main container doesn't mount it.

Side benefit: removes one of the remaining \`registry.nudgebee.com/*\` image dependencies (\`bitnami-os-shell\`).

## Test plan

- [ ] helm template renders without volume-init / bitnami-os-shell refs
- [ ] Once merged + re-released as 0.1.0-rc-3, dev-gke deploys cleanly