### PR TITLE
chore: prepare repo for open-source release

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Default reviewers for all changes in this repo.
+# Adjust the team handle below to match your GitHub org/team.
+
+*                               @nudgebee/maintainers
+
+# Chart-specific
+/charts/                        @nudgebee/maintainers
+/.github/workflows/             @nudgebee/maintainers
+/installation.sh                @nudgebee/maintainers

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,79 @@
+name: Bug report
+description: Report a problem with the nudgebee-agent Helm chart
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill in the details below so we can reproduce it.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe the bug clearly. Include error messages and unexpected behavior.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimum steps required to reproduce, including `helm install` command and any non-default values.
+      placeholder: |
+        1. helm install ...
+        2. kubectl get ...
+        3. ...
+    validations:
+      required: true
+
+  - type: input
+    id: chart-version
+    attributes:
+      label: Chart version
+      description: Output of `helm list -n <namespace>` or the version you installed.
+      placeholder: "e.g. 0.1.1"
+    validations:
+      required: true
+
+  - type: input
+    id: k8s-version
+    attributes:
+      label: Kubernetes version
+      description: Output of `kubectl version --short`.
+      placeholder: "e.g. v1.29.3"
+    validations:
+      required: true
+
+  - type: input
+    id: platform
+    attributes:
+      label: Cluster platform
+      description: EKS, GKE, AKS, kind, OpenShift, etc.
+    validations:
+      required: false
+
+  - type: textarea
+    id: values
+    attributes:
+      label: Relevant values.yaml overrides
+      description: Paste any non-default values you set (redact secrets and auth keys).
+      render: yaml
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Output from `kubectl logs` for the relevant pods. Redact sensitive data.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/nudgebee/k8s-agent/security/advisories/new
+    about: Report security issues privately. Do not open a public issue.
+  - name: NudgeBee documentation
+    url: https://app.nudgebee.com/help/docs/installation/agent/installation/
+    about: Installation, configuration, and troubleshooting guides.
+  - name: Community / questions
+    url: https://github.com/nudgebee/k8s-agent/discussions
+    about: Ask questions or discuss usage. Please search first.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,35 @@
+name: Feature request
+description: Suggest a new chart capability or configuration option
+labels: ["enhancement", "triage"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Describe the use case. What can't you do today with the chart?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How would you like the chart to support this? New values, new templates, behavior change?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you considered, including workarounds you're using today.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links, screenshots, related issues, etc.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+<!-- Thanks for opening a PR! Please fill in the sections below. -->
+
+## Summary
+
+<!-- What does this PR change and why? -->
+
+## Type of change
+
+- [ ] Bug fix (non-breaking)
+- [ ] New feature (non-breaking)
+- [ ] Breaking change (chart upgrade requires user action)
+- [ ] Documentation only
+- [ ] CI / tooling
+
+## Chart version
+
+- [ ] I bumped `version` in `charts/nudgebee-agent/Chart.yaml` (required for user-visible changes)
+- [ ] No version bump needed (docs/CI only)
+
+## Test plan
+
+<!-- How did you verify this works? -->
+
+- [ ] `helm lint charts/nudgebee-agent` passes
+- [ ] `ct lint --config .github/configs/ct.yaml` passes
+- [ ] `helm template` output reviewed
+- [ ] Installed on a real/kind cluster and verified the change
+
+## Related issues
+
+<!-- Closes #123, refs #456 -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - ci
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - docker

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,13 @@
+# Code of Conduct
+
+This project adopts the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) as its Code of Conduct.
+
+By participating in this project — opening issues, submitting pull requests, or interacting in discussions — you agree to abide by its terms.
+
+## Reporting
+
+Concerns about conduct in this community may be reported to `conduct@nudgebee.com`. All reports are reviewed and investigated promptly and fairly. Reporters' identities are kept confidential.
+
+## Enforcement
+
+Maintainers are responsible for clarifying and enforcing the standards in the Contributor Covenant, and may take any action they deem appropriate, up to and including removing contributions and banning contributors from the project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# Contributing to nudgebee-agent
+
+Thanks for your interest in contributing. This repo hosts the Helm chart for the NudgeBee Kubernetes agent.
+
+## Ways to contribute
+
+- Report bugs via [GitHub Issues](https://github.com/nudgebee/k8s-agent/issues).
+- Propose features or enhancements via a feature-request issue before opening a large PR.
+- Improve documentation (README, chart values, install script).
+- Submit chart fixes, additional configuration knobs, or new templates.
+
+For vulnerability reports, **do not open a public issue** — see [SECURITY.md](SECURITY.md).
+
+## Development setup
+
+Prerequisites:
+
+- [Helm](https://helm.sh/docs/intro/install/) 3.12+
+- [chart-testing](https://github.com/helm/chart-testing) (`ct`) for lint and install tests
+- [yamllint](https://github.com/adrienverge/yamllint)
+- A Kubernetes cluster for install tests ([kind](https://kind.sigs.k8s.io/) or [minikube](https://minikube.sigs.k8s.io/) works)
+
+Clone and update subchart dependencies:
+
+```bash
+git clone https://github.com/nudgebee/k8s-agent.git
+cd k8s-agent
+helm dependency update charts/nudgebee-agent
+```
+
+## Making changes
+
+1. Branch off `main`: `git checkout -b feat/short-description`.
+2. Edit chart templates / values / docs.
+3. Bump `version` in `charts/nudgebee-agent/Chart.yaml` if the change is user-visible.
+4. Run lint locally before pushing:
+
+   ```bash
+   helm lint charts/nudgebee-agent
+   ct lint --config .github/configs/ct.yaml
+   ```
+
+5. Render templates to sanity-check output:
+
+   ```bash
+   helm template test charts/nudgebee-agent --debug > /tmp/rendered.yaml
+   ```
+
+6. Commit using [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `fix(chart): ...`, `feat(chart): ...`, `docs: ...`).
+7. Open a PR against `main`. Fill out the PR template.
+
+## CI
+
+PRs run:
+
+- `helm-dev-lint.yml` — `helm lint` + `ct lint`
+- `helm-prod-test.yml` — install/uninstall test against an ephemeral cluster
+
+Both must pass before merge.
+
+## Releases
+
+Releases are cut from `main` by the maintainers using `release.yml` (publishes a packaged chart to the GitHub Pages Helm repo at `https://nudgebee.github.io/k8s-agent/`).
+
+## Code of Conduct
+
+By participating you agree to abide by the [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Support. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or support.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 NudgeBee, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,23 +1,114 @@
-# NudgeBee Kubernetes agent
+# NudgeBee Kubernetes Agent
 
-Helm chart for the NudgeBee Kubernetes agent — connects your cluster to the NudgeBee backend.
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![Helm Lint](https://github.com/nudgebee/k8s-agent/actions/workflows/helm-dev-lint.yml/badge.svg)](https://github.com/nudgebee/k8s-agent/actions/workflows/helm-dev-lint.yml)
+[![Helm Test](https://github.com/nudgebee/k8s-agent/actions/workflows/helm-prod-test.yml/badge.svg)](https://github.com/nudgebee/k8s-agent/actions/workflows/helm-prod-test.yml)
+[![Release](https://img.shields.io/github/v/release/nudgebee/k8s-agent)](https://github.com/nudgebee/k8s-agent/releases)
+
+Helm chart for the NudgeBee Kubernetes agent. The agent runs in your cluster, collects Kubernetes state, events, metrics, logs, and traces, and forwards them to the NudgeBee backend for observability, cost visibility, and incident automation.
+
+## What it deploys
+
+| Component | Purpose |
+| --- | --- |
+| `runner` | Connects to the NudgeBee backend over WebSocket; executes diagnostic and remediation actions in-cluster |
+| `kubewatch` (forwarder) | Streams Kubernetes resource changes and events to the runner |
+| `node-agent` (DaemonSet) | Per-node logs, profiles, and traces collector (eBPF-based) |
+| `opencost` (subchart) | Kubernetes cost allocation metrics |
+| `opentelemetry-collector` (subchart) | Receives OTLP signals from `node-agent` and exports to ClickHouse |
+| `clickhouse` (subchart) | Local store for traces / logs / metrics (7-day TTL by default) |
+| Prometheus rules / ServiceMonitors | Default alerting + scrape config for `kube-prometheus-stack` users |
+
+The runner connects out to `wss://relay.nudgebee.com/register` and `https://collector.nudgebee.com`. No inbound connectivity is required.
+
+## Prerequisites
+
+- Kubernetes 1.24+
+- Helm 3.12+
+- (Optional but recommended) [`kube-prometheus-stack`](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) — the chart ships `ServiceMonitor` and `PrometheusRule` resources by default
+- A NudgeBee account and auth key — sign up at <https://nudgebee.com>
 
 ## Install
 
 ```bash
 helm repo add nudgebee-agent https://nudgebee.github.io/k8s-agent/
 helm repo update
+
 helm upgrade --install nudgebee-agent nudgebee-agent/nudgebee-agent \
   --namespace nudgebee-agent --create-namespace \
   --set runner.nudgebee.auth_secret_key="<your-auth-key>"
 ```
 
-Or use `installation.sh` for an opinionated install with Prometheus auto-discovery:
+Or use the opinionated installer (auto-installs `kube-prometheus-stack` and wires up Prometheus discovery):
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/nudgebee/k8s-agent/main/installation.sh | bash -s -- -a "<your-auth-key>"
+curl -sSL https://raw.githubusercontent.com/nudgebee/k8s-agent/main/installation.sh \
+  | bash -s -- -a "<your-auth-key>"
 ```
 
-## Documentation
+## Configuration
 
-See the [installation guide](https://app.nudgebee.com/help/docs/installation/agent/installation/) for full setup, configuration, and troubleshooting.
+All configurable values live in [`charts/nudgebee-agent/values.yaml`](charts/nudgebee-agent/values.yaml). Common overrides:
+
+```yaml
+runner:
+  # Required
+  nudgebee:
+    auth_secret_key: "<your-auth-key>"
+
+  # Optional integrations — set the URL to enable
+  loki:
+    url: ""
+  es:
+    url: ""
+    apiKey: ""
+  signoz:
+    url: ""
+    apiKey: ""
+  grafana:
+    url: ""
+    username: ""
+    password: ""
+
+  # Grant write permissions (drain nodes, scale workloads, manage services etc.)
+  # Off by default — only enable if you want NudgeBee to perform remediations.
+  enableWritePermissions: false
+
+# Subcharts can be disabled if not needed
+opencost:
+  enabled: true
+opentelemetry-collector:
+  enabled: true
+clickhouse:
+  enabled: true
+```
+
+Full configuration reference: [installation guide](https://app.nudgebee.com/help/docs/installation/agent/installation/).
+
+## Uninstall
+
+```bash
+helm uninstall nudgebee-agent --namespace nudgebee-agent
+kubectl delete namespace nudgebee-agent
+```
+
+Note: ClickHouse PVCs are not deleted automatically — remove them manually if you no longer need the data.
+
+## Data sent to NudgeBee
+
+By default, the agent forwards:
+
+- Kubernetes object state (deployments, pods, services, etc.) and events
+- Cluster and node metrics (via Prometheus scrape)
+- OpenCost allocation data
+- Logs, traces, and profiles from `node-agent` (configurable; sensitive HTTP headers are redacted via the `SENSITIVE_HEADERS` env var)
+
+Secrets are explicitly **not** watched by the kubewatch forwarder (`kubewatch.config.resource.secret: false`).
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md). For security issues, see [SECURITY.md](SECURITY.md).
+
+## License
+
+[Apache License 2.0](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+# Security Policy
+
+## Supported versions
+
+We support the latest minor release of the `nudgebee-agent` Helm chart. Older releases receive fixes only at the maintainers' discretion.
+
+| Version | Supported |
+| ------- | --------- |
+| Latest `0.x` | Yes |
+| Older `0.x` | Best-effort |
+
+## Reporting a vulnerability
+
+Please **do not** open a public GitHub issue for security problems.
+
+Email `security@nudgebee.com` with:
+
+- A description of the issue and its impact.
+- Steps to reproduce (chart values, Kubernetes version, manifests if relevant).
+- Any known mitigations.
+
+You can also use [GitHub's private vulnerability reporting](https://github.com/nudgebee/k8s-agent/security/advisories/new) if you prefer.
+
+We aim to:
+
+- Acknowledge your report within 3 business days.
+- Provide an initial assessment within 7 business days.
+- Disclose and release a fix coordinated with the reporter.
+
+## Scope
+
+In scope:
+
+- The Helm chart in `charts/nudgebee-agent/` (templates, values, defaults).
+- The `installation.sh` bootstrap script.
+- Default RBAC and service-account configuration shipped by the chart.
+
+Out of scope (report upstream):
+
+- Vulnerabilities in third-party subcharts (`opencost`, `clickhouse`, `opentelemetry-collector`) — report to those projects.
+- Issues in the container images themselves (`nudgebee-agent`, `node-agent`, `kubewatch`) — these live in separate repos.

--- a/charts/nudgebee-agent/Chart.yaml
+++ b/charts/nudgebee-agent/Chart.yaml
@@ -1,8 +1,31 @@
 apiVersion: v2
 name: nudgebee-agent
-description: Nudgebee Helm chart for Kubernetes
+description: NudgeBee Kubernetes agent — connects your cluster to the NudgeBee backend for observability, cost, and incident automation.
 type: application
 icon: https://nudgebee-documents.s3.amazonaws.com/images/Nudgebee-logo.png
+home: https://github.com/nudgebee/k8s-agent
+sources:
+  - https://github.com/nudgebee/k8s-agent
+maintainers:
+  - name: NudgeBee
+    email: support@nudgebee.com
+    url: https://nudgebee.com
+keywords:
+  - kubernetes
+  - observability
+  - opentelemetry
+  - opencost
+  - monitoring
+  - clickhouse
+  - kubewatch
+  - sre
+annotations:
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/links: |
+    - name: Documentation
+      url: https://app.nudgebee.com/help/docs/installation/agent/installation/
+    - name: Source
+      url: https://github.com/nudgebee/k8s-agent
 # these are set to the right value by .github/workflows/release.yaml
 # we use 0.0.1 as a placeholder for the version` because Helm wont allow `0.0.0` and we want to be able to run
 # `helm install` on development checkouts without updating this file. the version doesn't matter in that case anyway

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -150,8 +150,8 @@ opencost:
   opencost:
     exporter:
       image:
-        registry: registry.nudgebee.com
-        repository: opencost
+        registry: ghcr.io
+        repository: nudgebee/opencost
         tag: 1.114.0
     prometheus:
       external:
@@ -181,7 +181,7 @@ openshift:
 opentelemetry-collector:
   enabled: true
   image:
-    repository: registry.nudgebee.com/opentelemetry-collector-contrib
+    repository: ghcr.io/nudgebee/opentelemetry-collector-contrib
     tag: 0.75.0
   # Inherit name overrides from parent chart
   nameOverride: ""
@@ -272,8 +272,8 @@ opentelemetry-collector:
 clickhouse:
   enabled: true
   image:
-    registry: registry.nudgebee.com
-    repository: clickhouse
+    registry: ghcr.io
+    repository: nudgebee/clickhouse
     tag: 24.12.4-debian-12-r0-nb-2
   nameOverride: ""
   fullnameOverride: ""
@@ -285,7 +285,11 @@ clickhouse:
     enabled: false
   auth:
     username: default
-    password: "Nudgebee@123"
+    # Leave empty to let the Bitnami subchart auto-generate a random password
+    # on first install (persisted in the `<release>-clickhouse` Secret under
+    # key `admin-password`). To pin a value, set it here or pass via
+    # `--set clickhouse.auth.password=...`.
+    password: ""
   extraOverrides: "<clickhouse>\n  <asynchronous_metric_log remove=\"1\"/>\n  <metric_log remove=\"1\"/>\n  <query_log remove=\"1\" />\n  <query_thread_log remove=\"1\" />  \n  <query_views_log remove=\"1\" />\n  <part_log remove=\"1\"/>\n  <text_log remove=\"1\" />\n  <trace_log remove=\"1\"/>\n  <opentelemetry_span_log remove=\"1\"/>\n</clickhouse>\n"
   resources:
     requests:

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -61,7 +61,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-05-18T18-17-59_787ea0cc865e96db72659ddc586058b8d737cded
+    tag: 2026-05-21T11-58-47_dea9a9abd8c9aa877c405ffa0e1c86e9d3983906
   imagePullPolicy: IfNotPresent
   resources:
     requests:


### PR DESCRIPTION
## Summary

Open-source readiness pass for `nudgebee/k8s-agent`. Adds standard OSS files, repoints private-registry images to public mirrors, and removes a hardcoded credential.

### New files
- `LICENSE` — Apache-2.0
- `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md` (adopts Contributor Covenant v2.1 by reference)
- `.github/CODEOWNERS`, `PULL_REQUEST_TEMPLATE.md`, `ISSUE_TEMPLATE/{bug,feature,config}`
- `.github/dependabot.yml` — weekly GitHub Actions + Docker updates

### Chart changes
- `Chart.yaml`: add `home`, `sources`, `maintainers`, `keywords`, Artifact Hub annotations (license + links)
- `values.yaml`: repoint `registry.nudgebee.com/{opencost,opentelemetry-collector-contrib,clickhouse}` → `ghcr.io/nudgebee/*` so external users can pull
- `values.yaml`: drop hardcoded ClickHouse password `Nudgebee@123` — Bitnami subchart now auto-generates a random password on first install (persisted in `<release>-clickhouse` Secret, key `admin-password`). Runner helper already reads from that secret.

### README
Expanded with badges, components table, prerequisites, data-sent-to-NudgeBee disclosure, uninstall, contributing/security links.

## Action items before merge

1. **Publish the mirror images** — chart now points at `ghcr.io/nudgebee/{opencost,opentelemetry-collector-contrib,clickhouse}`. These must exist and be **public** before this merges, otherwise installs break. Alternative: switch to upstream public images (`quay.io/opencost/opencost`, `otel/opentelemetry-collector-contrib`, `bitnami/clickhouse`).
2. **CODEOWNERS team handle** — currently `@nudgebee/maintainers` (placeholder). Replace with the real GitHub team.
3. **Enable repo features** — Discussions (referenced by issue template config), private vulnerability reporting (referenced by SECURITY.md).
4. Follow-up: `installation.sh` still hardcodes Grafana `admin/admin` — out of scope for this PR but worth a fix.

## Test plan

- [x] `helm lint charts/nudgebee-agent` passes
- [x] `helm template` renders cleanly with no `registry.nudgebee.com` refs and no hardcoded password
- [ ] CI (helm-dev-lint + helm-prod-test) green
- [ ] Manual install test on a kind cluster after mirror images are published