### PR TITLE
ci(release): pin runner image to the build in the release's history

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: write
       id-token: write # keyless cosign signing of chart packages
+      packages: read # read GHCR tags to pin the runner image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -78,6 +79,37 @@ jobs:
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo add opentelemetry https://open-telemetry.github.io/opentelemetry-helm-charts
           helm repo update
+
+      - name: Pin runner image to the build in this release's history
+        working-directory: ./charts/nudgebee-agent
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # The runner image is tagged "<timestamp>_<commit-sha>" and built only
+          # for main commits touching runner/** (runner-image.yaml). Pin the chart
+          # to the NEWEST such image whose commit is an ancestor of the release
+          # commit, so a released chart can never ship a runner image that
+          # predates — or isn't part of — its own code. This replaces relying on
+          # the PR-time "newest published image" (update-image-tags.yml), which
+          # records the previous build because a PR's own image isn't built yet
+          # when that job runs — the off-by-one that shipped rc-5 with a pre-#453
+          # runner.
+          picked=""
+          while IFS= read -r tag; do
+            sha="${tag##*_}"
+            if git merge-base --is-ancestor "$sha" HEAD 2>/dev/null; then
+              picked="$tag"; break
+            fi
+          done < <(gh api -H "Accept: application/vnd.github+json" \
+            "/orgs/nudgebee/packages/container/nudgebee-agent/versions?per_page=100" \
+            --jq '[.[].metadata.container.tags[]] | map(select(test("^[0-9]{4}.*_[0-9a-f]{40}$"))) | sort | reverse | .[]')
+          if [ -z "$picked" ]; then
+            echo "::error::No nudgebee-agent image found for any commit in this release's history — build/push the runner image first."
+            exit 1
+          fi
+          yq -i ".runner.image.tag=\"$picked\"" values.yaml
+          echo "Pinned runner.image.tag=$picked"
 
       - name: Run chart-releaser for RC
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: write
       id-token: write # keyless cosign signing of chart packages
+      packages: read # read GHCR tags to pin the runner image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -27,6 +28,34 @@ jobs:
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
           version: v3.10.0
+
+      - name: Pin runner image to the build in this release's history
+        working-directory: ./charts/nudgebee-agent
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # The runner image is tagged "<timestamp>_<commit-sha>" and built only
+          # for main commits touching runner/** (runner-image.yaml). Pin the chart
+          # to the NEWEST such image whose commit is an ancestor of the release
+          # commit, so a released chart can never ship a runner image that
+          # predates — or isn't part of — its own code. See release-rc.yml for the
+          # off-by-one this fixes (rc-5 shipped a pre-#453 runner).
+          picked=""
+          while IFS= read -r tag; do
+            sha="${tag##*_}"
+            if git merge-base --is-ancestor "$sha" HEAD 2>/dev/null; then
+              picked="$tag"; break
+            fi
+          done < <(gh api -H "Accept: application/vnd.github+json" \
+            "/orgs/nudgebee/packages/container/nudgebee-agent/versions?per_page=100" \
+            --jq '[.[].metadata.container.tags[]] | map(select(test("^[0-9]{4}.*_[0-9a-f]{40}$"))) | sort | reverse | .[]')
+          if [ -z "$picked" ]; then
+            echo "::error::No nudgebee-agent image found for any commit in this release's history — build/push the runner image first."
+            exit 1
+          fi
+          yq -i ".runner.image.tag=\"$picked\"" values.yaml
+          echo "Pinned runner.image.tag=$picked"
 
       - name: Add dependency chart repos
         run: |


### PR DESCRIPTION
## Problem

The chart's `runner.image.tag` is written by `update-image-tags.yml`, which runs on **PRs** and records the **newest already-published** GHCR image:

```yaml
--jq '... | map(select(test("^[0-9]{4}-"))) | .[0]'   # newest existing image
```

But a PR's own runner image isn't built until it lands on `main` (`runner-image.yaml` triggers on `push: main, paths: runner/**`). So at PR time the "newest" image is the **previous** build — the chart records `N-1`'s runner image while shipping `N`'s code.

This is exactly what shipped **rc-5**: cut at commit `5b2521dc` (which has the `pod_script_run_enricher` allowlist fix, #453), but its `values.yaml` pinned `runner.image.tag: 2026-06-02T08-54-58_42d1e24…` — the **#451** build, *before* #453. So every environment on rc-5 runs an agent without the fix (e.g. `iteration-test` rejecting `pod_script_run_enricher` and `jaeger_query_*`).

## Fix

Pin authoritatively **at release time**: select the newest `nudgebee-agent` image whose embedded commit SHA is an **ancestor of the release commit**, and **fail the release** if none exists. A released chart can no longer ship a runner image that predates — or isn't part of — its own code. Applied to both `release-rc.yml` and `release.yml`.

The PR-time `update-image-tags.yml` can stay (handy for dev), but it's no longer authoritative for releases.

## Verification

Simulated the new logic against real GHCR tags + repo history:

| Release HEAD | old (rc-5 shipped) | **new pick** |
|---|---|---|
| `5b2521dc` (#453) | `08-54_42d1e24` ❌ | **`11-50_5b2521dc`** ✅ |
| `42d1e24` (#451) | — | **`08-54_42d1e24`** ✅ (own image, not a newer non-ancestor) |

- Both workflow YAMLs validate.
- Logic is portable (`while read … done < <(…)`, `git merge-base --is-ancestor`).

## Notes

- Added `packages: read` to both release jobs (needed to read GHCR tags).
- `runner-image.yaml` builds only for `main` commits touching `runner/**`; the ancestor walk handles release commits that are chart-only by selecting the latest runner build in their history.
- Does **not** retro-fix rc-5 — re-cut an rc (or override `runner.image.tag`) to roll the fix to environments already on rc-5.

## Type of change

- [x] Build / CI