### PR TITLE
fix(release-rc): mark pre-release before signing

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -88,38 +88,7 @@ jobs:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_SKIP_EXISTING: "true"
 
-      - name: Install cosign
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-        with:
-          cosign-release: v3.0.6
-
-      - name: Sign chart packages (cosign keyless)
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COSIGN_YES: "true"
-        run: |
-          # chart-releaser stages each packaged chart under .cr-release-packages/
-          # and names the GitHub release after the tarball. Sign each blob
-          # keyless (Fulcio/Rekor) into a Sigstore bundle (.sigstore.json:
-          # signature + cert + transparency-log entry). cosign v3 deprecated
-          # --output-signature/-certificate in favour of this bundle format.
-          shopt -s nullglob
-          pkgs=(.cr-release-packages/*.tgz)
-          if [ ${#pkgs[@]} -eq 0 ]; then
-            echo "No chart packages produced — nothing to sign."
-            exit 0
-          fi
-          for pkg in "${pkgs[@]}"; do
-            tag="$(basename "${pkg%.tgz}")"
-            echo "Signing $pkg -> release $tag"
-            cosign sign-blob --yes \
-              --new-bundle-format \
-              --bundle "${pkg}.sigstore.json" \
-              "$pkg"
-            gh release upload "$tag" "${pkg}.sigstore.json" --clobber
-          done
-
-      - name: Mark release as pre-release  
+      - name: Mark release as pre-release
         run: |
           # Wait a moment for release to be fully created
           sleep 5
@@ -159,7 +128,42 @@ jobs:
           gh release edit "nudgebee-agent-${{ steps.rc_version.outputs.rc_version }}" \
             --title "Release Candidate ${{ steps.rc_version.outputs.rc_version }}" \
             --notes-file release_notes.md
-          
+
           echo "✅ Updated release title and notes"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Signing runs last: it is the most failure-prone step (Fulcio/Rekor),
+      # and by here the release is already published, marked pre-release, and
+      # has its notes — so a signing hiccup never leaves a half-configured
+      # full release behind.
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v3.0.6
+
+      - name: Sign chart packages (cosign keyless)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COSIGN_YES: "true"
+        run: |
+          # chart-releaser stages each packaged chart under .cr-release-packages/
+          # and names the GitHub release after the tarball. Sign each blob
+          # keyless (Fulcio/Rekor) into a Sigstore bundle (.sigstore.json:
+          # signature + cert + transparency-log entry). cosign v3 deprecated
+          # --output-signature/-certificate in favour of this bundle format.
+          shopt -s nullglob
+          pkgs=(.cr-release-packages/*.tgz)
+          if [ ${#pkgs[@]} -eq 0 ]; then
+            echo "No chart packages produced — nothing to sign."
+            exit 0
+          fi
+          for pkg in "${pkgs[@]}"; do
+            tag="$(basename "${pkg%.tgz}")"
+            echo "Signing $pkg -> release $tag"
+            cosign sign-blob --yes \
+              --new-bundle-format \
+              --bundle "${pkg}.sigstore.json" \
+              "$pkg"
+            gh release upload "$tag" "${pkg}.sigstore.json" --clobber
+          done


### PR DESCRIPTION
## Why
`nudgebee-agent-0.1.1-rc-4` published as a **full release**, not a pre-release. Root cause from the run's step outcomes:

| Step | Result |
|---|---|
| Run chart-releaser for RC | ✅ creates release (full, by default) |
| Sign chart packages | ❌ failed (the cosign v3 bug, fixed in #449) |
| Mark release as pre-release | ⏭️ **skipped** (prior step failed) |
| Update RC release notes | ⏭️ **skipped** |

Because "mark as pre-release" ran *after* signing, a signing failure left a full, unsigned release behind.

## Fix
Reorder so the release is finalized before the fragile signing step:

```
chart-releaser → mark pre-release → update notes → install cosign → sign
```

Now a signing failure leaves a correctly-marked, fully-noted **pre-release**, never a half-configured full release. (`release.yml` for prod needs no change — those are intentionally full releases.)

rc-4 itself was manually flipped to pre-release already. Follows #449 (cosign v3 `.sigstore.json` fix), now merged.