### PR TITLE
chore: route CODEOWNERS to @nudgebee/oss team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,10 @@
 # Default reviewers for all changes in this repo.
-# Adjust the team handle below to match your GitHub org/team.
+# Owners must have write access; a PR author cannot satisfy their own
+# code-owner review, so listing two owners means each reviews the other's PRs.
 
-*                               @nudgebee/maintainers
+*                               @blue4209211 @mayankpande88
 
 # Chart-specific
-/charts/                        @nudgebee/maintainers
-/.github/workflows/             @nudgebee/maintainers
-/installation.sh                @nudgebee/maintainers
+/charts/                        @blue4209211 @mayankpande88
+/.github/workflows/             @blue4209211 @mayankpande88
+/installation.sh                @blue4209211 @mayankpande88

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,10 @@
 # Default reviewers for all changes in this repo.
-# Owners must have write access; a PR author cannot satisfy their own
-# code-owner review, so listing two owners means each reviews the other's PRs.
+# @nudgebee/oss is the maintainers team (must have write access). A PR
+# author cannot satisfy their own code-owner review, so a teammate reviews.
 
-*                               @blue4209211 @mayankpande88
+*                               @nudgebee/oss
 
 # Chart-specific
-/charts/                        @blue4209211 @mayankpande88
-/.github/workflows/             @blue4209211 @mayankpande88
-/installation.sh                @blue4209211 @mayankpande88
+/charts/                        @nudgebee/oss
+/.github/workflows/             @nudgebee/oss
+/installation.sh                @nudgebee/oss


### PR DESCRIPTION
The existing `.github/CODEOWNERS` routed every path to `@nudgebee/maintainers` — a team that **does not exist** (GitHub API returns "Unknown owner"). The file was inert, and enabling `require_code_owner_reviews` against it would have **permanently blocked every PR**.

## What changed
- Created the **`@nudgebee/oss`** team (closed), added the maintainers, and granted it **write** access to this repo (a code owner must have write access).
- Repointed all CODEOWNERS patterns at `@nudgebee/oss`.

Validated with the GitHub CODEOWNERS API against this branch: **no errors** (the team resolves; on `main` the old `@nudgebee/maintainers` still errors, as expected until this merges).

Because a PR author can't satisfy their own code-owner review, every PR is reviewed by another team member.

## Follow-up to raise the Scorecard Branch-Protection score
This fixes the *file*. To make code-owner review **required**, an admin then enables it on `main`:

```
gh api -X PUT repos/nudgebee/k8s-agent/branches/main/protection/required_pull_request_reviews \
  -F require_code_owner_reviews=true -F required_approving_review_count=1 -F dismiss_stale_reviews=true
```

⚠️ `update-image-tags.yml` auto-pushes to PR branches with `GITHUB_TOKEN`; with code-owner review + `dismiss_stale` on, those pushes require re-approval and don't re-trigger checks (recursion guard). Fix that workflow's token (PAT / GitHub App) before enabling.