### PR TITLE
fix(release): use cosign v3 Sigstore bundle for chart signing

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -90,6 +90,8 @@ jobs:
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v3.0.6
 
       - name: Sign chart packages (cosign keyless)
         env:
@@ -98,7 +100,9 @@ jobs:
         run: |
           # chart-releaser stages each packaged chart under .cr-release-packages/
           # and names the GitHub release after the tarball. Sign each blob
-          # keyless (Fulcio/Rekor) and attach the signature + cert.
+          # keyless (Fulcio/Rekor) into a Sigstore bundle (.sigstore.json:
+          # signature + cert + transparency-log entry). cosign v3 deprecated
+          # --output-signature/-certificate in favour of this bundle format.
           shopt -s nullglob
           pkgs=(.cr-release-packages/*.tgz)
           if [ ${#pkgs[@]} -eq 0 ]; then
@@ -109,10 +113,10 @@ jobs:
             tag="$(basename "${pkg%.tgz}")"
             echo "Signing $pkg -> release $tag"
             cosign sign-blob --yes \
-              --output-signature "${pkg}.sig" \
-              --output-certificate "${pkg}.pem" \
+              --new-bundle-format \
+              --bundle "${pkg}.sigstore.json" \
               "$pkg"
-            gh release upload "$tag" "${pkg}.sig" "${pkg}.pem" --clobber
+            gh release upload "$tag" "${pkg}.sigstore.json" --clobber
           done
 
       - name: Mark release as pre-release  

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v3.0.6
 
       - name: Sign chart packages (cosign keyless)
         env:
@@ -48,8 +50,11 @@ jobs:
           # chart-releaser stages each packaged chart under .cr-release-packages/
           # and names the GitHub release after the tarball (e.g.
           # nudgebee-agent-0.1.1.tgz -> release nudgebee-agent-0.1.1). Sign each
-          # blob keyless (Fulcio/Rekor) and attach the signature + cert so the
-          # release carries verifiable provenance.
+          # blob keyless (Fulcio/Rekor) into a Sigstore bundle (sig + cert +
+          # transparency-log entry) so the release carries verifiable
+          # provenance. cosign v3 deprecated --output-signature/-certificate in
+          # favour of the .sigstore.json bundle (which OpenSSF Scorecard also
+          # recognises as a signature).
           shopt -s nullglob
           pkgs=(.cr-release-packages/*.tgz)
           if [ ${#pkgs[@]} -eq 0 ]; then
@@ -60,8 +65,8 @@ jobs:
             tag="$(basename "${pkg%.tgz}")"
             echo "Signing $pkg -> release $tag"
             cosign sign-blob --yes \
-              --output-signature "${pkg}.sig" \
-              --output-certificate "${pkg}.pem" \
+              --new-bundle-format \
+              --bundle "${pkg}.sigstore.json" \
               "$pkg"
-            gh release upload "$tag" "${pkg}.sig" "${pkg}.pem" --clobber
+            gh release upload "$tag" "${pkg}.sigstore.json" --clobber
           done

--- a/README.md
+++ b/README.md
@@ -50,20 +50,18 @@ curl -sSL https://raw.githubusercontent.com/nudgebee/k8s-agent/main/installation
 ### Verifying chart signatures
 
 Chart packages are signed with [cosign](https://github.com/sigstore/cosign)
-keyless signing. Each GitHub release attaches `<chart>.tgz.sig` and
-`<chart>.tgz.pem` alongside the chart tarball. To verify a downloaded
-package:
+keyless signing. Each GitHub release attaches a `<chart>.tgz.sigstore.json`
+Sigstore bundle (signature + certificate + transparency-log entry) alongside
+the chart tarball. To verify a downloaded package (requires cosign v3+):
 
 ```bash
 VERSION=0.1.1
 BASE="https://github.com/nudgebee/k8s-agent/releases/download/nudgebee-agent-${VERSION}"
 curl -sSLO "${BASE}/nudgebee-agent-${VERSION}.tgz"
-curl -sSLO "${BASE}/nudgebee-agent-${VERSION}.tgz.sig"
-curl -sSLO "${BASE}/nudgebee-agent-${VERSION}.tgz.pem"
+curl -sSLO "${BASE}/nudgebee-agent-${VERSION}.tgz.sigstore.json"
 
 cosign verify-blob \
-  --certificate "nudgebee-agent-${VERSION}.tgz.pem" \
-  --signature "nudgebee-agent-${VERSION}.tgz.sig" \
+  --bundle "nudgebee-agent-${VERSION}.tgz.sigstore.json" \
   --certificate-identity-regexp "^https://github\.com/nudgebee/k8s-agent/\.github/workflows/release(-rc)?\.yml@.*" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
   "nudgebee-agent-${VERSION}.tgz"


### PR DESCRIPTION
The cosign signing added in #447 failed on the first real RC release ([run](https://github.com/nudgebee/k8s-agent/actions/runs/26799878848/job/79004087916)):

```
Flag --output-signature has been deprecated, please use --bundle ...
Error: signing ...rc-4.tgz: create bundle file: open : no such file or directory
```

`sigstore/cosign-installer` now installs **cosign v3**, which deprecated `--output-signature`/`--output-certificate` and defaults to the new Sigstore bundle format. With no `--bundle` path given, cosign tried to open an empty bundle path and died.

## Fix
- **Pin `cosign-release: v3.0.6`** so the behaviour is deterministic across runs.
- Sign into a single **`<chart>.tgz.sigstore.json`** Sigstore bundle via `--new-bundle-format --bundle` (signature + Fulcio cert + Rekor transparency-log entry in one file).
- Upload that bundle instead of the old `.sig`/`.pem` pair.
- README verification updated to `cosign verify-blob --bundle …sigstore.json`.

## Why `.sigstore.json`
OpenSSF Scorecard's `releasesAreSigned` probe recognises exactly these suffixes:
`.asc .minisig .sig .sign .sigstore .sigstore.json`. The cosign v3 bundle is `.sigstore.json`, so it both verifies correctly and earns Signed-Releases credit.

## Validation
- Flags confirmed against a locally-installed cosign v3.0.6 (`--new-bundle-format`, `--bundle`). The signing command reaches the Fulcio/Rekor step exactly as the keyless CI path will (couldn't complete keyless locally — no OIDC + corporate TLS proxy, both absent in CI).
- Both workflows parse as YAML; signing shell passes `bash -n`.

## Context
This depends on the repo-level **immutable releases** setting now being **off** — that's what let chart-releaser create the release and reach the signing step in the first place. The pre-existing zombie `rc-3` (immutable, 0 assets) still needs deletion separately.