### PR TITLE
ci(release): sign chart packages with cosign (keyless)

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -10,6 +10,7 @@ jobs:
   release-rc:
     permissions:
       contents: write
+      id-token: write # keyless cosign signing of chart packages
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -86,6 +87,33 @@ jobs:
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_SKIP_EXISTING: "true"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign chart packages (cosign keyless)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COSIGN_YES: "true"
+        run: |
+          # chart-releaser stages each packaged chart under .cr-release-packages/
+          # and names the GitHub release after the tarball. Sign each blob
+          # keyless (Fulcio/Rekor) and attach the signature + cert.
+          shopt -s nullglob
+          pkgs=(.cr-release-packages/*.tgz)
+          if [ ${#pkgs[@]} -eq 0 ]; then
+            echo "No chart packages produced — nothing to sign."
+            exit 0
+          fi
+          for pkg in "${pkgs[@]}"; do
+            tag="$(basename "${pkg%.tgz}")"
+            echo "Signing $pkg -> release $tag"
+            cosign sign-blob --yes \
+              --output-signature "${pkg}.sig" \
+              --output-certificate "${pkg}.pem" \
+              "$pkg"
+            gh release upload "$tag" "${pkg}.sig" "${pkg}.pem" --clobber
+          done
 
       - name: Mark release as pre-release  
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ jobs:
   release:
     permissions:
       contents: write
+      id-token: write # keyless cosign signing of chart packages
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -35,3 +36,32 @@ jobs:
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign chart packages (cosign keyless)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COSIGN_YES: "true"
+        run: |
+          # chart-releaser stages each packaged chart under .cr-release-packages/
+          # and names the GitHub release after the tarball (e.g.
+          # nudgebee-agent-0.1.1.tgz -> release nudgebee-agent-0.1.1). Sign each
+          # blob keyless (Fulcio/Rekor) and attach the signature + cert so the
+          # release carries verifiable provenance.
+          shopt -s nullglob
+          pkgs=(.cr-release-packages/*.tgz)
+          if [ ${#pkgs[@]} -eq 0 ]; then
+            echo "No chart packages produced — nothing to sign."
+            exit 0
+          fi
+          for pkg in "${pkgs[@]}"; do
+            tag="$(basename "${pkg%.tgz}")"
+            echo "Signing $pkg -> release $tag"
+            cosign sign-blob --yes \
+              --output-signature "${pkg}.sig" \
+              --output-certificate "${pkg}.pem" \
+              "$pkg"
+            gh release upload "$tag" "${pkg}.sig" "${pkg}.pem" --clobber
+          done

--- a/README.md
+++ b/README.md
@@ -47,6 +47,28 @@ curl -sSL https://raw.githubusercontent.com/nudgebee/k8s-agent/main/installation
   | bash -s -- -a "<your-auth-key>"
 ```
 
+### Verifying chart signatures
+
+Chart packages are signed with [cosign](https://github.com/sigstore/cosign)
+keyless signing. Each GitHub release attaches `<chart>.tgz.sig` and
+`<chart>.tgz.pem` alongside the chart tarball. To verify a downloaded
+package:
+
+```bash
+VERSION=0.1.1
+BASE="https://github.com/nudgebee/k8s-agent/releases/download/nudgebee-agent-${VERSION}"
+curl -sSLO "${BASE}/nudgebee-agent-${VERSION}.tgz"
+curl -sSLO "${BASE}/nudgebee-agent-${VERSION}.tgz.sig"
+curl -sSLO "${BASE}/nudgebee-agent-${VERSION}.tgz.pem"
+
+cosign verify-blob \
+  --certificate "nudgebee-agent-${VERSION}.tgz.pem" \
+  --signature "nudgebee-agent-${VERSION}.tgz.sig" \
+  --certificate-identity-regexp "https://github.com/nudgebee/k8s-agent/.github/workflows/release(-rc)?.yml@.*" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  "nudgebee-agent-${VERSION}.tgz"
+```
+
 ## Configuration
 
 All configurable values live in [`charts/nudgebee-agent/values.yaml`](charts/nudgebee-agent/values.yaml). Common overrides:

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ curl -sSLO "${BASE}/nudgebee-agent-${VERSION}.tgz.pem"
 cosign verify-blob \
   --certificate "nudgebee-agent-${VERSION}.tgz.pem" \
   --signature "nudgebee-agent-${VERSION}.tgz.sig" \
-  --certificate-identity-regexp "https://github.com/nudgebee/k8s-agent/.github/workflows/release(-rc)?.yml@.*" \
+  --certificate-identity-regexp "^https://github\.com/nudgebee/k8s-agent/\.github/workflows/release(-rc)?\.yml@.*" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
   "nudgebee-agent-${VERSION}.tgz"
 ```

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -61,7 +61,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-06-01T11-35-01_9cc96cf11ee44201e633cf7e53a9b5e15f3d40c8
+    tag: 2026-06-02T04-24-22_10ba4386e158ca6108aff1b8d513507d8c47cc09
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -61,7 +61,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-06-01T08-54-45_88fc8f3fb4e0e7f2c88adb111432362e3c697242
+    tag: 2026-06-01T11-35-01_9cc96cf11ee44201e633cf7e53a9b5e15f3d40c8
   imagePullPolicy: IfNotPresent
   resources:
     requests:
@@ -112,6 +112,7 @@ runner:
     auth_secret_key: ""
   serviceAccount:
     annotations: {}
+  profilerImage: ghcr.io/nudgebee/application-profiler-{}:dc5fd6d
 nodeAgent:
   enabled: true
   podmonitor:


### PR DESCRIPTION
Addresses OpenSSF Scorecard's **Signed-Releases** check. GitHub releases currently ship only the bare chart `.tgz` with no signature or provenance.

## What changed

Both `release.yml` and `release-rc.yml` now:
1. Install cosign (`sigstore/cosign-installer`, SHA-pinned).
2. After `chart-releaser` stages packages under `.cr-release-packages/`, keyless-sign each tarball (Fulcio cert + Rekor transparency log) and upload `<chart>.tgz.sig` + `<chart>.tgz.pem` to the matching release — the release tag is derived from the tarball name, matching chart-releaser's own convention (`nudgebee-agent-0.1.1.tgz` → release `nudgebee-agent-0.1.1`).
3. Gain `id-token: write` so the job can mint the OIDC token for keyless signing.

`README.md` documents verification with `cosign verify-blob` against the workflow identity and the GitHub Actions OIDC issuer.

## Notes / scope
- **Takes effect on the next release.** Existing releases stay unsigned, so Scorecard (which samples the 5 most recent releases) will improve gradually as signed releases accumulate.
- This is distinct from the runner **container** signing already in `runner-image.yaml` — Scorecard's Signed-Releases check inspects **GitHub Release assets** (the Helm chart), not GHCR images.
- Keyless signing requires CI OIDC, so it can't be exercised locally; YAML + extracted shell were syntax-validated and the tag-derivation loop was verified against the existing release naming.

## Follow-up (not in this PR)
Full 10/10 on the check also wants SLSA provenance (`.intoto.jsonl`). The signature alone is the bulk of the score; provenance via `slsa-github-generator` can be a later addition.