### PR TITLE
fix(runner): resolve pod owner up to controlling Deployment

### DIFF
--- a/runner/pkg/discovery/converters.go
+++ b/runner/pkg/discovery/converters.go
@@ -652,7 +652,7 @@ func ownerInfosWithRSLookup(owners []metav1.OwnerReference, namespace string, rs
 	for _, o := range owners {
 		if rsLookup != nil && o.Kind == "ReplicaSet" {
 			if rs := rsLookup(namespace, o.Name); rs != nil {
-				if ctrl := controllerOwner(rs.OwnerReferences); ctrl != nil {
+				if ctrl, ok := controllerOwner(rs.OwnerReferences); ok {
 					out = append(out, map[string]any{"kind": ctrl.Kind, "name": ctrl.Name})
 					continue
 				}
@@ -665,17 +665,17 @@ func ownerInfosWithRSLookup(owners []metav1.OwnerReference, namespace string, rs
 
 // controllerOwner returns the controller=true OwnerReference, or the
 // first ref when none is explicitly marked (pre-1.16 manifests / some
-// operators omit the field).
-func controllerOwner(refs []metav1.OwnerReference) *metav1.OwnerReference {
-	for i := range refs {
-		if refs[i].Controller != nil && *refs[i].Controller {
-			return &refs[i]
+// operators omit the field). The bool is false when refs is empty.
+func controllerOwner(refs []metav1.OwnerReference) (metav1.OwnerReference, bool) {
+	for _, ref := range refs {
+		if ref.Controller != nil && *ref.Controller {
+			return ref, true
 		}
 	}
 	if len(refs) > 0 {
-		return &refs[0]
+		return refs[0], true
 	}
-	return nil
+	return metav1.OwnerReference{}, false
 }
 
 // isHelmRelease checks the standard label/annotation conventions.

--- a/runner/pkg/discovery/converters.go
+++ b/runner/pkg/discovery/converters.go
@@ -19,6 +19,16 @@ import (
 // "absent" and emit null defaults.
 type podLookupFn func(namespace string, selector labels.Selector) *corev1.Pod
 
+// replicaSetLookupFn fetches a ReplicaSet by (namespace, name) out of the
+// shared informer cache. Used by the Pod converter to resolve a Pod's
+// immediate ReplicaSet owner up to its controlling Deployment by
+// reading the ReplicaSet's own ownerReferences — the authoritative
+// answer, vs. heuristically stripping a pod-template-hash suffix from
+// the RS name. Returns nil when the RS isn't (yet) in cache; callers
+// fall back to emitting the RS as-is and rely on the next status event
+// to self-heal once the cache syncs.
+type replicaSetLookupFn func(namespace, name string) *appsv1.ReplicaSet
+
 // Converters for each resource type. The collector reads keys like
 // `service_key`, `node_creation_time`, `workload_count` directly and
 // crashes with KeyError when they're missing — emit every documented
@@ -624,11 +634,48 @@ func containersFromTemplate(tpl corev1.PodTemplateSpec) []map[string]any {
 }
 
 func ownerInfos(owners []metav1.OwnerReference) []map[string]any {
+	return ownerInfosWithRSLookup(owners, "", nil)
+}
+
+// ownerInfosWithRSLookup is the Pod-path variant: when an owner ref is a
+// ReplicaSet and the RS is in the informer cache, the RS's own
+// controller ownerReference (typically a Deployment) is emitted
+// instead. This is the authoritative ReplicaSet→Deployment resolution
+// — no name-suffix heuristics. When rsLookup is nil or the RS isn't in
+// cache, falls back to passing the owner ref through unchanged; the
+// next pod-status event self-heals once the RS cache syncs.
+//
+// `namespace` is the namespace of the owned object (OwnerReference is
+// always same-namespace per K8s rules), used to scope the RS lookup.
+func ownerInfosWithRSLookup(owners []metav1.OwnerReference, namespace string, rsLookup replicaSetLookupFn) []map[string]any {
 	out := make([]map[string]any, 0, len(owners))
 	for _, o := range owners {
+		if rsLookup != nil && o.Kind == "ReplicaSet" {
+			if rs := rsLookup(namespace, o.Name); rs != nil {
+				if ctrl := controllerOwner(rs.OwnerReferences); ctrl != nil {
+					out = append(out, map[string]any{"kind": ctrl.Kind, "name": ctrl.Name})
+					continue
+				}
+			}
+		}
 		out = append(out, map[string]any{"kind": o.Kind, "name": o.Name})
 	}
 	return out
+}
+
+// controllerOwner returns the controller=true OwnerReference, or the
+// first ref when none is explicitly marked (pre-1.16 manifests / some
+// operators omit the field).
+func controllerOwner(refs []metav1.OwnerReference) *metav1.OwnerReference {
+	for i := range refs {
+		if refs[i].Controller != nil && *refs[i].Controller {
+			return &refs[i]
+		}
+	}
+	if len(refs) > 0 {
+		return &refs[0]
+	}
+	return nil
 }
 
 // isHelmRelease checks the standard label/annotation conventions.

--- a/runner/pkg/discovery/converters_test.go
+++ b/runner/pkg/discovery/converters_test.go
@@ -370,6 +370,119 @@ func TestConvertDeployment_EmitsAll11ConfigKeys(t *testing.T) {
 	}
 }
 
+// Regression: with the Go-agent cutover, Deployment-owned pods were
+// being emitted with owner=[{ReplicaSet, <hash-named-rs>}] because the
+// converter forwarded raw OwnerReferences. The collector keys
+// k8s_pods.workload_{type,name} off owner[0], so every UI/triage query
+// filtered by workload_type="Deployment" started returning empty. The
+// fix: when the immediate owner is a ReplicaSet, walk one hop via the
+// RS informer and emit the RS's controller (the Deployment) instead.
+//
+// This authoritative lookup avoids the legacy regex heuristic
+// (strip-pod-template-hash) used by trigger fingerprinting — works
+// correctly for RSes created outside the Deployment controller
+// (manual / operator-owned RSes whose names don't end in a hash) and
+// doesn't break if the controller's hash format ever changes.
+func TestPodConverter_ResolvesReplicaSetOwnerToDeployment(t *testing.T) {
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "checkout-7f9d8c5b6",
+			Namespace: "shop",
+			OwnerReferences: []metav1.OwnerReference{{
+				Kind:       "Deployment",
+				Name:       "checkout",
+				Controller: ptr.To(true),
+			}},
+		},
+		Spec: appsv1.ReplicaSetSpec{Replicas: ptr.To(int32(1))},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "checkout-7f9d8c5b6-w8pqw",
+			Namespace: "shop",
+			OwnerReferences: []metav1.OwnerReference{{
+				Kind:       "ReplicaSet",
+				Name:       "checkout-7f9d8c5b6",
+				Controller: ptr.To(true),
+			}},
+		},
+	}
+
+	lookup := func(ns, name string) *appsv1.ReplicaSet {
+		if ns == "shop" && name == "checkout-7f9d8c5b6" {
+			return rs
+		}
+		return nil
+	}
+
+	got, ok := newPodConverter(lookup)(pod)
+	if !ok {
+		t.Fatal("converter ok=false")
+	}
+	cfg := got.(map[string]any)["config"].(map[string]any)
+	owners := cfg["owner"].([]map[string]any)
+	if len(owners) != 1 {
+		t.Fatalf("owners = %v; want one resolved entry", owners)
+	}
+	if owners[0]["kind"] != "Deployment" || owners[0]["name"] != "checkout" {
+		t.Errorf("owners[0] = %v; want {kind: Deployment, name: checkout}", owners[0])
+	}
+}
+
+// When the RS isn't (yet) in cache, the converter must fall back to
+// emitting the immediate ReplicaSet owner unchanged. The next
+// pod-status event self-heals once WaitForCacheSync completes. Without
+// this fallback, a startup race could drop pods entirely.
+func TestPodConverter_FallsBackWhenReplicaSetMissing(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "p",
+			Namespace: "shop",
+			OwnerReferences: []metav1.OwnerReference{{
+				Kind: "ReplicaSet", Name: "missing-rs",
+			}},
+		},
+	}
+	got, ok := newPodConverter(func(string, string) *appsv1.ReplicaSet { return nil })(pod)
+	if !ok {
+		t.Fatal("converter ok=false")
+	}
+	cfg := got.(map[string]any)["config"].(map[string]any)
+	owners := cfg["owner"].([]map[string]any)
+	if len(owners) != 1 || owners[0]["kind"] != "ReplicaSet" || owners[0]["name"] != "missing-rs" {
+		t.Errorf("fallback owners = %v; want immediate RS unchanged", owners)
+	}
+}
+
+// Non-Deployment workloads (DaemonSet, StatefulSet, Job, operator CRs)
+// own pods directly. The converter must NOT touch those owner refs.
+func TestPodConverter_PassesThroughNonReplicaSetOwners(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "node-exporter-abc",
+			Namespace: "kube-system",
+			OwnerReferences: []metav1.OwnerReference{{
+				Kind: "DaemonSet", Name: "node-exporter",
+			}},
+		},
+	}
+	// Provide a lookup that would panic if invoked — proves the
+	// converter short-circuits on non-RS kinds.
+	lookup := func(string, string) *appsv1.ReplicaSet {
+		t.Fatal("rsLookup should not be called for non-ReplicaSet owners")
+		return nil
+	}
+	got, ok := newPodConverter(lookup)(pod)
+	if !ok {
+		t.Fatal("converter ok=false")
+	}
+	cfg := got.(map[string]any)["config"].(map[string]any)
+	owners := cfg["owner"].([]map[string]any)
+	if len(owners) != 1 || owners[0]["kind"] != "DaemonSet" || owners[0]["name"] != "node-exporter" {
+		t.Errorf("daemonset passthrough owners = %v", owners)
+	}
+}
+
 // When a Pod owned by the workload has reported status, qos_class / ip
 // / conditions come from that Pod.
 func TestServiceDict_PodLookupFillsRuntimeFields(t *testing.T) {

--- a/runner/pkg/discovery/service.go
+++ b/runner/pkg/discovery/service.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -70,8 +71,16 @@ func NewService(cs kubernetes.Interface, sink *Sink, resync time.Duration, logge
 }
 
 // RegisterPods wires the Pod informer + workqueue + converter. Call before Run().
+//
+// The converter is bound to the ReplicaSet informer's indexer so each
+// Pod's `owner` field is resolved up to the controlling Deployment
+// (RS.OwnerReferences) instead of being emitted as the immediate
+// ReplicaSet. This is what keeps `k8s_pods.workload_type =
+// "Deployment"` at the backend; without it every Deployment-owned pod
+// gets recorded as workload_type="ReplicaSet" and the UI workload
+// queries return empty.
 func (s *Service) RegisterPods() {
-	s.register(s.factory.Core().V1().Pods().Informer(), TypeService, convertPod)
+	s.register(s.factory.Core().V1().Pods().Informer(), TypeService, newPodConverter(s.replicaSetLookup()))
 }
 
 // RegisterDeployments wires the Deployment informer. The converter is
@@ -147,6 +156,33 @@ func (s *Service) podLookup() podLookupFn {
 			}
 		}
 		return nil
+	}
+}
+
+// replicaSetLookup returns a `(namespace, name) -> *ReplicaSet` closure
+// backed by the ReplicaSet informer's indexer. Used by the Pod
+// converter to walk the Pod → ReplicaSet → Deployment owner chain at
+// emit time. Returns nil when the RS isn't (yet) in cache — caller
+// falls back to emitting the ReplicaSet ref unchanged, and the next
+// pod-status event re-emits with the correct owner once
+// WaitForCacheSync completes.
+//
+// As with podLookup, GetIndexer() is taken eagerly here:
+// SharedInformerFactory.ReplicaSets().Informer() is idempotent, so the
+// indexer is the same shared instance RegisterReplicaSets wires up
+// regardless of registration order.
+func (s *Service) replicaSetLookup() replicaSetLookupFn {
+	indexer := s.factory.Apps().V1().ReplicaSets().Informer().GetIndexer()
+	return func(namespace, name string) *appsv1.ReplicaSet {
+		if indexer == nil {
+			return nil
+		}
+		obj, ok, err := indexer.GetByKey(namespace + "/" + name)
+		if err != nil || !ok {
+			return nil
+		}
+		rs, _ := obj.(*appsv1.ReplicaSet)
+		return rs
 	}
 }
 
@@ -358,56 +394,70 @@ func enqueue(q workqueue.TypedRateLimitingInterface[string], obj any) {
 // convertPod produces the service-of-type-Pod dict. Same wire shape as
 // Deployment/StatefulSet/etc. — the collector reads pods through the
 // same `_process_discovery` path, keying off `service_key`
-// and `type=="Pod"` for the terminal-state
-// branch.
+// and `type=="Pod"` for the terminal-state branch.
+//
+// This is the no-lookup variant kept for backward-compat / tests; the
+// production `RegisterPods` path wires `newPodConverter(rsLookup)` so
+// the owner field is resolved up to the controlling Deployment via the
+// ReplicaSet informer. Without the lookup, a Pod owned by a ReplicaSet
+// is emitted with `owner = [{kind: "ReplicaSet", ...}]` — the backend
+// then keys its workload tables to the RS rather than the Deployment.
 func convertPod(obj any) (any, bool) {
-	p, ok := obj.(*corev1.Pod)
-	if !ok {
-		return nil, false
-	}
-	containers := make([]map[string]any, 0, len(p.Spec.Containers))
-	for _, c := range p.Spec.Containers {
-		containers = append(containers, map[string]any{
-			"name":  c.Name,
-			"image": c.Image,
-		})
-	}
-	owners := make([]map[string]any, 0, len(p.OwnerReferences))
-	for _, o := range p.OwnerReferences {
-		owners = append(owners, map[string]any{"kind": o.Kind, "name": o.Name})
-	}
-	// Pods don't have a "ready replica" semantic — use ready-container count
-	// for ready_pods and 1 for total_pods (it's a single pod). The UI uses
-	// these for service-detail rollups.
-	readyContainers := int32(0)
-	for _, cs := range p.Status.ContainerStatuses {
-		if cs.Ready {
-			readyContainers++
+	return newPodConverter(nil)(obj)
+}
+
+// newPodConverter binds a ReplicaSet lookup so the Pod's `owner` field
+// can be resolved up one hop to the controlling Deployment. See
+// ownerInfosWithRSLookup for the resolution rule; without rsLookup the
+// emitted owner remains the immediate ReplicaSet, which breaks all
+// downstream workload-keyed views (k8s_pods.workload_type stays
+// "ReplicaSet" forever).
+func newPodConverter(rsLookup replicaSetLookupFn) func(any) (any, bool) {
+	return func(obj any) (any, bool) {
+		p, ok := obj.(*corev1.Pod)
+		if !ok {
+			return nil, false
 		}
+		containers := make([]map[string]any, 0, len(p.Spec.Containers))
+		for _, c := range p.Spec.Containers {
+			containers = append(containers, map[string]any{
+				"name":  c.Name,
+				"image": c.Image,
+			})
+		}
+		// Pods don't have a "ready replica" semantic — use ready-container count
+		// for ready_pods and 1 for total_pods (it's a single pod). The UI uses
+		// these for service-detail rollups.
+		readyContainers := int32(0)
+		for _, cs := range p.Status.ContainerStatuses {
+			if cs.Ready {
+				readyContainers++
+			}
+		}
+		return map[string]any{
+			"name":             p.Name,
+			"namespace":        p.Namespace,
+			"type":             "Pod",
+			"service_key":      p.Namespace + "/Pod/" + p.Name,
+			"resource_version": parseResourceVersion(p.ObjectMeta),
+			"creation_time":    p.CreationTimestamp.UTC().Format(time.RFC3339),
+			"update_time":      time.Now().UTC().UnixMilli(),
+			"deleted":          false,
+			"classification":   "None",
+			"total_pods":       1,
+			"ready_pods":       readyContainers,
+			"is_helm_release":  isHelmRelease(p.Labels, p.Annotations),
+			"node_name":        p.Spec.NodeName,
+			"status":           string(p.Status.Phase),
+			"restart_count":    podRestartCounts(p),
+			"status_dict":      nil,
+			"config": map[string]any{
+				"labels":     nonNilLabels(p.Labels),
+				"containers": containers,
+				"owner":      ownerInfosWithRSLookup(p.OwnerReferences, p.Namespace, rsLookup),
+			},
+		}, true
 	}
-	return map[string]any{
-		"name":             p.Name,
-		"namespace":        p.Namespace,
-		"type":             "Pod",
-		"service_key":      p.Namespace + "/Pod/" + p.Name,
-		"resource_version": parseResourceVersion(p.ObjectMeta),
-		"creation_time":    p.CreationTimestamp.UTC().Format(time.RFC3339),
-		"update_time":      time.Now().UTC().UnixMilli(),
-		"deleted":          false,
-		"classification":   "None",
-		"total_pods":       1,
-		"ready_pods":       readyContainers,
-		"is_helm_release":  isHelmRelease(p.Labels, p.Annotations),
-		"node_name":        p.Spec.NodeName,
-		"status":           string(p.Status.Phase),
-		"restart_count":    podRestartCounts(p),
-		"status_dict":      nil,
-		"config": map[string]any{
-			"labels":     nonNilLabels(p.Labels),
-			"containers": containers,
-			"owner":      owners,
-		},
-	}, true
 }
 
 // podRestartCounts produces the per-container restart_count map.

--- a/runner/pkg/discovery/service.go
+++ b/runner/pkg/discovery/service.go
@@ -247,9 +247,17 @@ func (s *Service) Run(ctx context.Context) error {
 
 	s.factory.Start(stopCh)
 
-	// Wait for all caches to sync before emitting the first full snapshot.
-	if !cache.WaitForCacheSync(stopCh, s.cacheSyncFuncs()...) {
-		return errors.New("discovery: cache sync timed out")
+	// Wait at the factory level (not just on handler-bound informers) so
+	// auxiliary informers instantiated via lookup closures — replicaSetLookup,
+	// podLookup — are synced before the initial snapshot. Otherwise, a caller
+	// that wires RegisterPods without RegisterReplicaSets would race: the RS
+	// informer would still be started (factory tracks any informer ever
+	// requested), but a handler-only sync wait wouldn't include it, and the
+	// first pod snapshot could fire with unresolved ReplicaSet owners.
+	for typ, ok := range s.factory.WaitForCacheSync(stopCh) {
+		if !ok {
+			return fmt.Errorf("discovery: cache sync timed out for %v", typ)
+		}
 	}
 	s.logger.Info("discovery caches synced", "handlers", len(s.handlers))
 
@@ -292,14 +300,6 @@ func (s *Service) Run(ctx context.Context) error {
 	}
 	wg.Wait()
 	return nil
-}
-
-func (s *Service) cacheSyncFuncs() []cache.InformerSynced {
-	out := make([]cache.InformerSynced, 0, len(s.handlers))
-	for _, h := range s.handlers {
-		out = append(out, h.informer.HasSynced)
-	}
-	return out
 }
 
 // emitAllSnapshots posts one full-load envelope per resource type by walking


### PR DESCRIPTION
## Summary

The Pod converter forwarded raw `pod.OwnerReferences` as-is, so any Deployment-owned pod was emitted with `owner = [{kind: "ReplicaSet", name: "<deploy>-<hash>"}]`. The backend collector keys its `k8s_pods.workload_{type,name}` columns off `owner[0]`, so since this agent rolled out, no rows with `workload_type = "Deployment"` have been written for affected accounts — every UI/triage query that filters by Deployment returns empty.

This PR resolves the owner at emit time using the ReplicaSet informer (already registered in `RegisterAll`). When a Pod's immediate owner is a ReplicaSet, the converter reads the RS from cache and emits the RS's own controller `ownerReference` (typically the Deployment) instead.

### Why not the regex heuristic
`pkg/triggers/owner.go` strips a pod-template-hash suffix from the RS name as a heuristic. That works for Deployment-controller-managed RSes but breaks for operator-owned or manually-created ReplicaSets whose names don't end in the hash pattern, and depends on the controller's hash format staying stable. Walking the RS's own `ownerReferences` via the informer is authoritative and costs an in-process indexer hit.

### Changes
- **`runner/pkg/discovery/converters.go`** — add `replicaSetLookupFn` type, `controllerOwner` helper (handles `controller=true` ref + pre-1.16 fallback), and `ownerInfosWithRSLookup(owners, namespace, rsLookup)` variant.
- **`runner/pkg/discovery/service.go`** — split `convertPod` into `newPodConverter(rsLookup)` factory (matching the existing `newDeploymentConverter` pattern); add `replicaSetLookup()` closure backed by the RS informer indexer; wire `RegisterPods` to use the factory.

## Type of change

- [x] Bug fix (non-breaking)

## Chart version

- [x] No version bump needed (docs/CI only)

(Runner Go code only — chart unchanged.)

## Test plan

- [x] `go test ./pkg/discovery/...` — all pass, including three new cases:
  - `TestPodConverter_ResolvesReplicaSetOwnerToDeployment` — Pod → RS → Deployment lookup hits cache, emits the Deployment as `owner[0]`.
  - `TestPodConverter_FallsBackWhenReplicaSetMissing` — startup-race safety; when the RS isn't in the informer cache yet, the immediate RS ref is emitted unchanged and the next status event self-heals.
  - `TestPodConverter_PassesThroughNonReplicaSetOwners` — DaemonSet / StatefulSet / Job owners untouched (lookup fn fatals if invoked).
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./pkg/discovery/...` clean.

## Related issues

Backend impact: backend `k8s_pods` rows for affected accounts have had `workload_type = "ReplicaSet"` instead of `"Deployment"` since this agent rolled out. A separate backfill on the collector side will rewrite those rows; this PR fixes the source.