### PR TITLE
fix(runner): handle legacy create_or_replace_alert_rule payload shape

### DIFF
--- a/.github/workflows/update-image-tags.yml
+++ b/.github/workflows/update-image-tags.yml
@@ -53,6 +53,15 @@ jobs:
           echo "nudgebee_kubewatch_image: $nudgebee_kubewatch_image"
           yq -i ".kubewatch.image.tag=\"$nudgebee_kubewatch_image\"" values.yaml
 
+          # application-profiler: newest short-SHA tag from GHCR (bpf is canonical;
+          # all variants share the same SHA since release.yml builds them together).
+          # The `{}` placeholder is preserved — the agent substitutes it per variant at runtime.
+          nudgebee_profiler_sha=$(gh api -H "Accept: application/vnd.github+json" \
+            "/orgs/nudgebee/packages/container/application-profiler-bpf/versions?per_page=20" \
+            --jq '[.[].metadata.container.tags[]] | map(select(test("^[0-9a-f]{7}$"))) | .[0]')
+          echo "nudgebee_profiler_sha: $nudgebee_profiler_sha"
+          yq -i ".runner.profilerImage=\"ghcr.io/nudgebee/application-profiler-{}:$nudgebee_profiler_sha\"" values.yaml
+
       - name: Commit updated image tags
         env:
           BASE_REF: ${{ github.base_ref }}

--- a/charts/nudgebee-agent/templates/_helpers.tpl
+++ b/charts/nudgebee-agent/templates/_helpers.tpl
@@ -87,6 +87,10 @@ Runner container template. Invoked with root context: include "nudgebee.runner.c
       value: {{ .Release.Namespace }}
     - name: SCANNER_SERVICE_ACCOUNT
       value: {{ include "nudgebee-agent.fullname" . }}-runner-service-account
+    {{- if .Values.runner.profilerImage }}
+    - name: PROFILER_IMAGE
+      value: {{ .Values.runner.profilerImage | quote }}
+    {{- end }}
     {{- if .Values.rsa }}
     - name: MUTATE_ENABLED
       value: "true"

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -61,7 +61,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-06-01T08-54-45_88fc8f3fb4e0e7f2c88adb111432362e3c697242
+    tag: 2026-06-01T11-35-01_9cc96cf11ee44201e633cf7e53a9b5e15f3d40c8
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -62,6 +62,10 @@ runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
     tag: 2026-06-01T08-54-45_88fc8f3fb4e0e7f2c88adb111432362e3c697242
+  # Image template the pod_profiler action launches debugger pods from.
+  # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
+  # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.
+  profilerImage: "ghcr.io/nudgebee/application-profiler-{}:dc5fd6d"
   imagePullPolicy: IfNotPresent
   resources:
     requests:

--- a/runner/cmd/agent/main.go
+++ b/runner/cmd/agent/main.go
@@ -486,6 +486,9 @@ func run(ctx context.Context, logger *slog.Logger, cfg *config.Config) error {
 		if installNs == "" {
 			installNs = cfg.ScannerNamespace
 		}
+		if installNs == "" {
+			logger.Warn("install namespace is empty (neither INSTALLATION_NAMESPACE nor SCANNER_NAMESPACE set) — legacy alert-rule actions will error at request time")
+		}
 		mut.SetNamespace(installNs)
 		if cfg.LokiRulesURL != "" {
 			lokiRulesHeaders := map[string]string{}

--- a/runner/cmd/agent/main.go
+++ b/runner/cmd/agent/main.go
@@ -478,6 +478,15 @@ func run(ctx context.Context, logger *slog.Logger, cfg *config.Config) error {
 		}
 		mut := mutate.New(typedKube, cfg.AlertManagerURL, amHeaders)
 		mut.SetDynamic(dynamicKube) // unlocks PrometheusRule CRUD actions
+		// INSTALLATION_NAMESPACE is set by the chart via the downward API.
+		// Required by the legacy alert-rule path; falls back to the scanner
+		// namespace (also chart-set) so a hand-rolled deployment without
+		// INSTALLATION_NAMESPACE still resolves to the right namespace.
+		installNs := os.Getenv("INSTALLATION_NAMESPACE")
+		if installNs == "" {
+			installNs = cfg.ScannerNamespace
+		}
+		mut.SetNamespace(installNs)
 		if cfg.LokiRulesURL != "" {
 			lokiRulesHeaders := map[string]string{}
 			for k, v := range config.ParseHeaders(os.Getenv("LOKI_RULES_HEADERS")) {
@@ -489,10 +498,18 @@ func run(ctx context.Context, logger *slog.Logger, cfg *config.Config) error {
 		}
 		mh := mutate.Handlers(mut)
 		maps.Copy(handlers, mh)
-		// Mutations REQUIRE RSA partial-keys in production. NOT light-action.
+		// Most Group-D mutations REQUIRE RSA partial-keys in production and
+		// stay out of lightActions. The two PrometheusRule legacy actions are
+		// the exception: api-server → relay → agent today sends them unsigned
+		// behind the relay's shared-secret gate, same posture as the read
+		// primitives. Carving them in here closes the gap without forcing
+		// signing into api-server's relay client.
+		lightActions["create_or_replace_alert_rule"] = struct{}{}
+		lightActions["delete_alert_rule"] = struct{}{}
 		logger.Info("mutate enabled",
 			"alertmanager_url", cfg.AlertManagerURL,
 			"loki_rules_url", cfg.LokiRulesURL,
+			"install_namespace", installNs,
 			"actions", len(mh))
 	}
 

--- a/runner/pkg/mutate/alertrules.go
+++ b/runner/pkg/mutate/alertrules.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/util/retry"
 )
 
 // PrometheusRule CRD GVR. Standard prometheus-operator group.
@@ -146,43 +147,62 @@ func (m *Mutator) CreateOrReplaceAlertRule(ctx context.Context, p LegacyAlertRul
 	}
 
 	ri := m.dynamic.Resource(prometheusRuleGVR).Namespace(m.Namespace)
-	existing, err := ri.Get(ctx, LegacyAlertRuleCRDName, metav1.GetOptions{})
-	if apierrors.IsNotFound(err) {
-		u := newLegacyAlertRuleCR(m.Namespace, []any{rule})
-		created, cerr := ri.Create(ctx, u, metav1.CreateOptions{})
-		if cerr != nil {
-			return nil, cerr
+	// Shared CR + concurrent UI sessions → 409 Conflict whenever two callers
+	// land between Get and Update. RetryOnConflict re-reads + re-applies the
+	// patch on each conflict; the AlreadyExists branch covers the rare case
+	// where two callers race to create the CR at once (we surface that as a
+	// Conflict so the retry loop handles it the same way).
+	var result *unstructured.Unstructured
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		existing, gerr := ri.Get(ctx, LegacyAlertRuleCRDName, metav1.GetOptions{})
+		if apierrors.IsNotFound(gerr) {
+			u := newLegacyAlertRuleCR(m.Namespace, []any{rule})
+			created, cerr := ri.Create(ctx, u, metav1.CreateOptions{})
+			if cerr != nil {
+				if apierrors.IsAlreadyExists(cerr) {
+					return apierrors.NewConflict(
+						schema.GroupResource{Group: prometheusRuleGVR.Group, Resource: prometheusRuleGVR.Resource},
+						LegacyAlertRuleCRDName, cerr)
+				}
+				return cerr
+			}
+			result = created
+			return nil
 		}
-		return created.UnstructuredContent(), nil
-	}
+		if gerr != nil {
+			return gerr
+		}
+
+		groups, _, _ := unstructured.NestedSlice(existing.Object, "spec", "groups")
+		if len(groups) == 0 {
+			groups = []any{map[string]any{
+				"name":  LegacyAlertRuleGroupName,
+				"rules": []any{rule},
+			}}
+		} else if !replaceLegacyRuleInPlace(groups, p.Alert, rule) {
+			first, _ := groups[0].(map[string]any)
+			if first == nil {
+				first = map[string]any{"name": LegacyAlertRuleGroupName}
+			}
+			rules, _ := first["rules"].([]any)
+			first["rules"] = append(rules, rule)
+			groups[0] = first
+		}
+		if serr := unstructured.SetNestedSlice(existing.Object, groups, "spec", "groups"); serr != nil {
+			return serr
+		}
+
+		updated, uerr := ri.Update(ctx, existing, metav1.UpdateOptions{})
+		if uerr != nil {
+			return uerr
+		}
+		result = updated
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
-
-	groups, _, _ := unstructured.NestedSlice(existing.Object, "spec", "groups")
-	if len(groups) == 0 {
-		groups = []any{map[string]any{
-			"name":  LegacyAlertRuleGroupName,
-			"rules": []any{rule},
-		}}
-	} else if !replaceLegacyRuleInPlace(groups, p.Alert, rule) {
-		first, _ := groups[0].(map[string]any)
-		if first == nil {
-			first = map[string]any{"name": LegacyAlertRuleGroupName}
-		}
-		rules, _ := first["rules"].([]any)
-		first["rules"] = append(rules, rule)
-		groups[0] = first
-	}
-	if err := unstructured.SetNestedSlice(existing.Object, groups, "spec", "groups"); err != nil {
-		return nil, err
-	}
-
-	updated, err := ri.Update(ctx, existing, metav1.UpdateOptions{})
-	if err != nil {
-		return nil, err
-	}
-	return updated.UnstructuredContent(), nil
+	return result.UnstructuredContent(), nil
 }
 
 // DeleteAlertRule removes a single rule by `alert` name from the canonical
@@ -199,41 +219,45 @@ func (m *Mutator) DeleteAlertRule(ctx context.Context, alert string) error {
 		return errors.New("mutate: alert name required")
 	}
 	ri := m.dynamic.Resource(prometheusRuleGVR).Namespace(m.Namespace)
-	existing, err := ri.Get(ctx, LegacyAlertRuleCRDName, metav1.GetOptions{})
-	if apierrors.IsNotFound(err) {
-		return nil
-	}
-	if err != nil {
-		return err
-	}
-	groups, _, _ := unstructured.NestedSlice(existing.Object, "spec", "groups")
-	changed := false
-	for gi := range groups {
-		g, _ := groups[gi].(map[string]any)
-		if g == nil {
-			continue
+	// Same conflict story as CreateOrReplaceAlertRule: shared CR, concurrent
+	// writers. Retry re-reads + re-applies the deletion on 409.
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		existing, gerr := ri.Get(ctx, LegacyAlertRuleCRDName, metav1.GetOptions{})
+		if apierrors.IsNotFound(gerr) {
+			return nil
 		}
-		rules, _ := g["rules"].([]any)
-		kept := make([]any, 0, len(rules))
-		for _, raw := range rules {
-			r, _ := raw.(map[string]any)
-			if r != nil && r["alert"] == alert {
-				changed = true
+		if gerr != nil {
+			return gerr
+		}
+		groups, _, _ := unstructured.NestedSlice(existing.Object, "spec", "groups")
+		changed := false
+		for gi := range groups {
+			g, _ := groups[gi].(map[string]any)
+			if g == nil {
 				continue
 			}
-			kept = append(kept, raw)
+			rules, _ := g["rules"].([]any)
+			kept := make([]any, 0, len(rules))
+			for _, raw := range rules {
+				r, _ := raw.(map[string]any)
+				if r != nil && str(r, "alert") == alert {
+					changed = true
+					continue
+				}
+				kept = append(kept, raw)
+			}
+			g["rules"] = kept
+			groups[gi] = g
 		}
-		g["rules"] = kept
-		groups[gi] = g
-	}
-	if !changed {
-		return nil
-	}
-	if err := unstructured.SetNestedSlice(existing.Object, groups, "spec", "groups"); err != nil {
-		return err
-	}
-	_, err = ri.Update(ctx, existing, metav1.UpdateOptions{})
-	return err
+		if !changed {
+			return nil
+		}
+		if serr := unstructured.SetNestedSlice(existing.Object, groups, "spec", "groups"); serr != nil {
+			return serr
+		}
+		_, uerr := ri.Update(ctx, existing, metav1.UpdateOptions{})
+		return uerr
+	})
 }
 
 // replaceLegacyRuleInPlace walks each group's rules and replaces the first
@@ -248,7 +272,7 @@ func replaceLegacyRuleInPlace(groups []any, alert string, rule map[string]any) b
 		rules, _ := g["rules"].([]any)
 		for ri := range rules {
 			r, _ := rules[ri].(map[string]any)
-			if r == nil || r["alert"] != alert {
+			if r == nil || str(r, "alert") != alert {
 				continue
 			}
 			rules[ri] = rule

--- a/runner/pkg/mutate/alertrules.go
+++ b/runner/pkg/mutate/alertrules.go
@@ -84,3 +84,204 @@ func (m *Mutator) DeletePrometheusRule(ctx context.Context, namespace, name stri
 	}
 	return nil
 }
+
+// Legacy alert-rule path: the api-server's eventrule code (and the older
+// Robusta playbook) sends `create_or_replace_alert_rule` with a flat
+// {alert, expr, duration, annotations, labels} payload — NOT a full
+// PrometheusRule manifest. We mutate a single shared CR in the agent's
+// install namespace so existing installations (which already carry this CR
+// from the legacy runner) keep working without a manifest-shape migration
+// in api-server.
+const (
+	// LegacyAlertRuleCRDName is the canonical CR the legacy runner created.
+	// We reuse the exact name so an existing installation's rules survive
+	// the migration; a fresh installation gets a CR with this name too.
+	LegacyAlertRuleCRDName = "nudgebee-prometheus.rules"
+
+	// LegacyAlertRuleGroupName is the group inside the CR the legacy runner
+	// appended into. New rules added by the legacy path go here.
+	LegacyAlertRuleGroupName = "kubernetes-apps"
+
+	// LegacyAlertRuleLabelKey/Value matches the label_selector the Robusta
+	// playbook used to identify the canonical CR — preserved on freshly
+	// created CRs so a parallel legacy runner can still find them.
+	LegacyAlertRuleLabelKey   = "release.app"
+	LegacyAlertRuleLabelValue = "nudgebee-resource-management"
+)
+
+// LegacyAlertRuleParams is the wire shape `create_or_replace_alert_rule`
+// arrives with. Duration is translated to the CR's `for` field.
+type LegacyAlertRuleParams struct {
+	Alert       string
+	Expr        string
+	Duration    string
+	Annotations map[string]any
+	Labels      map[string]any
+}
+
+// CreateOrReplaceAlertRule applies a single alert rule to the canonical
+// PrometheusRule CR. If a rule with the same `alert` name already exists in
+// any group, it is replaced in place; otherwise the rule is appended to the
+// first group. If the CR doesn't exist yet, it is created with the rule
+// inside a single group named LegacyAlertRuleGroupName.
+func (m *Mutator) CreateOrReplaceAlertRule(ctx context.Context, p LegacyAlertRuleParams) (any, error) {
+	if m.dynamic == nil {
+		return nil, errors.New("mutate: dynamic client not configured")
+	}
+	if m.Namespace == "" {
+		return nil, errors.New("mutate: agent namespace not configured (set INSTALLATION_NAMESPACE)")
+	}
+	if p.Alert == "" || p.Expr == "" {
+		return nil, errors.New("mutate: alert and expr required")
+	}
+
+	rule := map[string]any{
+		"alert":       p.Alert,
+		"expr":        p.Expr,
+		"annotations": p.Annotations,
+		"labels":      p.Labels,
+	}
+	if p.Duration != "" {
+		rule["for"] = p.Duration
+	}
+
+	ri := m.dynamic.Resource(prometheusRuleGVR).Namespace(m.Namespace)
+	existing, err := ri.Get(ctx, LegacyAlertRuleCRDName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		u := newLegacyAlertRuleCR(m.Namespace, []any{rule})
+		created, cerr := ri.Create(ctx, u, metav1.CreateOptions{})
+		if cerr != nil {
+			return nil, cerr
+		}
+		return created.UnstructuredContent(), nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	groups, _, _ := unstructured.NestedSlice(existing.Object, "spec", "groups")
+	if len(groups) == 0 {
+		groups = []any{map[string]any{
+			"name":  LegacyAlertRuleGroupName,
+			"rules": []any{rule},
+		}}
+	} else if !replaceLegacyRuleInPlace(groups, p.Alert, rule) {
+		first, _ := groups[0].(map[string]any)
+		if first == nil {
+			first = map[string]any{"name": LegacyAlertRuleGroupName}
+		}
+		rules, _ := first["rules"].([]any)
+		first["rules"] = append(rules, rule)
+		groups[0] = first
+	}
+	if err := unstructured.SetNestedSlice(existing.Object, groups, "spec", "groups"); err != nil {
+		return nil, err
+	}
+
+	updated, err := ri.Update(ctx, existing, metav1.UpdateOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return updated.UnstructuredContent(), nil
+}
+
+// DeleteAlertRule removes a single rule by `alert` name from the canonical
+// PrometheusRule CR. Missing CR or missing rule are no-ops — matches the
+// legacy semantics so a delete-after-uninstall doesn't error.
+func (m *Mutator) DeleteAlertRule(ctx context.Context, alert string) error {
+	if m.dynamic == nil {
+		return errors.New("mutate: dynamic client not configured")
+	}
+	if m.Namespace == "" {
+		return errors.New("mutate: agent namespace not configured (set INSTALLATION_NAMESPACE)")
+	}
+	if alert == "" {
+		return errors.New("mutate: alert name required")
+	}
+	ri := m.dynamic.Resource(prometheusRuleGVR).Namespace(m.Namespace)
+	existing, err := ri.Get(ctx, LegacyAlertRuleCRDName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	groups, _, _ := unstructured.NestedSlice(existing.Object, "spec", "groups")
+	changed := false
+	for gi := range groups {
+		g, _ := groups[gi].(map[string]any)
+		if g == nil {
+			continue
+		}
+		rules, _ := g["rules"].([]any)
+		kept := make([]any, 0, len(rules))
+		for _, raw := range rules {
+			r, _ := raw.(map[string]any)
+			if r != nil && r["alert"] == alert {
+				changed = true
+				continue
+			}
+			kept = append(kept, raw)
+		}
+		g["rules"] = kept
+		groups[gi] = g
+	}
+	if !changed {
+		return nil
+	}
+	if err := unstructured.SetNestedSlice(existing.Object, groups, "spec", "groups"); err != nil {
+		return err
+	}
+	_, err = ri.Update(ctx, existing, metav1.UpdateOptions{})
+	return err
+}
+
+// replaceLegacyRuleInPlace walks each group's rules and replaces the first
+// entry whose `alert` equals the target name. Returns true if a replacement
+// happened.
+func replaceLegacyRuleInPlace(groups []any, alert string, rule map[string]any) bool {
+	for gi := range groups {
+		g, _ := groups[gi].(map[string]any)
+		if g == nil {
+			continue
+		}
+		rules, _ := g["rules"].([]any)
+		for ri := range rules {
+			r, _ := rules[ri].(map[string]any)
+			if r == nil || r["alert"] != alert {
+				continue
+			}
+			rules[ri] = rule
+			g["rules"] = rules
+			groups[gi] = g
+			return true
+		}
+	}
+	return false
+}
+
+// newLegacyAlertRuleCR builds a fresh canonical PrometheusRule CR with the
+// Robusta-compat labels so a parallel legacy runner can still find it via
+// the same label selector.
+func newLegacyAlertRuleCR(namespace string, rules []any) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "monitoring.coreos.com/v1",
+		"kind":       "PrometheusRule",
+		"metadata": map[string]any{
+			"name":      LegacyAlertRuleCRDName,
+			"namespace": namespace,
+			"labels": map[string]any{
+				LegacyAlertRuleLabelKey: LegacyAlertRuleLabelValue,
+				"role":                  "alert-rules",
+			},
+		},
+		"spec": map[string]any{
+			"groups": []any{
+				map[string]any{
+					"name":  LegacyAlertRuleGroupName,
+					"rules": rules,
+				},
+			},
+		},
+	}}
+}

--- a/runner/pkg/mutate/alertrules_test.go
+++ b/runner/pkg/mutate/alertrules_test.go
@@ -159,3 +159,264 @@ func TestHandlers_PromRuleActionsRegisteredWhenDynamicSet(t *testing.T) {
 		}
 	}
 }
+
+// Legacy alert-rule path: the api-server today sends {alert, expr, duration,
+// annotations, labels} — not a manifest. These tests pin the shape-router and
+// the canonical-CR semantics so the path doesn't silently regress to "DB row
+// saved but no CR" the way it did before this change.
+
+func newLegacyCR(namespace string, rules []map[string]any) *unstructured.Unstructured {
+	asAny := make([]any, len(rules))
+	for i, r := range rules {
+		asAny[i] = r
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "monitoring.coreos.com/v1",
+		"kind":       "PrometheusRule",
+		"metadata": map[string]any{
+			"name":      LegacyAlertRuleCRDName,
+			"namespace": namespace,
+			"labels": map[string]any{
+				LegacyAlertRuleLabelKey: LegacyAlertRuleLabelValue,
+				"role":                  "alert-rules",
+			},
+		},
+		"spec": map[string]any{
+			"groups": []any{
+				map[string]any{"name": LegacyAlertRuleGroupName, "rules": asAny},
+			},
+		},
+	}}
+}
+
+func legacyRulesFromCR(t *testing.T, dyn *dynamicfake.FakeDynamicClient, namespace string) []any {
+	t.Helper()
+	got, err := dyn.Resource(prometheusRuleGVR).Namespace(namespace).Get(
+		context.Background(), LegacyAlertRuleCRDName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("read CR: %v", err)
+	}
+	groups, _, _ := unstructured.NestedSlice(got.Object, "spec", "groups")
+	if len(groups) == 0 {
+		return nil
+	}
+	g, _ := groups[0].(map[string]any)
+	rules, _ := g["rules"].([]any)
+	return rules
+}
+
+func TestCreateOrReplaceAlertRule_CreatesCRWhenAbsent(t *testing.T) {
+	dyn := dynamicfake.NewSimpleDynamicClient(promRuleScheme())
+	m := New(fake.NewClientset(), "", nil)
+	m.SetDynamic(dyn)
+	m.SetNamespace("nudgebee-agent")
+
+	if _, err := m.CreateOrReplaceAlertRule(context.Background(), LegacyAlertRuleParams{
+		Alert:       "TestAlertA",
+		Expr:        "up == 0",
+		Duration:    "1m",
+		Annotations: map[string]any{"summary": "s"},
+		Labels:      map[string]any{"severity": "warning"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	rules := legacyRulesFromCR(t, dyn, "nudgebee-agent")
+	if len(rules) != 1 {
+		t.Fatalf("want 1 rule, got %d", len(rules))
+	}
+	r, _ := rules[0].(map[string]any)
+	if r["alert"] != "TestAlertA" || r["for"] != "1m" {
+		t.Errorf("bad rule shape: %v", r)
+	}
+}
+
+func TestCreateOrReplaceAlertRule_AppendsWhenAlertNew(t *testing.T) {
+	pre := newLegacyCR("nudgebee-agent", []map[string]any{
+		{"alert": "Existing", "expr": "up", "for": "5m"},
+	})
+	dyn := dynamicfake.NewSimpleDynamicClient(promRuleScheme(), pre)
+	m := New(fake.NewClientset(), "", nil)
+	m.SetDynamic(dyn)
+	m.SetNamespace("nudgebee-agent")
+
+	if _, err := m.CreateOrReplaceAlertRule(context.Background(), LegacyAlertRuleParams{
+		Alert: "Fresh", Expr: "up == 0", Duration: "2m",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	rules := legacyRulesFromCR(t, dyn, "nudgebee-agent")
+	if len(rules) != 2 {
+		t.Fatalf("want 2 rules after append, got %d", len(rules))
+	}
+}
+
+func TestCreateOrReplaceAlertRule_ReplacesExistingAlertInPlace(t *testing.T) {
+	pre := newLegacyCR("nudgebee-agent", []map[string]any{
+		{"alert": "TargetAlert", "expr": "old_expr", "for": "5m"},
+		{"alert": "Other", "expr": "up", "for": "1m"},
+	})
+	dyn := dynamicfake.NewSimpleDynamicClient(promRuleScheme(), pre)
+	m := New(fake.NewClientset(), "", nil)
+	m.SetDynamic(dyn)
+	m.SetNamespace("nudgebee-agent")
+
+	if _, err := m.CreateOrReplaceAlertRule(context.Background(), LegacyAlertRuleParams{
+		Alert: "TargetAlert", Expr: "new_expr", Duration: "30s",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	rules := legacyRulesFromCR(t, dyn, "nudgebee-agent")
+	if len(rules) != 2 {
+		t.Fatalf("expected 2 rules (in-place replace), got %d", len(rules))
+	}
+	r0, _ := rules[0].(map[string]any)
+	if r0["expr"] != "new_expr" || r0["for"] != "30s" {
+		t.Errorf("expected first rule replaced, got %v", r0)
+	}
+	r1, _ := rules[1].(map[string]any)
+	if r1["alert"] != "Other" {
+		t.Errorf("second rule should be untouched, got %v", r1)
+	}
+}
+
+func TestCreateOrReplaceAlertRule_RequiresNamespace(t *testing.T) {
+	dyn := dynamicfake.NewSimpleDynamicClient(promRuleScheme())
+	m := New(fake.NewClientset(), "", nil)
+	m.SetDynamic(dyn)
+	// Namespace deliberately not set.
+	if _, err := m.CreateOrReplaceAlertRule(context.Background(), LegacyAlertRuleParams{
+		Alert: "X", Expr: "up",
+	}); err == nil || !strings.Contains(err.Error(), "namespace") {
+		t.Errorf("expected namespace error, got %v", err)
+	}
+}
+
+func TestCreateOrReplaceAlertRule_RequiresAlertAndExpr(t *testing.T) {
+	dyn := dynamicfake.NewSimpleDynamicClient(promRuleScheme())
+	m := New(fake.NewClientset(), "", nil)
+	m.SetDynamic(dyn)
+	m.SetNamespace("nudgebee-agent")
+	if _, err := m.CreateOrReplaceAlertRule(context.Background(), LegacyAlertRuleParams{}); err == nil {
+		t.Error("expected error when alert+expr empty")
+	}
+}
+
+func TestDeleteAlertRule_RemovesByAlertName(t *testing.T) {
+	pre := newLegacyCR("nudgebee-agent", []map[string]any{
+		{"alert": "Keep", "expr": "up"},
+		{"alert": "Drop", "expr": "down"},
+	})
+	dyn := dynamicfake.NewSimpleDynamicClient(promRuleScheme(), pre)
+	m := New(fake.NewClientset(), "", nil)
+	m.SetDynamic(dyn)
+	m.SetNamespace("nudgebee-agent")
+
+	if err := m.DeleteAlertRule(context.Background(), "Drop"); err != nil {
+		t.Fatal(err)
+	}
+	rules := legacyRulesFromCR(t, dyn, "nudgebee-agent")
+	if len(rules) != 1 {
+		t.Fatalf("want 1 rule after delete, got %d", len(rules))
+	}
+	r, _ := rules[0].(map[string]any)
+	if r["alert"] != "Keep" {
+		t.Errorf("wrong rule retained: %v", r)
+	}
+}
+
+func TestDeleteAlertRule_NoCRIsNoop(t *testing.T) {
+	dyn := dynamicfake.NewSimpleDynamicClient(promRuleScheme())
+	m := New(fake.NewClientset(), "", nil)
+	m.SetDynamic(dyn)
+	m.SetNamespace("nudgebee-agent")
+	if err := m.DeleteAlertRule(context.Background(), "anything"); err != nil {
+		t.Errorf("delete on missing CR should be no-op, got %v", err)
+	}
+}
+
+func TestDeleteAlertRule_UnknownAlertIsNoop(t *testing.T) {
+	pre := newLegacyCR("nudgebee-agent", []map[string]any{
+		{"alert": "Keep", "expr": "up"},
+	})
+	dyn := dynamicfake.NewSimpleDynamicClient(promRuleScheme(), pre)
+	m := New(fake.NewClientset(), "", nil)
+	m.SetDynamic(dyn)
+	m.SetNamespace("nudgebee-agent")
+	if err := m.DeleteAlertRule(context.Background(), "DoesNotExist"); err != nil {
+		t.Errorf("delete of unknown alert should be no-op, got %v", err)
+	}
+	if got := legacyRulesFromCR(t, dyn, "nudgebee-agent"); len(got) != 1 {
+		t.Errorf("expected CR untouched, got %d rules", len(got))
+	}
+}
+
+// Shape-router: the handler must pick the legacy path for {alert, expr, ...}
+// and the manifest path for {apiVersion, kind, metadata, spec}.
+
+func TestHandleCreateOrReplacePromRule_RoutesLegacyShape(t *testing.T) {
+	dyn := dynamicfake.NewSimpleDynamicClient(promRuleScheme())
+	m := New(fake.NewClientset(), "", nil)
+	m.SetDynamic(dyn)
+	m.SetNamespace("nudgebee-agent")
+
+	_, err := handleCreateOrReplacePromRule(context.Background(), m, map[string]any{
+		"alert":       "RouterTest",
+		"expr":        "up",
+		"duration":    "1m",
+		"annotations": map[string]any{"summary": "s"},
+		"labels":      map[string]any{"severity": "warning"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rules := legacyRulesFromCR(t, dyn, "nudgebee-agent")
+	if len(rules) != 1 {
+		t.Fatalf("legacy path should have created 1 rule, got %d", len(rules))
+	}
+}
+
+func TestHandleCreateOrReplacePromRule_RoutesManifestShape(t *testing.T) {
+	dyn := dynamicfake.NewSimpleDynamicClient(promRuleScheme())
+	m := New(fake.NewClientset(), "", nil)
+	m.SetDynamic(dyn)
+	m.SetNamespace("nudgebee-agent") // set but should be ignored on the manifest path
+
+	if _, err := handleCreateOrReplacePromRule(context.Background(), m,
+		newPromRuleManifest("manifest-route", "monitoring")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := dyn.Resource(prometheusRuleGVR).Namespace("monitoring").Get(
+		context.Background(), "manifest-route", metav1.GetOptions{}); err != nil {
+		t.Errorf("manifest-route CR should exist: %v", err)
+	}
+}
+
+func TestHandleDeletePromRule_RoutesByAlertVsName(t *testing.T) {
+	pre := newLegacyCR("nudgebee-agent", []map[string]any{
+		{"alert": "ToDrop", "expr": "up"},
+	})
+	// Also seed a manifest-style CR for the by-name path.
+	manifest := &unstructured.Unstructured{}
+	manifest.SetGroupVersionKind(schema.GroupVersionKind{Group: "monitoring.coreos.com", Version: "v1", Kind: "PrometheusRule"})
+	manifest.SetName("standalone")
+	manifest.SetNamespace("monitoring")
+	dyn := dynamicfake.NewSimpleDynamicClient(promRuleScheme(), pre, manifest)
+	m := New(fake.NewClientset(), "", nil)
+	m.SetDynamic(dyn)
+	m.SetNamespace("nudgebee-agent")
+
+	// Alert-shape removes a rule from the canonical CR.
+	if err := handleDeletePromRule(context.Background(), m, map[string]any{"alert": "ToDrop"}); err != nil {
+		t.Fatalf("alert-shape: %v", err)
+	}
+	if got := legacyRulesFromCR(t, dyn, "nudgebee-agent"); len(got) != 0 {
+		t.Errorf("expected ToDrop removed, %d rules remain", len(got))
+	}
+
+	// Name+namespace removes the standalone CR.
+	if err := handleDeletePromRule(context.Background(), m, map[string]any{
+		"name": "standalone", "namespace": "monitoring",
+	}); err != nil {
+		t.Fatalf("manifest-shape: %v", err)
+	}
+}

--- a/runner/pkg/mutate/handlers.go
+++ b/runner/pkg/mutate/handlers.go
@@ -108,7 +108,23 @@ func getBool(m map[string]any, k string, fallback bool) bool {
 	return fallback
 }
 
+// handleCreateOrReplacePromRule accepts two payload shapes:
+//
+//  1. Full PrometheusRule manifest at the top level (or under `rule`) —
+//     used by callers that own the CR shape directly.
+//  2. Legacy api-server / Robusta shape: a flat {alert, expr, duration,
+//     annotations, labels} map. Detected by the presence of a non-empty
+//     `alert` string AND the absence of an `apiVersion`. We translate it
+//     into a single rule appended to the canonical CR — see
+//     CreateOrReplaceAlertRule.
+//
+// Keeping both behind one action name avoids a coordinated rollout with the
+// api-server: today's callers send the legacy shape; future callers can opt
+// into the manifest shape without a new wire action.
 func handleCreateOrReplacePromRule(ctx context.Context, m *Mutator, p map[string]any) (any, error) {
+	if isLegacyAlertRulePayload(p) {
+		return m.CreateOrReplaceAlertRule(ctx, parseLegacyAlertRuleParams(p))
+	}
 	rule, ok := p["rule"]
 	if !ok {
 		// Allow the caller to pass the manifest at the top level too.
@@ -117,8 +133,47 @@ func handleCreateOrReplacePromRule(ctx context.Context, m *Mutator, p map[string
 	return m.CreateOrReplacePrometheusRule(ctx, rule)
 }
 
+// handleDeletePromRule accepts two payload shapes that mirror
+// handleCreateOrReplacePromRule: full manifest delete (by namespace+name)
+// or the legacy `alert`-only shape (drops a single rule from the canonical
+// CR).
 func handleDeletePromRule(ctx context.Context, m *Mutator, p map[string]any) error {
+	if alert := str(p, "alert"); alert != "" {
+		return m.DeleteAlertRule(ctx, alert)
+	}
 	return m.DeletePrometheusRule(ctx, str(p, "namespace"), str(p, "name"))
+}
+
+// isLegacyAlertRulePayload detects the flat Robusta shape: `alert` set and
+// no `apiVersion`. We also accept the shape when `rule` is absent — a
+// caller wrapping the full manifest under `rule` is treating it as a
+// manifest no matter the rest of the keys.
+func isLegacyAlertRulePayload(p map[string]any) bool {
+	if p == nil {
+		return false
+	}
+	if _, hasRule := p["rule"]; hasRule {
+		return false
+	}
+	if _, hasAV := p["apiVersion"]; hasAV {
+		return false
+	}
+	return str(p, "alert") != ""
+}
+
+func parseLegacyAlertRuleParams(p map[string]any) LegacyAlertRuleParams {
+	out := LegacyAlertRuleParams{
+		Alert:    str(p, "alert"),
+		Expr:     str(p, "expr"),
+		Duration: str(p, "duration"),
+	}
+	if a, ok := p["annotations"].(map[string]any); ok {
+		out.Annotations = a
+	}
+	if l, ok := p["labels"].(map[string]any); ok {
+		out.Labels = l
+	}
+	return out
 }
 
 // handleReplaceWorkload accepts the body as either:

--- a/runner/pkg/mutate/mutate.go
+++ b/runner/pkg/mutate/mutate.go
@@ -36,6 +36,11 @@ type Mutator struct {
 	LokiRulesURL     string
 	LokiRulesHeaders map[string]string
 
+	// Namespace is the agent's install namespace. Required by the legacy
+	// alert-rule path (CreateOrReplaceAlertRule / DeleteAlertRule), which
+	// locates the canonical PrometheusRule CR there.
+	Namespace string
+
 	// dynamic is the dynamic client used for CRD operations like
 	// PrometheusRule. Set via SetDynamic.
 	dynamic dynamic.Interface
@@ -54,6 +59,10 @@ func (m *Mutator) SetLokiRules(url string, headers map[string]string) {
 	m.LokiRulesURL = url
 	m.LokiRulesHeaders = headers
 }
+
+// SetNamespace records the agent's install namespace. Required by the legacy
+// alert-rule path; everything else is independent of it.
+func (m *Mutator) SetNamespace(ns string) { m.Namespace = ns }
 
 // DeletePod removes one pod. namespace + name required.
 func (m *Mutator) DeletePod(ctx context.Context, namespace, name string, gracePeriodSec *int64) error {


### PR DESCRIPTION
## Summary

`create_or_replace_alert_rule` and `delete_alert_rule` from the api-server (and the older Robusta playbook) arrive with a flat `{alert, expr, duration, annotations, labels}` payload — not a full PrometheusRule manifest. The current handler requires `metadata.name + namespace + spec`, so every call from api-server failed with `mutate: rule.metadata.name and namespace are required` and the corresponding `event_rules` row was persisted **without** an actual PrometheusRule CR in the cluster. Because the api-server's relay client only treats `data.error_msg` as a failure, the rejection was silently swallowed and the UI reported success.

This change keeps both shapes behind the same action name and closes the auth gap:

- **Manifest path** (existing): unchanged for callers that pass a full CR.
- **Legacy path** (new): translates the flat payload into one rule applied to a canonical shared CR named `nudgebee-prometheus.rules` in the agent's install namespace.
  - Wired from `INSTALLATION_NAMESPACE` (chart already sets it via the downward API), falling back to `ScannerNamespace`.
  - Robusta semantics: if a rule with the same `alert` exists in any group, replace it in place; otherwise append to the first group. If the CR is missing, create a fresh one with `release.app=nudgebee-resource-management` so a parallel legacy runner still finds it via the same label selector.
  - `duration` is translated to the rule's `for` field (Prometheus CRD shape).
- **Delete** gets the same shape-routing: `{alert}` drops a single rule from the canonical CR (idempotent for missing CR / missing rule); `{namespace, name}` still deletes a whole CR.

### Auth carve-out

`create_or_replace_alert_rule` and `delete_alert_rule` are added to the light-action allowlist. Most Group-D mutations stay RSA-required, but these two travel `api-server → relay → agent` and are gated by the relay's shared secret today — same trust posture as the read primitives that already sit in the allowlist. Without the carve-out, the agent silently rejects every call (`not in light-action allowlist`). The comment above the allowlist write spells the posture out so a future reader doesn't unintentionally un-carve them.

## Type of change

- [x] Bug fix (non-breaking)

## Chart version

- [x] No version bump needed (runner-only code change; image tag will pick up the next runner release)

## Test plan

- [x] `go vet ./...` clean
- [x] `make lint` clean
- [x] `go test ./...` — full agent suite green, including 11 new tests for the legacy create / delete / shape-router paths:
  - `TestCreateOrReplaceAlertRule_CreatesCRWhenAbsent`
  - `TestCreateOrReplaceAlertRule_AppendsWhenAlertNew`
  - `TestCreateOrReplaceAlertRule_ReplacesExistingAlertInPlace`
  - `TestCreateOrReplaceAlertRule_RequiresNamespace`
  - `TestCreateOrReplaceAlertRule_RequiresAlertAndExpr`
  - `TestDeleteAlertRule_RemovesByAlertName`
  - `TestDeleteAlertRule_NoCRIsNoop`
  - `TestDeleteAlertRule_UnknownAlertIsNoop`
  - `TestHandleCreateOrReplacePromRule_RoutesLegacyShape`
  - `TestHandleCreateOrReplacePromRule_RoutesManifestShape`
  - `TestHandleDeletePromRule_RoutesByAlertVsName`
- [ ] End-to-end on a dev cluster: build the agent image, swap it in, fire the api-server `alertmanager_create_rule` action, and confirm the rule lands inside `nudgebee-prometheus.rules` (pending — will follow up after this PR is reviewed).

## Notes for reviewers

- The api-server's `relay.Execute` still silently swallows non-`data.error_msg` agent errors. That's a separate fix in the `nudgebee` monorepo; calling it out here so we don't lose track.