### PR TITLE
feat(opencost): respect OPENCOST_ENABLED so per-cluster disable stops cost polling

### DIFF
--- a/charts/nudgebee-agent/templates/runner.yaml
+++ b/charts/nudgebee-agent/templates/runner.yaml
@@ -90,6 +90,10 @@ type: Opaque
 stringData:
   NUDGEBEE_ENDPOINT: {{ .Values.runner.nudgebee.endpoint }}
   NUDGEBEE_AUTH_SECRET_KEY: {{ .Values.runner.nudgebee.auth_secret_key }}
+  # Tie cost polling/discovery to the OpenCost subchart toggle. When OpenCost is
+  # disabled the runner must NOT autodiscover a neighbouring namespace's OpenCost,
+  # so the server side detects cost is off and takes over centrally.
+  OPENCOST_ENABLED: {{ .Values.opencost.enabled | quote }}
   {{- if .Values.globalConfig.prometheus_url }}
   PROMETHEUS_URL: {{ .Values.globalConfig.prometheus_url | quote }}
   {{- end }}

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -61,7 +61,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-06-02T11-50-30_5b2521dc3f06edea44f5a89479ff65a0380c3a7a
+    tag: 2026-06-03T15-43-09_e336bf46149b67360b5bff113f5f17fb342c96b0
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -154,14 +154,13 @@ nodeAgent:
   env:
     - name: SENSITIVE_HEADERS
       value: "Authorization,Proxy-Authorization,Cookie,Set-Cookie,X-Auth-Token,X-CSRF-Token,X-Session-ID,X-JWT-Token,X-Api-Key,X-Api-Token,X-Access-Token,X-Secret-Token,X-Refresh-Token,X-User-Token,X-Firebase-Auth,X-Google-Auth,X-Authorization,X-Wsse,X-WebService-Token,Authentication,Proxy-Authentication,X-Authentication-Token,X-Device-ID,X-Device-Token,X-Device-Key"
-# OpenCost now runs centrally on the Nudgebee server side (one multi-tenant
-# instance per environment) instead of one per cluster. With this disabled the
-# agent ships no in-cluster OpenCost; the server detects that the agent's
-# OpenCost is off and computes this cluster's cost allocations centrally (it
-# reaches this cluster's Prometheus through the relay). Re-enable per cluster
-# with `--set opencost.enabled=true` to roll back to the in-cluster path.
+# OpenCost runs per-cluster in the agent by default. To move a cluster to the
+# central server-side OpenCost instead, set `--set opencost.enabled=false`: the
+# agent then ships no in-cluster OpenCost AND the runner stops discovering/polling
+# cost (see OPENCOST_ENABLED), so the server detects cost is off and computes this
+# cluster's allocations centrally (reaching its Prometheus via the relay).
 opencost:
-  enabled: false
+  enabled: true
   nameOverride: ""
   fullnameOverride: ""
   opencost:

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -154,8 +154,14 @@ nodeAgent:
   env:
     - name: SENSITIVE_HEADERS
       value: "Authorization,Proxy-Authorization,Cookie,Set-Cookie,X-Auth-Token,X-CSRF-Token,X-Session-ID,X-JWT-Token,X-Api-Key,X-Api-Token,X-Access-Token,X-Secret-Token,X-Refresh-Token,X-User-Token,X-Firebase-Auth,X-Google-Auth,X-Authorization,X-Wsse,X-WebService-Token,Authentication,Proxy-Authentication,X-Authentication-Token,X-Device-ID,X-Device-Token,X-Device-Key"
+# OpenCost now runs centrally on the Nudgebee server side (one multi-tenant
+# instance per environment) instead of one per cluster. With this disabled the
+# agent ships no in-cluster OpenCost; the server detects that the agent's
+# OpenCost is off and computes this cluster's cost allocations centrally (it
+# reaches this cluster's Prometheus through the relay). Re-enable per cluster
+# with `--set opencost.enabled=true` to roll back to the in-cluster path.
 opencost:
-  enabled: true
+  enabled: false
   nameOverride: ""
   fullnameOverride: ""
   opencost:

--- a/runner/cmd/agent/main.go
+++ b/runner/cmd/agent/main.go
@@ -185,14 +185,31 @@ func run(ctx context.Context, logger *slog.Logger, cfg *config.Config) error {
 			logger.Info("alertmanager auto-discovered", "url", u)
 		}
 	}
-	// Mirrors OpenCostDiscovery.find_open_cost_url.
-	// OPENCOST_ENDPOINT env wins; falls back to in-cluster Service lookup.
-	opencostURL := os.Getenv("OPENCOST_ENDPOINT")
-	if opencostURL == "" {
-		if u := disc.FindFirst(ctx, svcdiscover.OpencostSelectors); u != "" {
-			opencostURL = u
-			logger.Info("opencost auto-discovered", "url", u)
+	// OpenCost can be disabled at the agent (OPENCOST_ENABLED=false) — cost is then
+	// computed centrally on the server side. When disabled, skip BOTH the
+	// OPENCOST_ENDPOINT env and the cluster-wide Service autodiscovery: discovery
+	// matches `app=opencost` across all namespaces, so otherwise the agent latches
+	// onto a neighbouring namespace's OpenCost and keeps reporting itself
+	// cost-enabled, which suppresses the server-side takeover. Defaults to enabled.
+	opencostEnabled := true
+	if v := os.Getenv("OPENCOST_ENABLED"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			opencostEnabled = b
 		}
+	}
+	opencostURL := ""
+	if opencostEnabled {
+		// Mirrors OpenCostDiscovery.find_open_cost_url.
+		// OPENCOST_ENDPOINT env wins; falls back to in-cluster Service lookup.
+		opencostURL = os.Getenv("OPENCOST_ENDPOINT")
+		if opencostURL == "" {
+			if u := disc.FindFirst(ctx, svcdiscover.OpencostSelectors); u != "" {
+				opencostURL = u
+				logger.Info("opencost auto-discovered", "url", u)
+			}
+		}
+	} else {
+		logger.Info("opencost disabled (OPENCOST_ENABLED=false); skipping discovery and cost polling")
 	}
 
 	var promClient *prometheus.Client

--- a/runner/cmd/agent/main.go
+++ b/runner/cmd/agent/main.go
@@ -196,6 +196,8 @@ func run(ctx context.Context, logger *slog.Logger, cfg *config.Config) error {
 	if v := os.Getenv("OPENCOST_ENABLED"); v != "" {
 		if b, err := strconv.ParseBool(v); err == nil {
 			opencostEnabled = b
+		} else {
+			logger.Warn("invalid OPENCOST_ENABLED, defaulting to enabled", "value", v, "err", err)
 		}
 	}
 	opencostURL := ""


### PR DESCRIPTION
# Description

Makes it possible to move a single cluster's cost collection to the central server-side OpenCost, by disabling the agent's in-cluster OpenCost **effectively**. Default behaviour is unchanged — OpenCost stays enabled per-cluster unless explicitly opted out with `--set opencost.enabled=false`.

**Root cause this fixes:** the runner autodiscovers OpenCost by the `app=opencost` label across **all namespaces**. So not deploying the subchart wasn't enough — the runner would latch onto a *neighbouring* namespace's OpenCost and keep reporting `opencostConnection=true`, which suppresses the server-side takeover (the server enrolls a cluster only when its agent reports cost **off**).

## Changes
- **runner** (`cmd/agent/main.go`) — gate cost discovery + polling on `OPENCOST_ENABLED` (default `true`, backward-compatible). When `false`, skip both `OPENCOST_ENDPOINT` and the cluster-wide autodiscovery → runner reports `opencostConnection=false`.
- **runner.yaml** — wire `OPENCOST_ENABLED` into the runner secret from `opencost.enabled`.
- **values.yaml** — document the per-cluster opt-out; **default stays `opencost.enabled: true`**.

With `--set opencost.enabled=false`: no in-cluster OpenCost + runner stops cost discovery → agent reports cost off → the server-side `OpenCost Spend Sync` cron (nudgebee-enterprise#31573) pulls this cluster's allocations from central OpenCost and stores them. Rollback: `--set opencost.enabled=true`.

## Type of change

- [x] New feature (non-breaking; default behaviour unchanged)

# How Has This Been Tested?

- [x] `go build ./...` + `go vet` + `gofmt` clean; `pkg/svcdiscover` + `pkg/telemetry` tests pass
- [x] `helm template` (default) → OpenCost subchart rendered + `OPENCOST_ENABLED: "true"`
- [x] `helm template --set opencost.enabled=false` → **0** OpenCost objects + `OPENCOST_ENABLED: "false"`
- [x] `helm dependency build` succeeds