### PR TITLE
test(config): add Fuzz targets for ParseHeaders and ParseTargets

### DIFF
--- a/runner/pkg/config/config_fuzz_test.go
+++ b/runner/pkg/config/config_fuzz_test.go
@@ -1,0 +1,80 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// FuzzParseHeaders asserts ParseHeaders never panics and produces a
+// well-formed header map for any input.
+func FuzzParseHeaders(f *testing.F) {
+	for _, seed := range []string{
+		"",
+		"X-Scope-OrgID: tenant-a",
+		"X-Scope-OrgID: tenant-a, X-Auth: secret",
+		"   X-Foo  :   bar   ",
+		":no-key",
+		"no-colon",
+		"k:",
+		",,,",
+		"k:v,",
+		"k1:v1,,k2:v2",
+		"k:multi:colons:here",
+		"\x00:\x00",
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, s string) {
+		h := ParseHeaders(s)
+		for k, vs := range h {
+			if k == "" {
+				t.Fatalf("empty key in result: %q", s)
+			}
+			if k != strings.TrimSpace(k) {
+				t.Fatalf("untrimmed key %q from %q", k, s)
+			}
+			for _, v := range vs {
+				if v != strings.TrimSpace(v) {
+					t.Fatalf("untrimmed value %q for key %q from %q", v, k, s)
+				}
+			}
+		}
+	})
+}
+
+// FuzzParseTargets asserts ParseTargets never panics and produces a
+// well-formed target map for any input.
+func FuzzParseTargets(f *testing.F) {
+	for _, seed := range []string{
+		"",
+		"foo=http://foo",
+		"foo=http://foo;bar=http://bar",
+		"  foo  =  http://foo  ",
+		"=no-key",
+		"no-equals",
+		"foo=",
+		";;;",
+		"foo=bar;",
+		"foo=a=b=c",
+		"k1=v1;;k2=v2",
+		"\x00=\x00",
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, s string) {
+		m := ParseTargets(s)
+		for k, v := range m {
+			if k == "" {
+				t.Fatalf("empty key in result: %q", s)
+			}
+			if k != strings.TrimSpace(k) {
+				t.Fatalf("untrimmed key %q from %q", k, s)
+			}
+			if v != strings.TrimSpace(v) {
+				t.Fatalf("untrimmed value %q for key %q from %q", v, k, s)
+			}
+		}
+	})
+}


### PR DESCRIPTION
Clears OpenSSF Scorecard's `Fuzzing` check (alert #41) — Scorecard looks for `FuzzXxx(f *testing.F)` functions; none existed in the runner before this.

## Targets

Two parsers that handle env-var input — both are entry points for untrusted-ish config strings (`PROMETHEUS_HEADERS`, `HTTP_PROXY_TARGETS`, etc.) and use manual `IndexByte` + slice arithmetic, which is exactly the kind of code worth random-input testing.

- `FuzzParseHeaders` — `pkg/config.ParseHeaders(string) http.Header`
- `FuzzParseTargets` — `pkg/config.ParseTargets(string) map[string]string`

Invariants asserted: no panics, keys are non-empty and trimmed, values are trimmed.

## Verification
Locally with `go test -fuzz`: ~2.2M execs over 10s per target, **no crashes**, coverage corpus grew (119 / 105 interesting inputs respectively). Seed corpus covers empty input, multiple delimiters, colon-in-value, empty key/value, null bytes.