### PR TITLE
fix(chart): decouple MUTATE_ENABLED from .Values.rsa

### DIFF
--- a/charts/nudgebee-agent/Chart.yaml
+++ b/charts/nudgebee-agent/Chart.yaml
@@ -29,8 +29,8 @@ annotations:
 # these are set to the right value by .github/workflows/release.yaml
 # we use 0.0.1 as a placeholder for the version` because Helm wont allow `0.0.0` and we want to be able to run
 # `helm install` on development checkouts without updating this file. the version doesn't matter in that case anyway
-version: 0.1.1
-appVersion: 0.1.1
+version: 0.1.2
+appVersion: 0.1.2
 dependencies:
 - name: opencost
   version: 2.0.1

--- a/charts/nudgebee-agent/templates/_helpers.tpl
+++ b/charts/nudgebee-agent/templates/_helpers.tpl
@@ -91,9 +91,19 @@ Runner container template. Invoked with root context: include "nudgebee.runner.c
     - name: PROFILER_IMAGE
       value: {{ .Values.runner.profilerImage | quote }}
     {{- end }}
-    {{- if .Values.rsa }}
+    # MUTATE_ENABLED gates the runner's mutate subsystem (delete_pod,
+    # cordon, rollout_restart, PrometheusRule CRUD, AlertManager silences,
+    # Loki rules, ...). The auth boundary lives inside the runner — only
+    # the explicitly-allowlisted light actions accept unsigned requests;
+    # every other mutate action falls through to the validator's
+    # HMAC/RSA-partial-keys path and is rejected without a signed request.
+    # So enabling the subsystem here does NOT loosen the security posture
+    # on installations that omit `.Values.rsa`; it only makes the
+    # light-action carve-outs (currently create_or_replace_alert_rule /
+    # delete_alert_rule) reachable end-to-end.
     - name: MUTATE_ENABLED
       value: "true"
+    {{- if .Values.rsa }}
     - name: RSA_PRIVATE_KEY_PATH
       value: /etc/nudgebee/auth/prv
     {{- end }}

--- a/charts/nudgebee-agent/templates/_helpers.tpl
+++ b/charts/nudgebee-agent/templates/_helpers.tpl
@@ -101,8 +101,13 @@ Runner container template. Invoked with root context: include "nudgebee.runner.c
     # on installations that omit `.Values.rsa`; it only makes the
     # light-action carve-outs (currently create_or_replace_alert_rule /
     # delete_alert_rule) reachable end-to-end.
+    #
+    # Operators who want a strictly read-only deployment can set
+    # `runner.mutateEnabled: false`. The `eq ... false` pattern is
+    # intentional: `default true` would treat an explicit `false` as
+    # unset and re-enable the subsystem.
     - name: MUTATE_ENABLED
-      value: "true"
+      value: {{ if eq .Values.runner.mutateEnabled false }}"false"{{ else }}"true"{{ end }}
     {{- if .Values.rsa }}
     - name: RSA_PRIVATE_KEY_PATH
       value: /etc/nudgebee/auth/prv

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -81,6 +81,13 @@ runner:
   # ingress/networkpolicy writes, resource quotas, limit ranges, namespace creation,
   # statefulset scaling, workload creation, and rollout lifecycle management.
   enableWritePermissions: false
+  # Kill-switch for the runner's mutate subsystem (delete_pod, cordon,
+  # rollout_restart, PrometheusRule CRUD, AlertManager silences, Loki rules).
+  # Default is true so the light-action alert-rule path (driven by the UI)
+  # works without extra configuration; the auth boundary lives in the runner,
+  # not here. Set to false for a strictly read-only deployment where every
+  # mutate action — light-action or not — is unregistered at startup.
+  mutateEnabled: true
   customClusterRoleRules: []
   imagePullSecrets: []
   extraVolumes: []

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -61,7 +61,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-06-02T08-54-58_42d1e24062422e1fca0bd5e40c4a13deb7636e34
+    tag: 2026-06-02T11-50-30_5b2521dc3f06edea44f5a89479ff65a0380c3a7a
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.


### PR DESCRIPTION
## Summary

\`MUTATE_ENABLED\` was only set on the runner container when the optional \`.Values.rsa\` block was configured. That left the mutate subsystem **off** on every fresh install — which made the light-action carve-outs added in #446 (\`create_or_replace_alert_rule\`, \`delete_alert_rule\`) unreachable: a UI-initiated event-rule create lands in the api-server DB but the agent never registers the handlers, so the PrometheusRule CR never gets written. Reproduced this on the dev cluster after #446 merged; worked around with \`kubectl set env deploy/nudgebee-agent-runner MUTATE_ENABLED=true\` to validate end-to-end.

This change moves \`MUTATE_ENABLED\` out of the rsa-conditional block so it is always \`true\`. \`RSA_PRIVATE_KEY_PATH\` stays inside the block because it points at a file that only exists when the rsa secret is mounted.

### Why this doesn't loosen security on non-rsa installs

The agent's auth boundary lives in the [validator](https://github.com/nudgebee/k8s-agent/blob/main/runner/pkg/auth/auth.go), not at handler-registration time. Only actions explicitly added to \`lightActions\` accept unsigned requests; every other Group-D mutation (\`delete_pod\`, \`cordon\`, \`rollout_restart\`, …) falls through to the HMAC / RSA-partial-keys path and 403s without a signed request, RSA configured or not. So enabling the subsystem here only makes the **already-allowlisted** light actions reachable end-to-end — it doesn't expose new attack surface.

A short comment above the env block spells the posture out so a future reader doesn't accidentally re-couple them.

## Type of change

- [x] Bug fix (non-breaking)

## Chart version

- [x] I bumped \`version\` in \`charts/nudgebee-agent/Chart.yaml\` (0.1.1 → 0.1.2)

## Test plan

- [x] \`helm lint charts/nudgebee-agent\` passes
- [x] \`ct lint --config .github/configs/ct.yaml --lint-conf .github/configs/lintconf.yaml --check-version-increment=false --target-branch main\` (same flags as \`helm-dev-lint.yml\`) passes
- [x] \`helm template t charts/nudgebee-agent\` (no rsa) renders \`MUTATE_ENABLED=true\` and **no** \`RSA_PRIVATE_KEY_PATH\` — confirmed
- [x] \`helm template t charts/nudgebee-agent --set rsa.prv=… --set rsa.pub=…\` renders both env vars — confirmed
- [x] On dev cluster (already running #446 agent image, manual \`MUTATE_ENABLED=true\` previously): create / update / delete event-rule end-to-end against the canonical \`nudgebee-prometheus.rules\` CR all worked. After this chart change lands and is rolled, the same will hold without the manual env override.

## Related

Follows #446. The other open follow-up from the same investigation — api-server's \`relay.Execute\` silently swallowing non-\`data.error_msg\` agent errors — is in the \`nudgebee\` monorepo, separate PR.