### PR TITLE
fix(chart): default runner.es.url and runner.signoz.url to empty

### DIFF
--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -56,7 +56,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-05-18T07-34-08_bb616ea340b11a941bac1ad2615df5b2f3284e65
+    tag: 2026-05-18T18-17-59_787ea0cc865e96db72659ddc586058b8d737cded
   imagePullPolicy: IfNotPresent
   resources:
     requests:

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -83,10 +83,12 @@ runner:
     url: ""
     headers: ""
   es:
-    url: "https://elasticsearch-es-internal-http.monitoring.svc:9200"
+    # Set to enable Elasticsearch actions. Surfaces as ELASTICSEARCH_URL.
+    url: ""
     apiKey: ""
   signoz:
-    url: "https://signoz.signoz.svc:8080"
+    # Set to enable SigNoz actions. Surfaces as SIGNOZ_URL.
+    url: ""
     apiKey: ""
   grafana:
     url: ""


### PR DESCRIPTION
## Problem

Chart defaulted:
- `runner.es.url` → `https://elasticsearch-es-internal-http.monitoring.svc:9200`
- `runner.signoz.url` → `https://signoz.signoz.svc:8080`

The runner-secret template emits `ELASTICSEARCH_URL` / `SIGNOZ_URL` only when those values are non-empty. With a hardcoded default URL, **every install** ended up with both env vars set. The Go agent then enabled ES + SigNoz subsystems and tried to connect to non-existent services on most clusters.

## Fix

Default both to `""` so they're opt-in. Customers who actually have ES or SigNoz set the URL explicitly.

## Verification

```
helm template t charts/nudgebee-agent | grep -E 'ELASTICSEARCH_URL|SIGNOZ_URL'
# (no output — keys not emitted)

helm template t charts/nudgebee-agent \
  --set runner.es.url=http://es:9200 \
  --set runner.signoz.url=http://signoz:8080 \
  | grep -E 'ELASTICSEARCH_URL|SIGNOZ_URL'
# ELASTICSEARCH_URL: http://es:9200
# SIGNOZ_URL: http://signoz:8080
```