### PR TITLE
fix(chart): wire globalConfig.prometheus_url to PROMETHEUS_URL env

### DIFF
--- a/charts/nudgebee-agent/templates/runner.yaml
+++ b/charts/nudgebee-agent/templates/runner.yaml
@@ -90,6 +90,12 @@ type: Opaque
 stringData:
   NUDGEBEE_ENDPOINT: {{ .Values.runner.nudgebee.endpoint }}
   NUDGEBEE_AUTH_SECRET_KEY: {{ .Values.runner.nudgebee.auth_secret_key }}
+  {{- if .Values.globalConfig.prometheus_url }}
+  PROMETHEUS_URL: {{ .Values.globalConfig.prometheus_url | quote }}
+  {{- end }}
+  {{- if .Values.globalConfig.prometheus_headers }}
+  PROMETHEUS_HEADERS: {{ .Values.globalConfig.prometheus_headers | quote }}
+  {{- end }}
   {{- if .Values.runner.grafana.password }}
   GRAFANA_PASSWORD: {{ .Values.runner.grafana.password | quote }}
   {{- end }}

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -5,6 +5,11 @@ enablePrometheusStack: true
 automountServiceAccountToken: true
 globalConfig:
   custom_annotations: {}
+  # Prometheus URL the runner queries (e.g. "http://prometheus-server.prometheus.svc:80").
+  # Surfaces as PROMETHEUS_URL on the runner pod. Leave empty to let the agent auto-discover.
+  prometheus_url: ""
+  # Optional headers (comma-separated "Header: value" pairs). Surfaces as PROMETHEUS_HEADERS.
+  prometheus_headers: ""
 enableServiceMonitors: true
 # parameters for the nudgebee forwarder deployment
 kubewatch:

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -61,7 +61,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-05-18T07-34-08_bb616ea340b11a941bac1ad2615df5b2f3284e65
+    tag: 2026-05-18T18-17-59_787ea0cc865e96db72659ddc586058b8d737cded
   imagePullPolicy: IfNotPresent
   resources:
     requests:


### PR DESCRIPTION
The Go agent reads \`PROMETHEUS_URL\` from the environment ([pkg/config/config.go:127](https://github.com/nudgebee/nudgebee-agent/blob/main/pkg/config/config.go#L127)). The cutover removed the chart's \`globalConfig.prometheus_url\` plumbing — customers who set \`globalConfig.prometheus_url\` (\`installation.sh\` does it explicitly, dev-gke values does too) were having it silently dropped after upgrading to 0.1.x.

## Fix

- Restore \`globalConfig.prometheus_url\` + \`globalConfig.prometheus_headers\` as documented values keys.
- Surface them as \`PROMETHEUS_URL\` / \`PROMETHEUS_HEADERS\` in the runner-secret (envFrom picks them up onto the runner pod).
- Conditional render — keys only emit when set, so empty defaults don't pollute the Secret.

## Validation

\`\`\`
helm template t charts/nudgebee-agent --set globalConfig.prometheus_url=http://prom:9090
# → renders PROMETHEUS_URL: "http://prom:9090" in runner-secret

helm template t charts/nudgebee-agent
# → no PROMETHEUS_URL key emitted (default empty)
\`\`\`