### PR TITLE
docs(readme): add install snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,23 @@
 # NudgeBee Kubernetes agent
-Module to connect kubernetes to NudgeBee.
 
-## Getting started
-For more details please visit [here](https://app.nudgebee.com/help/docs/installation/agent/installation/)
+Helm chart for the NudgeBee Kubernetes agent — connects your cluster to the NudgeBee backend.
+
+## Install
+
+```bash
+helm repo add nudgebee-agent https://nudgebee.github.io/k8s-agent/
+helm repo update
+helm upgrade --install nudgebee-agent nudgebee-agent/nudgebee-agent \
+  --namespace nudgebee-agent --create-namespace \
+  --set runner.nudgebee.auth_secret_key="<your-auth-key>"
+```
+
+Or use `installation.sh` for an opinionated install with Prometheus auto-discovery:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/nudgebee/k8s-agent/main/installation.sh | bash -s -- -a "<your-auth-key>"
+```
+
+## Documentation
+
+See the [installation guide](https://app.nudgebee.com/help/docs/installation/agent/installation/) for full setup, configuration, and troubleshooting.


### PR DESCRIPTION
## Summary

Add a helm install command + reference to \`installation.sh\` so the README is useful standalone. Previously linked only to external docs.

## Notes

- Uses \`helm upgrade --install\` (idempotent — survives re-runs)
- Auth-key placeholder is quoted in both snippets so values with shell-special characters (\`&\`, \`;\`, etc.) work correctly

## Gemini review carry-overs

- ✅ \`helm install\` → \`helm upgrade --install\` (idempotent)
- ✅ Quoted \`<your-auth-key>\` placeholder in both snippets

## Rebase note

Original branch also re-pointed a broken CI badge (\`helm-test.yml\` → \`helm-dev-lint.yml\`), but main has since removed badges entirely. Respected that during rebase — install snippets are the only remaining change.