### PR TITLE
fix(runner): allowlist pod_script_run_enricher for unsigned api-server calls

### DIFF
--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -61,7 +61,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-06-02T04-24-22_10ba4386e158ca6108aff1b8d513507d8c47cc09
+    tag: 2026-06-02T08-54-58_42d1e24062422e1fca0bd5e40c4a13deb7636e34
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/runner/cmd/agent/main.go
+++ b/runner/cmd/agent/main.go
@@ -461,7 +461,19 @@ func run(ctx context.Context, logger *slog.Logger, cfg *config.Config) error {
 		runner := podrunner.New(typedKube, cfg.ScannerNamespace, cfg.ScannerServiceAccount, cfg.AccountID)
 		rh := podrunner.Handlers(runner)
 		maps.Copy(handlers, rh)
-		// NOT a light-action — same trust posture as pod_bash_enricher.
+		// By trust posture pod_script_run_enricher belongs with pod_bash_enricher
+		// (arbitrary command execution → HMAC/RSA only). But api-server's
+		// relay.CommandExecutor dispatches it UNSIGNED behind the relay's
+		// shared-secret gate — the k8s-mode DB integration connection tests
+		// (postgresql/mysql/clickhouse/mssql/oracle), runbook-server, and
+		// llm-server all reach it this way and none of them sign. Same situation
+		// as the PrometheusRule actions carved in below. Without this the
+		// dispatcher rejects every such request with "not in light-action
+		// allowlist", surfacing in the UI as a misleading "failed to connect to
+		// the cluster". Allowlist it here to close the gap without forcing
+		// signing into api-server's relay client. pod_bash_enricher / pod_profiler
+		// stay OUT — they have no unsigned api-server caller.
+		lightActions["pod_script_run_enricher"] = struct{}{}
 		logger.Info("pod-runner enabled",
 			"default_namespace", cfg.ScannerNamespace,
 			"service_account", cfg.ScannerServiceAccount,

--- a/runner/cmd/agent/main.go
+++ b/runner/cmd/agent/main.go
@@ -473,6 +473,10 @@ func run(ctx context.Context, logger *slog.Logger, cfg *config.Config) error {
 		// the cluster". Allowlist it here to close the gap without forcing
 		// signing into api-server's relay client. pod_bash_enricher / pod_profiler
 		// stay OUT — they have no unsigned api-server caller.
+		// TODO(security): this trades per-request HMAC/RSA verification for the
+		// relay's shared-secret gate, so a relay/secret compromise yields
+		// arbitrary in-cluster command execution. Remove this entry once
+		// api-server's relay client signs pod_script_run_enricher.
 		lightActions["pod_script_run_enricher"] = struct{}{}
 		logger.Info("pod-runner enabled",
 			"default_namespace", cfg.ScannerNamespace,


### PR DESCRIPTION
## Summary

The k8s-mode connection test for DB integrations (postgresql/mysql/clickhouse/mssql/oracle) was failing in the UI with the misleading message *"failed to connect to the cluster. Please verify the agent is running and your configuration is correct"* — even though the agent is running and reachable.

Root cause is a trust-model mismatch, not a connectivity problem:

- The connection test runs `psql -c "SELECT 1 + 1"` via api-server's `relay.CommandExecutor`, which dispatches the **`pod_script_run_enricher`** action.
- api-server's relay client sends actions **unsigned** (it has no HMAC/RSA signing — it relies on the relay's shared-secret gate), so the request reaches the agent in *light-action* mode.
- `pod_script_run_enricher` was deliberately **excluded** from the light-action allowlist (it runs arbitrary commands / spawns pods → intended to require HMAC or RSA partial-keys).
- The dispatcher therefore rejected it with `auth: action "pod_script_run_enricher" not in light-action allowlist`. That error string contains `"relay"`, so api-server's `HandleRelayError` flattens it into the generic "failed to connect to the cluster" message.

This is the same situation already handled for the two PrometheusRule mutate actions (`create_or_replace_alert_rule` / `delete_alert_rule`), which are also dispatched unsigned by api-server and explicitly carved into the allowlist. This PR applies the same carve-out to `pod_script_run_enricher`.

`pod_bash_enricher` and `pod_profiler` deliberately **stay out** of the allowlist — they have no unsigned api-server caller and keep their HMAC/RSA-only posture.

### Trade-off
This accepts arbitrary-command pod execution under the relay's shared-secret gate rather than per-request HMAC. The design-pure alternative is to teach api-server's relay client to HMAC-sign this action; this PR is the pragmatic unblock that mirrors the existing PrometheusRule precedent and avoids forcing signing into the api-server relay client. The allowlist entry is gated on `PodExecEnabled`, so it only applies when the handler is actually registered.

## Type of change

- [x] Bug fix (non-breaking)

## Chart version

- [x] No version bump needed (runner code change; no chart template change)

## Test plan

- [x] `go build ./cmd/agent/` passes
- [x] `go vet ./cmd/agent/` clean, `gofmt` clean
- [x] `go test ./pkg/auth/... ./pkg/podrunner/...` pass
- [ ] Re-run the postgresql k8s-mode connection test against a cluster running this build

## Related issues

<!-- none -->