### PR TITLE
fix(rbac): grant karpenter permissions unconditionally

### DIFF
--- a/charts/nudgebee-agent/templates/forwarder-service-account.yaml
+++ b/charts/nudgebee-agent/templates/forwarder-service-account.yaml
@@ -135,46 +135,36 @@ rules:
   # absent CRD is inert and becomes active the moment karpenter is installed.
   # This avoids stale RBAC under GitOps/templated installs (where .Capabilities
   # cannot see CRDs) or when karpenter is installed after this chart.
+  # The forwarder only watches resources, so it gets read-only access.
   - apiGroups:
-    - karpenter.sh
+      - karpenter.sh
     resources:
-    - nodepools
-    - nodepools/status
-    - nodeclaims
-    - nodeclaims/status
+      - nodepools
+      - nodepools/status
+      - nodeclaims
+      - nodeclaims/status
     verbs:
-    - get
-    - list
-    - watch
-    - create
-    - delete
-    - patch
+      - get
+      - list
+      - watch
 
   - apiGroups:
-    - karpenter.k8s.aws
+      - karpenter.k8s.aws
     resources:
-    - ec2nodeclasses
+      - ec2nodeclasses
     verbs:
-    - get
-    - list
-    - watch
-    - create
-    - delete
-    - update
-    - patch
+      - get
+      - list
+      - watch
 
   - apiGroups:
-    - karpenter.azure.com
+      - karpenter.azure.com
     resources:
-    - aksnodeclasses
+      - aksnodeclasses
     verbs:
-    - get
-    - list
-    - watch
-    - create
-    - delete
-    - update
-    - patch
+      - get
+      - list
+      - watch
 
 ---
 apiVersion: v1

--- a/charts/nudgebee-agent/templates/forwarder-service-account.yaml
+++ b/charts/nudgebee-agent/templates/forwarder-service-account.yaml
@@ -131,52 +131,50 @@ rules:
     - watch
 {{- end }}
 
-{{- if (.Capabilities.APIVersions.Has "karpenter.sh/v1beta1/NodePool") }}
-  - apiGroups: 
+  # Karpenter permissions are granted unconditionally. An RBAC rule for an
+  # absent CRD is inert and becomes active the moment karpenter is installed.
+  # This avoids stale RBAC under GitOps/templated installs (where .Capabilities
+  # cannot see CRDs) or when karpenter is installed after this chart.
+  - apiGroups:
     - karpenter.sh
-    resources: 
+    resources:
     - nodepools
     - nodepools/status
     - nodeclaims
     - nodeclaims/status
-    verbs: 
-    - get 
+    verbs:
+    - get
     - list
     - watch
     - create
     - delete
     - patch
-{{- end }}
 
-{{- if (.Capabilities.APIVersions.Has "karpenter.k8s.aws/v1beta1/EC2NodeClass") }}
-  - apiGroups: 
+  - apiGroups:
     - karpenter.k8s.aws
-    resources: 
+    resources:
     - ec2nodeclasses
-    verbs: 
-    - get 
+    verbs:
+    - get
     - list
     - watch
     - create
     - delete
     - update
     - patch
-{{- end }}
 
-{{- if (.Capabilities.APIVersions.Has "karpenter.azure.com/v1alpha2/AKSNodeClass") }}
-  - apiGroups: 
+  - apiGroups:
     - karpenter.azure.com
-    resources: 
+    resources:
     - aksnodeclasses
-    verbs: 
-    - get 
+    verbs:
+    - get
     - list
     - watch
     - create
     - delete
     - update
     - patch
-{{- end }}
 
 ---
 apiVersion: v1

--- a/charts/nudgebee-agent/templates/runner-service-account.yaml
+++ b/charts/nudgebee-agent/templates/runner-service-account.yaml
@@ -442,53 +442,51 @@ rules:
 {{- end }}
 {{- end }}
 
-{{- if or (.Capabilities.APIVersions.Has "karpenter.sh/v1beta1/NodePool") (.Capabilities.APIVersions.Has "karpenter.sh/v1/NodePool") }}
-  - apiGroups: 
+  # Karpenter permissions are granted unconditionally. An RBAC rule for an
+  # absent CRD is inert and becomes active the moment karpenter is installed.
+  # This avoids stale RBAC under GitOps/templated installs (where .Capabilities
+  # cannot see CRDs) or when karpenter is installed after this chart.
+  - apiGroups:
     - karpenter.sh
-    resources: 
+    resources:
     - nodepools
     - nodepools/status
     - nodeclaims
     - nodeclaims/status
-    verbs: 
-    - get 
+    verbs:
+    - get
     - list
     - watch
     - create
     - delete
     - patch
     - update
-{{- end }}
 
-{{- if or (.Capabilities.APIVersions.Has "karpenter.k8s.aws/v1beta1/EC2NodeClass") (.Capabilities.APIVersions.Has "karpenter.k8s.aws/v1/EC2NodeClass") }}
-  - apiGroups: 
+  - apiGroups:
     - karpenter.k8s.aws
-    resources: 
+    resources:
     - ec2nodeclasses
-    verbs: 
-    - get 
+    verbs:
+    - get
     - list
     - watch
     - create
     - delete
     - update
     - patch
-{{- end }}
 
-{{- if .Capabilities.APIVersions.Has "karpenter.azure.com/v1alpha2/AKSNodeClass" }}
-  - apiGroups: 
+  - apiGroups:
     - karpenter.azure.com
-    resources: 
+    resources:
     - aksnodeclasses
-    verbs: 
-    - get 
+    verbs:
+    - get
     - list
     - watch
     - create
     - delete
     - update
     - patch
-{{- end }}
 
 {{- if .Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1/VolumeSnapshot" }}
   - apiGroups:

--- a/charts/nudgebee-agent/templates/runner-service-account.yaml
+++ b/charts/nudgebee-agent/templates/runner-service-account.yaml
@@ -442,51 +442,58 @@ rules:
 {{- end }}
 {{- end }}
 
-  # Karpenter permissions are granted unconditionally. An RBAC rule for an
+  # Karpenter read permissions are granted unconditionally. An RBAC rule for an
   # absent CRD is inert and becomes active the moment karpenter is installed.
   # This avoids stale RBAC under GitOps/templated installs (where .Capabilities
   # cannot see CRDs) or when karpenter is installed after this chart.
+  # Write verbs are gated behind runner.enableWritePermissions.
   - apiGroups:
-    - karpenter.sh
+      - karpenter.sh
     resources:
-    - nodepools
-    - nodepools/status
-    - nodeclaims
-    - nodeclaims/status
+      - nodepools
+      - nodepools/status
+      - nodeclaims
+      - nodeclaims/status
     verbs:
-    - get
-    - list
-    - watch
-    - create
-    - delete
-    - patch
-    - update
+      - get
+      - list
+      - watch
+{{- if .Values.runner.enableWritePermissions }}
+      - create
+      - delete
+      - patch
+      - update
+{{- end }}
 
   - apiGroups:
-    - karpenter.k8s.aws
+      - karpenter.k8s.aws
     resources:
-    - ec2nodeclasses
+      - ec2nodeclasses
     verbs:
-    - get
-    - list
-    - watch
-    - create
-    - delete
-    - update
-    - patch
+      - get
+      - list
+      - watch
+{{- if .Values.runner.enableWritePermissions }}
+      - create
+      - delete
+      - update
+      - patch
+{{- end }}
 
   - apiGroups:
-    - karpenter.azure.com
+      - karpenter.azure.com
     resources:
-    - aksnodeclasses
+      - aksnodeclasses
     verbs:
-    - get
-    - list
-    - watch
-    - create
-    - delete
-    - update
-    - patch
+      - get
+      - list
+      - watch
+{{- if .Values.runner.enableWritePermissions }}
+      - create
+      - delete
+      - update
+      - patch
+{{- end }}
 
 {{- if .Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1/VolumeSnapshot" }}
   - apiGroups:

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -61,7 +61,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-06-02T11-50-30_5b2521dc3f06edea44f5a89479ff65a0380c3a7a
+    tag: 2026-06-03T09-09-29_128d140be7a21099785e06c81af587d62dd943c8
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.


### PR DESCRIPTION
## Problem

The runner logs `nodeclaims.karpenter.sh is forbidden` even on clusters where karpenter is installed:

```
list nodeclaims: nodeclaims.karpenter.sh is forbidden: User "system:serviceaccount:nudgebee-agent:nudgebee-agent-runner-service-account" cannot list resource "nodeclaims" in API group "karpenter.sh" at the cluster scope
```

The karpenter RBAC rules exist in the runner and forwarder ClusterRoles, but they're gated on `.Capabilities.APIVersions.Has "karpenter.sh/.../NodePool"`. That gate is evaluated once at **chart-render time** and silently drops the rule in two common cases:

- **GitOps / templated installs** (ArgoCD, Flux, `helm template | kubectl apply`) — `.Capabilities.APIVersions` does not include CRDs, so the gate is always false.
- **Karpenter installed after this chart** — the rule never gets written until the next `helm upgrade`.

The forwarder gate additionally only checked `v1beta1`, missing karpenter `v1` clusters.

## Fix

Drop the capability gates and grant the `karpenter.sh`, `karpenter.k8s.aws`, and `karpenter.azure.com` rules unconditionally in both ClusterRoles.

An RBAC rule referencing an absent apiGroup/resource is **inert** — the API server accepts it and it grants nothing until the CRD exists. So unconditional granting is functionally equivalent to the gated behavior, minus the install-path and ordering fragility, and it activates the moment karpenter is present.

## Verification

- `helm lint` passes.
- `helm template` (without any `--api-versions`) now emits the karpenter rules in both the runner and forwarder ClusterRoles.