### PR TITLE
fix(runner): remove warning_event matcher

### DIFF
--- a/runner/pkg/alerts/finding.go
+++ b/runner/pkg/alerts/finding.go
@@ -110,7 +110,7 @@ func (b *Builder) FromMatchedTrigger(matchSpec MatchedTrigger, rawData []byte) (
 	// Owner-aware subject — the UI groups findings by service_key, which
 	// is namespace/owner-or-pod. Use the resolved owner when the matcher
 	// walked one (most Pod-based matchers do); fall back to the raw
-	// subject otherwise (warning_event, node_not_ready).
+	// subject otherwise (node_not_ready).
 	subjectOwner, subjectOwnerKind := matchSpec.Owner.Name, matchSpec.Owner.Kind
 	if subjectOwner != "" {
 		serviceKey = matchSpec.SubjectNamespace + "/" + subjectOwner
@@ -194,8 +194,6 @@ func (m MatchedTrigger) Title() string {
 		return fmt.Sprintf("Job %s/%s failed", m.SubjectNamespace, m.SubjectName)
 	case "node_not_ready":
 		return fmt.Sprintf("Node %s is NotReady", m.SubjectName)
-	case "Kubernetes Warning Event":
-		return fmt.Sprintf("Warning Event on %s %s/%s", m.SubjectKind, m.SubjectNamespace, m.SubjectName)
 	default:
 		return fmt.Sprintf("%s on %s/%s", m.AggregationKey, m.SubjectNamespace, m.SubjectName)
 	}

--- a/runner/pkg/triggers/engine.go
+++ b/runner/pkg/triggers/engine.go
@@ -1,7 +1,6 @@
 package triggers
 
 import (
-	"strings"
 	"time"
 )
 
@@ -48,19 +47,14 @@ func (e *Engine) WithEventsLister(l K8sEventsLister) *Engine {
 }
 
 // fetchSubjectEvents builds a "Recent <Kind> events" table for the
-// matched object. Skipped when the lister is unwired (unit tests),
-// when the matched kind is Event (the warning_event matcher's subject
-// IS the event already, no point fetching events about an event), or
+// matched object. Skipped when the lister is unwired (unit tests) or
 // when the namespace/name pair can't be resolved.
 //
 // Centralizing this in the engine — rather than per-matcher EnrichBlocks
 // — lets every matcher (current + future) inherit the evidence without
 // repeating the same recentEventsTable call.
-func (e *Engine) fetchSubjectEvents(matcherName, kind, namespace, name string) []EvidenceBlock {
+func (e *Engine) fetchSubjectEvents(kind, namespace, name string) []EvidenceBlock {
 	if e.eventsLister == nil || namespace == "" || name == "" || kind == "" {
-		return nil
-	}
-	if matcherName == "warning_event" {
 		return nil
 	}
 	return recentEventsTable(EnrichContext{EventsLister: e.eventsLister},
@@ -134,20 +128,6 @@ func (e *Engine) Match(ev IncomingK8sEvent) []Match {
 		}
 
 		name, namespace, lowerKind, node := SubjectFromObj(ev.Kind, ev.Obj)
-		// Warning Event: subject is the involvedObject, not the Event itself.
-		if spec.Name == "warning_event" {
-			if io, _ := ev.Obj["involvedObject"].(map[string]any); io != nil {
-				if v, _ := io["name"].(string); v != "" {
-					name = v
-				}
-				if v, _ := io["namespace"].(string); v != "" {
-					namespace = v
-				}
-				if v, _ := io["kind"].(string); v != "" {
-					lowerKind = strings.ToLower(v)
-				}
-			}
-		}
 		var extra []EvidenceBlock
 		if spec.EnrichBlocks != nil {
 			extra = spec.EnrichBlocks(ev.Obj, ev.OldObj, EnrichContext{
@@ -163,7 +143,7 @@ func (e *Engine) Match(ev IncomingK8sEvent) []Match {
 		// the primary finding (sick node, sibling-pod failures) so users
 		// don't have to leave the Finding card to triage. All three are
 		// skipped when the lister isn't wired (unit tests / no K8s client).
-		extra = append(extra, e.fetchSubjectEvents(spec.Name, ev.Kind, namespace, name)...)
+		extra = append(extra, e.fetchSubjectEvents(ev.Kind, namespace, name)...)
 		extra = append(extra, e.fetchNodeEvents(node)...)
 		extra = append(extra, e.fetchNamespaceEvents(namespace)...)
 		matches = append(matches, Match{

--- a/runner/pkg/triggers/events_block_test.go
+++ b/runner/pkg/triggers/events_block_test.go
@@ -78,31 +78,6 @@ func TestEngine_AppendsRecentEventsTablePerMatch(t *testing.T) {
 	}
 }
 
-// TestEngine_SubjectEventsSkippedForWarningEvent: the warning_event
-// matcher's subject IS already the K8s Event, so fetching events about
-// an event would be circular and noisy. Engine must skip the subject
-// fetch in that case — but node + namespace tables still apply since
-// they're keyed off the involved Pod's namespace/node, not the Event.
-func TestEngine_SubjectEventsSkippedForWarningEvent(t *testing.T) {
-	ev := asObj(t, `{
-		"metadata":{"name":"e1","namespace":"prod"},
-		"type":"Warning",
-		"reason":"FailedScheduling",
-		"involvedObject":{"kind":"Pod","name":"web-0","namespace":"prod"}
-	}`)
-	stub := &stubLister{events: []K8sEvent{{Reason: "X"}}}
-	eng := NewEngine(Builtins(), time.Now().Add(-time.Hour)).WithEventsLister(stub)
-	matches := eng.Match(IncomingK8sEvent{Operation: "create", Kind: "Event", Obj: ev})
-	if !contains(matchNames(matches), "warning_event") {
-		t.Fatal("expected warning_event to fire")
-	}
-	for _, c := range stub.calls {
-		if c.kind == "Event" {
-			t.Errorf("ListEvents must NOT be called with kind=Event for warning_event matches; got %+v", c)
-		}
-	}
-}
-
 // TestEngine_AppendsNodeEventsTable: when the matched Pod has a node,
 // the engine attaches a "Recent Node events" table so users see
 // node-level issues (DiskPressure / NetworkUnavailable / kubelet

--- a/runner/pkg/triggers/predicates.go
+++ b/runner/pkg/triggers/predicates.go
@@ -23,7 +23,6 @@ func Builtins() []MatcherSpec {
 		imagePullBackoffMatcher(),
 		jobFailureMatcher(),
 		nodeNotReadyMatcher(),
-		warningEventMatcher(),
 	}
 	// One matcher per babysitter-watched kind. We register them as
 	// separate specs (rather than `Kind: "Any"` with an in-predicate
@@ -421,44 +420,6 @@ func nodeNotReadyMatcher() MatcherSpec {
 			// distinct Findings per transition rather than one forever.
 			ts := nodeReadyLastTransition(obj)
 			return fp("node_not_ready", name, ts)
-		},
-	}
-}
-
-// ------- Warning Event -------
-
-// warningEventMatcher fires for K8s Event resources of type=Warning.
-// Emits aggregation_key "Kubernetes Warning Event" (literal string with
-// capitalization).
-//
-// Requires kubewatch's chart to subscribe to events
-// (k8s-agent/charts/nudgebee-agent/values.yaml has `event: true` at
-// the resource block). Verified live before adding this matcher.
-func warningEventMatcher() MatcherSpec {
-	return MatcherSpec{
-		Name:           "warning_event",
-		Kind:           "Event",
-		Operations:     []string{"create"},
-		AggregationKey: "Kubernetes Warning Event",
-		Priority:       "MEDIUM",
-		FindingType:    "issue",
-		RateLimit:      5 * time.Minute,
-		Predicate: func(obj, _ map[string]any) bool {
-			t, _ := obj["type"].(string)
-			return t == "Warning"
-		},
-		FingerprintFn: func(obj map[string]any) string {
-			// involvedObject (core/v1) or regarding (events.k8s.io/v1)
-			// is the resource the event describes.
-			io, _ := obj["involvedObject"].(map[string]any)
-			if io == nil {
-				io, _ = obj["regarding"].(map[string]any)
-			}
-			ioKind, _ := io["kind"].(string)
-			ioNS, _ := io["namespace"].(string)
-			ioName, _ := io["name"].(string)
-			reason, _ := obj["reason"].(string)
-			return fp("Kubernetes Warning Event", ioKind, ioNS, ioName, reason)
 		},
 	}
 }

--- a/runner/pkg/triggers/predicates_test.go
+++ b/runner/pkg/triggers/predicates_test.go
@@ -718,30 +718,6 @@ func TestNodeNotReady_DoesNotRefireWhilePersistentlyNotReady(t *testing.T) {
 	}
 }
 
-// ---------- warning_event ----------
-
-func TestWarningEvent_FiresForWarningType(t *testing.T) {
-	ev := asObj(t, `{
-		"type":"Warning",
-		"reason":"FailedScheduling",
-		"involvedObject":{"kind":"Pod","namespace":"prod","name":"web-0"}
-	}`)
-	if !warningEventMatcher().Predicate(ev, nil) {
-		t.Error("Warning Event must fire")
-	}
-}
-
-func TestWarningEvent_DropsNormalType(t *testing.T) {
-	ev := asObj(t, `{
-		"type":"Normal",
-		"reason":"Created",
-		"involvedObject":{"kind":"Pod","namespace":"prod","name":"web-0"}
-	}`)
-	if warningEventMatcher().Predicate(ev, nil) {
-		t.Error("Normal Event must not fire")
-	}
-}
-
 // ---------- engine integration ----------
 
 func TestEngine_FiresMultipleMatchersForSamePod(t *testing.T) {

--- a/runner/pkg/triggers/types.go
+++ b/runner/pkg/triggers/types.go
@@ -2,8 +2,7 @@
 // side. Most kubewatch events match nothing and are silently dropped;
 // the few that match a registered trigger emit a Finding with a
 // specific aggregation_key (`report_crash_loop`, `pod_oom_killer_enricher`,
-// `image_pull_backoff_reporter`, `job_failure`, `node_not_ready`,
-// `Kubernetes Warning Event`, …).
+// `image_pull_backoff_reporter`, `job_failure`, `node_not_ready`, …).
 //
 // Matchers are declared as data-driven MatcherSpec values rather than
 // hardcoded if-blocks so when stage 2.3 ships DB-stored playbook config
@@ -170,9 +169,7 @@ type Match struct {
 	// bare Pod) or when the chain doesn't terminate at a known kind.
 	Owner OwnerRef
 
-	// SubjectName / SubjectNamespace come from obj.metadata. The matcher
-	// may override SubjectName for special cases (warning_event uses
-	// involvedObject.name, not obj.metadata.name).
+	// SubjectName / SubjectNamespace come from obj.metadata.
 	SubjectName      string
 	SubjectNamespace string
 	SubjectKind      string // lowercased; "pod" | "deployment" | etc.


### PR DESCRIPTION
## Summary

Removes the `warning_event` matcher from the runner's trigger engine. The matcher fired on every K8s Event of `type=Warning` and produced ~6k findings/24h on dev clusters, dominated by kubelet probe-flap noise (`Unhealthy` startup/liveness probes on `calico-node`, `fluent-bit`, `loki-canary`, transient app readiness). The high-signal warning conditions are already covered by dedicated matchers (`pod_crash_loop`, `pod_oom_killed`, `image_pull_backoff`, `node_not_ready`, `job_failure`).

This is a **re-apply of nudgebee-agent PR #52**, which was merged into the pre-OSS history on 2026-05-19 but dropped when the upstream repo was re-initialized on 2026-05-21. The runner code was imported into this repo on 2026-05-26 (#433) from a snapshot that pre-dates the removal, and the fix has been missing here ever since.

### Also fixes the subject-shape bug exposed by the matcher

The engine override that swapped in `involvedObject.{kind,name,namespace}` as the Finding subject only read the **deprecated core/v1** `involvedObject` field; it ignored the **modern events.k8s.io/v1** `regarding` field. When the payload used the modern API, the override fell through and `SubjectFromObj` returned the K8s Event resource's own `metadata.name` — which for an Event is auto-generated as `{involvedObj}.{eventUID}`.

Concrete example observed on dev today (event id ` 786b0300-533f-4e70-8d49-9b59106c93b0`): a `kubelet Unhealthy` startup-probe Event was emitted with `regarding.name = notifications-58f67d7655-q87d2`, but the resulting Finding had:

- `subject_kind = "event"`
- `subject_name = "notifications-58f67d7655-q87d2.18b5319ebc909bed"`

Downstream, the `event_resource_events_enricher` ran `ListEvents(ns, kind="Event", name="notifications-58f67d7655-q87d2.18b5319ebc909bed")` and obviously got zero rows.

With the matcher gone, the engine override and its `fetchSubjectEvents` skip are deleted too.

## Type of change

- [x] Bug fix (non-breaking)

## Chart version

- [x] No version bump needed (runner-only code change; image tag will pick up the next runner release)

## Test plan

- [x] `make validate` clean (`fmt` + `vet` + `go test -race -count=1 ./...` — all packages green)
- [x] `golangci-lint run` clean (0 issues)
- [x] Triggers + alerts unit tests pass with the `TestWarningEvent_*` and `TestEngine_SubjectEventsSkippedForWarningEvent` tests removed (no other test references)
- [ ] On a dev cluster, confirm no new Findings with `aggregation_key="Kubernetes Warning Event"` after the new runner image rolls out (pending — will follow up after merge + chart bump)

## Follow-ups (out of scope here)

- Re-apply the same removal to `nudgebee/nudgebee-agent` `main` so the next runner re-sync doesn't drop it again.