### PR TITLE
feat(rightsize): port continuous_rightsizing action from the legacy agent

### DIFF
--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -61,7 +61,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-06-05T05-00-58_65c09f10dc934851683f8bec946e0df23c4561a2
+    tag: 2026-06-08T17-03-33_3a481b67bee8817dd9e187505b6cb37988df6c1f
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -61,7 +61,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-06-03T09-09-29_128d140be7a21099785e06c81af587d62dd943c8
+    tag: 2026-06-03T15-43-09_e336bf46149b67360b5bff113f5f17fb342c96b0
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/runner/cmd/agent/main.go
+++ b/runner/cmd/agent/main.go
@@ -53,6 +53,7 @@ import (
 	"github.com/nudgebee/nudgebee-agent/pkg/podrunner"
 	"github.com/nudgebee/nudgebee-agent/pkg/podshell"
 	"github.com/nudgebee/nudgebee-agent/pkg/relay"
+	"github.com/nudgebee/nudgebee-agent/pkg/rightsize"
 	"github.com/nudgebee/nudgebee-agent/pkg/scanners"
 	"github.com/nudgebee/nudgebee-agent/pkg/servicemap"
 	"github.com/nudgebee/nudgebee-agent/pkg/svcdiscover"
@@ -531,6 +532,24 @@ func run(ctx context.Context, logger *slog.Logger, cfg *config.Config) error {
 			"loki_rules_url", cfg.LokiRulesURL,
 			"install_namespace", installNs,
 			"actions", len(mh))
+	}
+
+	// continuous_rightsizing: samples Prometheus usage and patches workload
+	// resource requests/limits (recommend_only skips the patch). Needs both
+	// Prometheus (usage) and the dynamic client (read + Update across
+	// Deployment/StatefulSet/DaemonSet/ReplicaSet/Rollout). Driven by
+	// runbook-server's optimizer over the relay's shared-secret /request path —
+	// unsigned, same trust posture as the alert-rule mutations carved in above —
+	// so it goes in lightActions. Skipped when either client is unavailable
+	// rather than registered as a fail-auth stub.
+	if promClient != nil && dynamicKube != nil {
+		rs := rightsize.New(promClient, dynamicKube)
+		maps.Copy(handlers, rightsize.Handlers(rs))
+		lightActions["continuous_rightsizing"] = struct{}{}
+		logger.Info("continuous_rightsizing enabled")
+	} else {
+		logger.Warn("continuous_rightsizing disabled — needs both Prometheus and a dynamic K8s client",
+			"prometheus", promClient != nil, "dynamic_client", dynamicKube != nil)
 	}
 
 	// Read primitives are light-action (no signature). Mutations and pod-exec

--- a/runner/pkg/rightsize/handlers.go
+++ b/runner/pkg/rightsize/handlers.go
@@ -1,0 +1,157 @@
+package rightsize
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/nudgebee/nudgebee-agent/pkg/dispatch"
+)
+
+// Handlers wires the continuous_rightsizing action into the dispatch registry.
+//
+// The action is driven by runbook-server (manual workflow task + AutoOptimize
+// generator) via the relay's synchronous /request path. It samples Prometheus
+// and — unless recommend_only — patches workload resource requests/limits.
+func Handlers(r *Rightsizer) map[string]dispatch.Handler {
+	return map[string]dispatch.Handler{
+		"continuous_rightsizing": r.handle,
+	}
+}
+
+// handle parses the {settings, applications} action_params, runs the rightsizer
+// and returns the legacy response envelope: {success, data:[ApplicationResource]}.
+// On failure it returns success=false with the error message so runbook-server's
+// checkContinuousRightsizeAgentResp surfaces it (the dispatcher still replies
+// HTTP 200; in-band success drives the task outcome).
+func (r *Rightsizer) handle(ctx context.Context, params map[string]any) (any, error) {
+	s, err := parseSettings(params["settings"])
+	if err != nil {
+		return failure(err), nil
+	}
+	apps, err := parseApplications(params["applications"])
+	if err != nil {
+		return failure(err), nil
+	}
+	if len(apps) == 0 {
+		return failure(fmt.Errorf("rightsize: no applications provided")), nil
+	}
+
+	results, err := r.Run(ctx, s, apps)
+	if err != nil {
+		return failure(err), nil
+	}
+	return map[string]any{"success": true, "data": results}, nil
+}
+
+func failure(err error) map[string]any {
+	return map[string]any{"success": false, "data": nil, "msg": err.Error()}
+}
+
+// parseSettings resolves the wire settings (with backend defaults) into a
+// Settings. Notably: default_min_memory arrives in MiB and is converted to
+// bytes; a percentile of 0 ("NB Algo") falls back to the default percentile.
+func parseSettings(raw any) (Settings, error) {
+	m, _ := raw.(map[string]any)
+	if m == nil {
+		return Settings{}, fmt.Errorf("rightsize: missing settings")
+	}
+
+	s := Settings{
+		MinCPU:             numOr(m, "default_min_cpu", defaultMinCPU),
+		MinMemoryBytes:     numOr(m, "default_min_memory", 0) * 1024 * 1024, // MiB → bytes
+		OOMKillFactor:      numOr(m, "oom_kill_increase_factor", defaultOOMKillFactor),
+		ChangeThreshold:    numOr(m, "change_threshold", defaultChangeThreshold),
+		MaxChangeThreshold: numOr(m, "max_change_threshold", defaultMaxChangeThreshold),
+		CPUPercentile:      numOr(m, "cpu_analysis_percentile", 0),
+		MemoryPercentile:   numOr(m, "memory_analysis_percentile", 0),
+		AnalysisDuration:   int(numOr(m, "default_analysis_duration_hour", defaultAnalysisDuration)),
+		RecommendOnly:      boolOr(m, "recommend_only", false),
+		Identifier:         strField(m, "identifier"),
+	}
+
+	if s.MinMemoryBytes <= 0 {
+		s.MinMemoryBytes = defaultMinMemoryBytes
+	}
+	if s.OOMKillFactor <= 0 {
+		s.OOMKillFactor = defaultOOMKillFactor
+	}
+	if s.MaxChangeThreshold <= 0 {
+		s.MaxChangeThreshold = defaultMaxChangeThreshold
+	}
+	if s.AnalysisDuration <= 0 {
+		s.AnalysisDuration = defaultAnalysisDuration
+	}
+	// percentile 0 means "use the agent default" (the "NB Algo" form option).
+	if s.CPUPercentile <= 0 {
+		s.CPUPercentile = defaultPercentile
+	}
+	if s.MemoryPercentile <= 0 {
+		s.MemoryPercentile = defaultPercentile
+	}
+	return s, nil
+}
+
+func parseApplications(raw any) ([]Application, error) {
+	list, _ := raw.([]any)
+	if list == nil {
+		return nil, fmt.Errorf("rightsize: applications must be a list")
+	}
+	apps := make([]Application, 0, len(list))
+	for _, item := range list {
+		m, _ := item.(map[string]any)
+		if m == nil {
+			continue
+		}
+		app := Application{
+			Name:      strField(m, "name"),
+			Namespace: strField(m, "namespace"),
+			Kind:      strField(m, "kind"),
+		}
+		if app.Name == "" || app.Namespace == "" || app.Kind == "" {
+			return nil, fmt.Errorf("rightsize: application requires name, namespace and kind (got %+v)", m)
+		}
+		apps = append(apps, app)
+	}
+	return apps, nil
+}
+
+// numOr coerces a JSON number/string at key into float64, falling back to def.
+func numOr(m map[string]any, key string, def float64) float64 {
+	v, ok := m[key]
+	if !ok {
+		return def
+	}
+	switch t := v.(type) {
+	case float64:
+		return t
+	case int:
+		return float64(t)
+	case int64:
+		return float64(t)
+	case json.Number:
+		if f, err := t.Float64(); err == nil {
+			return f
+		}
+	case string:
+		if f, err := strconv.ParseFloat(t, 64); err == nil {
+			return f
+		}
+	}
+	return def
+}
+
+func boolOr(m map[string]any, key string, def bool) bool {
+	if v, ok := m[key].(bool); ok {
+		return v
+	}
+	return def
+}
+
+func strField(m map[string]any, key string) string {
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
+}

--- a/runner/pkg/rightsize/rightsize.go
+++ b/runner/pkg/rightsize/rightsize.go
@@ -1,0 +1,531 @@
+// Package rightsize implements the `continuous_rightsizing` action — a port of
+// the legacy Python agent's rightsizing module (handled inline in the old
+// receiver). For each requested workload it samples CPU/memory usage from
+// Prometheus, computes a recommendation per the configured percentile +
+// OOM-kill + floor + change-threshold rules, and — unless recommend_only —
+// patches the workload's container resource requests/limits in place.
+//
+// Two deliberate deviations from the original, both documented at the call
+// site: (1) default_min_memory arrives from the backend in MiB and is converted
+// to bytes here so the memory floor actually applies (the Python max() compared
+// bytes against a MiB-magnitude number, silently no-op-ing the floor); (2) the
+// memory percentile window uses the full analysis duration instead of a
+// hard-coded 1h, matching the user-facing "Analysis Duration" field.
+package rightsize
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/nudgebee/nudgebee-agent/pkg/observability/prometheus"
+)
+
+// Defaults mirror schedule/rightsizing.py module constants.
+const (
+	defaultMinCPU             = 0.01
+	defaultMinMemoryBytes     = 5 * 10 * 1024 * 1024 // 52,428,800 (~50Mi)
+	defaultOOMKillFactor      = 1.4
+	defaultChangeThreshold    = 15.0
+	defaultMaxChangeThreshold = 100.0
+	defaultPercentile         = 99.99
+	defaultAnalysisDuration   = 24
+	memoryLimitHeadroom       = 1.4 // recommended limit = request * 1.4
+)
+
+// annotationKey is the workload annotation the backend reads to correlate an
+// applied change with its originating run. Matches the legacy
+// VerticalRightsizeAnnotation.complete_key:
+// "<base>/V1.continuous-rightsize.vertical-scaler".
+const annotationKey = "workloads.nudgebee.com/V1.continuous-rightsize.vertical-scaler"
+
+// Settings is the resolved per-run configuration. All memory values are bytes.
+type Settings struct {
+	MinCPU             float64
+	MinMemoryBytes     float64
+	OOMKillFactor      float64
+	ChangeThreshold    float64
+	MaxChangeThreshold float64
+	CPUPercentile      float64
+	MemoryPercentile   float64
+	AnalysisDuration   int
+	RecommendOnly      bool
+	Identifier         string
+}
+
+// Application identifies one workload to rightsize.
+type Application struct {
+	Name      string
+	Namespace string
+	Kind      string
+}
+
+// supportedKinds maps the user-facing kind to its GVR. All are namespace-scoped
+// and expose containers at spec.template.spec.containers.
+var supportedKinds = map[string]schema.GroupVersionResource{
+	"Deployment":  {Group: "apps", Version: "v1", Resource: "deployments"},
+	"StatefulSet": {Group: "apps", Version: "v1", Resource: "statefulsets"},
+	"DaemonSet":   {Group: "apps", Version: "v1", Resource: "daemonsets"},
+	"ReplicaSet":  {Group: "apps", Version: "v1", Resource: "replicasets"},
+	"Rollout":     {Group: "argoproj.io", Version: "v1alpha1", Resource: "rollouts"},
+}
+
+// Rightsizer holds the clients the action needs: Prometheus for usage sampling
+// and a dynamic client for reading + patching workloads of any supported kind.
+type Rightsizer struct {
+	prom *prometheus.Client
+	dyn  dynamic.Interface
+}
+
+// New builds a Rightsizer. Both clients are required; main only registers the
+// action when each is available.
+func New(prom *prometheus.Client, dyn dynamic.Interface) *Rightsizer {
+	return &Rightsizer{prom: prom, dyn: dyn}
+}
+
+// Run rightsizes each application and returns one result object per workload,
+// shaped to match the legacy ApplicationResource (name, namespace, kind,
+// containers[]). Only hard failures (workload not found, update rejected,
+// malformed spec) abort the run; an out-of-bounds recommendation is skipped
+// per-resource and surfaced in the container's "skipped" list, not fatal.
+func (r *Rightsizer) Run(ctx context.Context, s Settings, apps []Application) ([]map[string]any, error) {
+	out := make([]map[string]any, 0, len(apps))
+	for _, app := range apps {
+		res, err := r.rightsizeWorkload(ctx, s, app)
+		if err != nil {
+			return nil, err
+		}
+		if res != nil {
+			out = append(out, res)
+		}
+	}
+	return out, nil
+}
+
+type containerStat struct {
+	cpuP99    float64 // cores
+	memoryMax float64 // bytes
+	oomKill   float64 // bytes (memory limit observed at OOMKill time, 0 if none)
+	hasData   bool
+}
+
+func (r *Rightsizer) rightsizeWorkload(ctx context.Context, s Settings, app Application) (map[string]any, error) {
+	gvr, ok := supportedKinds[app.Kind]
+	if !ok {
+		return nil, fmt.Errorf("rightsize: unsupported kind %q (supported: Deployment, StatefulSet, DaemonSet, ReplicaSet, Rollout)", app.Kind)
+	}
+
+	ri := r.dyn.Resource(gvr).Namespace(app.Namespace)
+	obj, err := ri.Get(ctx, app.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("rightsize: get %s %s/%s: %w", app.Kind, app.Namespace, app.Name, err)
+	}
+
+	containers, _, err := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "containers")
+	if err != nil || len(containers) == 0 {
+		return nil, fmt.Errorf("rightsize: %s %s/%s has no spec.template.spec.containers", app.Kind, app.Namespace, app.Name)
+	}
+
+	performUpdate := false
+	resultContainers := make([]map[string]any, 0, len(containers))
+	annotationChanges := make([]map[string]any, 0, len(containers))
+
+	for i := range containers {
+		c, _ := containers[i].(map[string]any)
+		if c == nil {
+			continue
+		}
+		name, _ := c["name"].(string)
+
+		reqCPU, reqMem, limCPU, limMem := containerResourceStrings(c)
+		currentCPU := parseCPUCores(reqCPU)
+		currentMem := parseMemBytes(reqMem)
+
+		stat, err := r.getResourceUsage(ctx, s, app, name)
+		if err != nil {
+			// Operational failure (e.g. Prometheus unreachable) — abort the
+			// workload rather than silently skip and report success.
+			return nil, fmt.Errorf("rightsize: %s %s/%s container %q: %w", app.Kind, app.Namespace, app.Name, name, err)
+		}
+		if !stat.hasData {
+			// No usage series at all for this container — nothing to base a
+			// recommendation on. Skip it (legacy: get_resource_usage → None).
+			continue
+		}
+
+		recMem := getRecommendedMemory(s, stat.memoryMax, stat.oomKill)
+		recMemLimit := recMem * memoryLimitHeadroom
+		if currentMem > recMemLimit {
+			recMemLimit = currentMem
+		}
+		recCPU := getRecommendedCPU(s, stat.cpuP99)
+
+		fmtRecMem := formatAndRoundUnit(recMem)
+		fmtRecCPU := formatAndRoundUnit(recCPU)
+		fmtRecMemLimit := formatAndRoundUnit(recMemLimit)
+
+		// Compare the *formatted* recommendation against the current request so
+		// the change-% reflects what would actually be applied (rounding folded
+		// in), matching the original.
+		recCPUcores := parseCPUCores(fmtRecCPU)
+		recMemBytes := parseMemBytes(fmtRecMem)
+
+		cpuChangePct := pctChange(recCPUcores, currentCPU)
+		memChangePct := pctChange(recMemBytes, currentMem)
+
+		// Decide each resource independently. A change within the threshold is
+		// left alone; a change at/above the max-change guard is *skipped* (not
+		// applied) and recorded — one oversized resource no longer aborts the
+		// whole run, and CPU can still be applied while memory is skipped (or
+		// vice-versa).
+		changed := false
+		var skipped []string
+		newReqCPU, newReqMem := reqCPU, reqMem
+		newLimCPU, newLimMem := limCPU, limMem
+
+		switch {
+		case memChangePct <= s.ChangeThreshold:
+			// within tolerance — leave memory as-is
+		case memChangePct >= s.MaxChangeThreshold:
+			skipped = append(skipped, fmt.Sprintf("memory change %.1f%% >= max %.0f%% (current %s → recommended %s)",
+				memChangePct, s.MaxChangeThreshold, orZero(reqMem), fmtRecMem))
+		default:
+			newReqMem = fmtRecMem
+			newLimMem = fmtRecMemLimit
+			changed = true
+		}
+
+		switch {
+		case cpuChangePct <= s.ChangeThreshold:
+			// within tolerance — leave CPU as-is
+		case cpuChangePct >= s.MaxChangeThreshold:
+			skipped = append(skipped, fmt.Sprintf("cpu change %.1f%% >= max %.0f%% (current %s → recommended %s)",
+				cpuChangePct, s.MaxChangeThreshold, orZero(reqCPU), fmtRecCPU))
+		default:
+			newReqCPU = fmtRecCPU
+			newLimCPU = "" // drop CPU limit — recommendation only sets the request
+			changed = true
+		}
+
+		if changed {
+			performUpdate = true
+			setContainerResources(c, newReqCPU, newReqMem, newLimCPU, newLimMem)
+			containers[i] = c
+		}
+
+		result := map[string]any{
+			"name": name,
+			"resources": map[string]any{
+				"requests": map[string]any{"cpu": reqCPU, "memory": reqMem},
+				"limits":   map[string]any{"cpu": limCPU, "memory": limMem},
+			},
+			// recommended_resources always reflects the computed recommendation,
+			// whether or not it was applied, so recommend_only runs and skipped
+			// resources still surface the target sizing.
+			"recommended_resources": map[string]any{
+				"requests": map[string]any{"cpu": fmtRecCPU, "memory": fmtRecMem},
+				"limits":   map[string]any{"cpu": "", "memory": fmtRecMemLimit},
+			},
+			"changed": changed,
+		}
+		if len(skipped) > 0 {
+			result["skipped"] = skipped
+		}
+		resultContainers = append(resultContainers, result)
+
+		annotationChanges = append(annotationChanges, map[string]any{
+			"container_name":      name,
+			"cpu_request":         fmtRecCPU,
+			"cpu_limit":           nil,
+			"memory_request":      fmtRecMem,
+			"memory_limit":        fmtRecMemLimit,
+			"prev_cpu_request":    nullable(reqCPU),
+			"prev_cpu_limit":      nullable(limCPU),
+			"prev_memory_request": nullable(reqMem),
+			"prev_memory_limit":   nullable(limMem),
+		})
+	}
+
+	if performUpdate && !s.RecommendOnly {
+		if err := unstructured.SetNestedSlice(obj.Object, containers, "spec", "template", "spec", "containers"); err != nil {
+			return nil, fmt.Errorf("rightsize: rebuild containers for %s %s/%s: %w", app.Kind, app.Namespace, app.Name, err)
+		}
+		writeAnnotation(obj, s.Identifier, annotationChanges)
+		if _, err := ri.Update(ctx, obj, metav1.UpdateOptions{}); err != nil {
+			return nil, fmt.Errorf("rightsize: apply %s %s/%s: %w", app.Kind, app.Namespace, app.Name, err)
+		}
+	}
+
+	return map[string]any{
+		"name":       app.Name,
+		"namespace":  app.Namespace,
+		"kind":       app.Kind,
+		"containers": resultContainers,
+	}, nil
+}
+
+// getResourceUsage samples cpu_p99, memory_max and oom_kill_limit for one
+// container. hasData is false only when neither the CPU nor the memory query
+// returned any series (so a genuinely-idle container with 0 CPU still counts).
+// CPU/memory query errors are fatal (returned); the OOM query is best-effort
+// (almost always empty) and its error is ignored.
+func (r *Rightsizer) getResourceUsage(ctx context.Context, s Settings, app Application, container string) (containerStat, error) {
+	cpu, cpuOK, err := r.queryMax(ctx, cpuUsageQuery(s, app, container))
+	if err != nil {
+		return containerStat{}, fmt.Errorf("cpu query: %w", err)
+	}
+	mem, memOK, err := r.queryMax(ctx, memoryUsageQuery(s, app, container))
+	if err != nil {
+		return containerStat{}, fmt.Errorf("memory query: %w", err)
+	}
+	oom, _, _ := r.queryMax(ctx, oomKillQuery(s, app, container))
+	return containerStat{cpuP99: cpu, memoryMax: mem, oomKill: oom, hasData: cpuOK || memOK}, nil
+}
+
+func getRecommendedCPU(s Settings, cpu float64) float64 {
+	cpu = math.Ceil(cpu*1000) / 1000.0 // round up to the nearest millicore
+	return math.Max(cpu, s.MinCPU)
+}
+
+func getRecommendedMemory(s Settings, memory, oomKillLimit float64) float64 {
+	rec := memory
+	if oomKillLimit > 0 {
+		rec = math.Max(rec, oomKillLimit*s.OOMKillFactor)
+	}
+	// The floor always applies — even after an OOM bump — so a kill at a tiny
+	// limit can't drive the recommendation below the configured minimum.
+	// (the legacy code skipped the floor on the OOM path; applying it here is safer.)
+	return math.Max(rec, s.MinMemoryBytes)
+}
+
+// pctChange returns the absolute percent change of rec vs current. A current of
+// 0 (no existing request) yields 100, matching the original — which means such
+// a container hits the max-change guard and aborts the run rather than being
+// silently sized from nothing.
+func pctChange(rec, current float64) float64 {
+	if current == 0 {
+		return 100
+	}
+	return math.Abs(rec-current) / current * 100
+}
+
+// --- Prometheus queries -----------------------------------------------------
+//
+// The cluster label (__CLUSTER__ in the legacy queries) is omitted: the agent queries its
+// own in-cluster Prometheus directly, so there is no cross-cluster selector to
+// inject (the relay substitutes __CLUSTER__ only on the proxied query path).
+
+func cpuUsageQuery(s Settings, app Application, container string) string {
+	dur := fmt.Sprintf("%dh", s.AnalysisDuration)
+	return fmt.Sprintf(
+		`quantile_over_time(%s, max(rate(container_cpu_usage_seconds_total{namespace="%s",pod=~"%s-.*",container="%s"}[1m])) by (container, pod, job, namespace)[%s:1m])`,
+		quantileFraction(s.CPUPercentile), app.Namespace, app.Name, container, dur)
+}
+
+func memoryUsageQuery(s Settings, app Application, container string) string {
+	dur := fmt.Sprintf("%dh", s.AnalysisDuration)
+	return fmt.Sprintf(
+		`quantile_over_time(%s, max(container_memory_usage_bytes{namespace="%s",pod=~"%s-.*",container="%s"}) by (container, pod, job, namespace)[%s:1m])`,
+		quantileFraction(s.MemoryPercentile), app.Namespace, app.Name, container, dur)
+}
+
+func oomKillQuery(s Settings, app Application, container string) string {
+	dur := fmt.Sprintf("%dh", s.AnalysisDuration)
+	return fmt.Sprintf(
+		`max_over_time((max(kube_pod_container_resource_limits{resource="memory",namespace="%s",pod=~"%s-.*",container="%s"}) by (pod, container, namespace, job) `+
+			`* on(pod, container, namespace, job) group_left(reason) `+
+			`max(kube_pod_container_status_last_terminated_reason{reason="OOMKilled",namespace="%s",pod=~"%s-.*",container="%s"}) by (pod, container, job, namespace, reason))[%s:1m])`,
+		app.Namespace, app.Name, container, app.Namespace, app.Name, container, dur)
+}
+
+// quantileFraction converts a percentile (0-100) to the fraction PromQL's
+// quantile_over_time expects, rounded to 2 decimals exactly like the original
+// (round(p/100, 2) — note 99.99 collapses to 1.0, i.e. the peak).
+func quantileFraction(percentile float64) string {
+	f := math.Round(percentile) / 100
+	if f > 1 {
+		f = 1
+	}
+	if f < 0 {
+		f = 0
+	}
+	return strconv.FormatFloat(f, 'g', -1, 64)
+}
+
+// queryMax runs an instant query and returns the max sample value across all
+// returned series, plus whether any series was returned. An operational error
+// (Prometheus down, HTTP error, bad JSON, status != success) is returned so the
+// caller can fail the action loudly instead of mistaking it for "no usage data"
+// — which on a mutating action would silently skip every container and report
+// success. An empty-but-successful result is NOT an error (hasData=false).
+func (r *Rightsizer) queryMax(ctx context.Context, promQL string) (float64, bool, error) {
+	raw, err := r.prom.Query(ctx, promQL, "", "30s")
+	if err != nil {
+		return 0, false, err
+	}
+	var resp struct {
+		Status string `json:"status"`
+		Data   struct {
+			ResultType string `json:"resultType"`
+			Result     []struct {
+				Value []any `json:"value"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return 0, false, fmt.Errorf("decode prometheus response: %w", err)
+	}
+	if resp.Status != "success" {
+		return 0, false, fmt.Errorf("prometheus query status %q", resp.Status)
+	}
+	max := math.NaN()
+	for _, series := range resp.Data.Result {
+		if len(series.Value) < 2 {
+			continue
+		}
+		v, ok := toFloat(series.Value[1])
+		if !ok || math.IsNaN(v) {
+			continue
+		}
+		if math.IsNaN(max) || v > max {
+			max = v
+		}
+	}
+	if math.IsNaN(max) {
+		return 0, len(resp.Data.Result) > 0, nil
+	}
+	return max, true, nil
+}
+
+// --- workload (unstructured) helpers ---------------------------------------
+
+// containerResourceStrings extracts the request/limit cpu+memory strings from
+// an unstructured container map. Missing values come back as "".
+func containerResourceStrings(c map[string]any) (reqCPU, reqMem, limCPU, limMem string) {
+	res, _ := c["resources"].(map[string]any)
+	if res == nil {
+		return "", "", "", ""
+	}
+	if req, _ := res["requests"].(map[string]any); req != nil {
+		reqCPU = asString(req["cpu"])
+		reqMem = asString(req["memory"])
+	}
+	if lim, _ := res["limits"].(map[string]any); lim != nil {
+		limCPU = asString(lim["cpu"])
+		limMem = asString(lim["memory"])
+	}
+	return reqCPU, reqMem, limCPU, limMem
+}
+
+// setContainerResources writes the new request/limit values back into the
+// unstructured container map, creating the resources/requests/limits maps as
+// needed. An empty value clears that key.
+func setContainerResources(c map[string]any, reqCPU, reqMem, limCPU, limMem string) {
+	res, _ := c["resources"].(map[string]any)
+	if res == nil {
+		res = map[string]any{}
+	}
+	req, _ := res["requests"].(map[string]any)
+	if req == nil {
+		req = map[string]any{}
+	}
+	lim, _ := res["limits"].(map[string]any)
+	if lim == nil {
+		lim = map[string]any{}
+	}
+
+	setOrDelete(req, "cpu", reqCPU)
+	setOrDelete(req, "memory", reqMem)
+	setOrDelete(lim, "cpu", limCPU)
+	setOrDelete(lim, "memory", limMem)
+
+	res["requests"] = req
+	if len(lim) == 0 {
+		delete(res, "limits")
+	} else {
+		res["limits"] = lim
+	}
+	c["resources"] = res
+}
+
+func setOrDelete(m map[string]any, key, val string) {
+	if val == "" {
+		delete(m, key)
+		return
+	}
+	m[key] = val
+}
+
+// writeAnnotation stamps the vertical-rightsize annotation onto the workload so
+// the backend can correlate the applied change with this run. Best-effort:
+// matches the legacy compact-JSON {identifier, time, container_changes}.
+func writeAnnotation(obj *unstructured.Unstructured, identifier string, changes []map[string]any) {
+	payload := map[string]any{
+		"identifier":        identifier,
+		"time":              time.Now().UTC().Format("2006-01-02T15:04:05.000000"),
+		"container_changes": changes,
+	}
+	// json.Marshal already emits compact JSON (no inter-token spaces); the
+	// original's space-stripping was both redundant and unsafe — it would
+	// corrupt any value legitimately containing a space.
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return
+	}
+	value := string(b)
+
+	ann := obj.GetAnnotations()
+	if ann == nil {
+		ann = map[string]string{}
+	}
+	ann[annotationKey] = value
+	obj.SetAnnotations(ann)
+}
+
+// --- small value helpers ----------------------------------------------------
+
+func toFloat(v any) (float64, bool) {
+	switch t := v.(type) {
+	case float64:
+		return t, true
+	case string:
+		f, err := strconv.ParseFloat(t, 64)
+		return f, err == nil
+	case json.Number:
+		f, err := t.Float64()
+		return f, err == nil
+	}
+	return 0, false
+}
+
+func asString(v any) string {
+	if v == nil {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return fmt.Sprintf("%v", v)
+}
+
+func nullable(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+func orZero(s string) string {
+	if s == "" {
+		return "0"
+	}
+	return s
+}

--- a/runner/pkg/rightsize/rightsize_test.go
+++ b/runner/pkg/rightsize/rightsize_test.go
@@ -1,0 +1,207 @@
+package rightsize
+
+import (
+	"math"
+	"testing"
+)
+
+func TestFormatAndRoundUnit(t *testing.T) {
+	cases := []struct {
+		in   float64
+		want string
+	}{
+		{0.05, "50m"},        // sub-core CPU → millicpu
+		{0.01, "10m"},        // min CPU floor
+		{0.5, "500m"},        // half a core
+		{2, "2"},             // whole cores, bare
+		{104857600, "100Mi"}, // 100 MiB exactly
+		{100 * 1024 * 1024, "100Mi"},
+		{1073741824, "1030Mi"}, // 1 GiB → Mi (1024 rounded UP to nearest 10)
+		{0, "0m"},              // x<1 path → int(0*1000)=0 → "0m"
+	}
+	for _, c := range cases {
+		if got := formatAndRoundUnit(c.in); got != c.want {
+			t.Errorf("formatAndRoundUnit(%v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestParseCPUCores(t *testing.T) {
+	cases := []struct {
+		in   string
+		want float64
+	}{
+		{"250m", 0.25},
+		{"1", 1},
+		{"2.5", 2.5},
+		{"", 0},
+		{"garbage", 0},
+	}
+	for _, c := range cases {
+		if got := parseCPUCores(c.in); math.Abs(got-c.want) > 1e-9 {
+			t.Errorf("parseCPUCores(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestParseMemBytes(t *testing.T) {
+	cases := []struct {
+		in   string
+		want float64
+	}{
+		{"100Mi", 100 * 1024 * 1024},
+		{"1Gi", 1024 * 1024 * 1024},
+		{"1000000", 1000000},
+		{"", 0},
+		{"nope", 0},
+	}
+	for _, c := range cases {
+		if got := parseMemBytes(c.in); math.Abs(got-c.want) > 1e-3 {
+			t.Errorf("parseMemBytes(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestGetRecommendedCPU(t *testing.T) {
+	s := Settings{MinCPU: 0.01}
+	// rounds up to nearest millicore
+	if got := getRecommendedCPU(s, 0.1234); got != 0.124 {
+		t.Errorf("getRecommendedCPU(0.1234) = %v, want 0.124", got)
+	}
+	// floor applies
+	if got := getRecommendedCPU(s, 0.001); got != 0.01 {
+		t.Errorf("getRecommendedCPU(0.001) = %v, want 0.01 (floor)", got)
+	}
+}
+
+func TestGetRecommendedMemory(t *testing.T) {
+	s := Settings{MinMemoryBytes: 50 * 1024 * 1024, OOMKillFactor: 1.5}
+
+	// no OOM, usage above floor → usage wins
+	usage := 200.0 * 1024 * 1024
+	if got := getRecommendedMemory(s, usage, 0); got != usage {
+		t.Errorf("getRecommendedMemory(usage, 0) = %v, want %v", got, usage)
+	}
+	// no OOM, usage below floor → floor wins
+	if got := getRecommendedMemory(s, 10*1024*1024, 0); got != s.MinMemoryBytes {
+		t.Errorf("getRecommendedMemory(below-floor, 0) = %v, want floor %v", got, s.MinMemoryBytes)
+	}
+	// OOM observed → max(usage, oom*factor)
+	oom := 300.0 * 1024 * 1024
+	want := oom * 1.5
+	if got := getRecommendedMemory(s, usage, oom); got != want {
+		t.Errorf("getRecommendedMemory(usage, oom) = %v, want %v", got, want)
+	}
+}
+
+func TestPctChange(t *testing.T) {
+	if got := pctChange(120, 100); math.Abs(got-20) > 1e-9 {
+		t.Errorf("pctChange(120,100) = %v, want 20", got)
+	}
+	if got := pctChange(80, 100); math.Abs(got-20) > 1e-9 {
+		t.Errorf("pctChange(80,100) = %v, want 20", got)
+	}
+	// no current request → 100 (hits max-change guard, matches original)
+	if got := pctChange(50, 0); got != 100 {
+		t.Errorf("pctChange(50,0) = %v, want 100", got)
+	}
+}
+
+func TestQuantileFraction(t *testing.T) {
+	cases := []struct {
+		in   float64
+		want string
+	}{
+		{99.99, "1"}, // round(0.9999, 2) = 1.0 → peak
+		{99, "0.99"},
+		{95, "0.95"},
+		{50, "0.5"},
+	}
+	for _, c := range cases {
+		if got := quantileFraction(c.in); got != c.want {
+			t.Errorf("quantileFraction(%v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestParseSettings(t *testing.T) {
+	raw := map[string]any{
+		"default_min_cpu":                0.01,
+		"default_min_memory":             float64(100), // MiB
+		"oom_kill_increase_factor":       1.5,
+		"change_threshold":               float64(10),
+		"cpu_analysis_percentile":        float64(0), // NB Algo → default
+		"memory_analysis_percentile":     float64(95),
+		"default_analysis_duration_hour": float64(24),
+		"recommend_only":                 false,
+		"identifier":                     "tenant/acct/wf/uuid",
+	}
+	s, err := parseSettings(raw)
+	if err != nil {
+		t.Fatalf("parseSettings error: %v", err)
+	}
+	if s.MinMemoryBytes != 100*1024*1024 {
+		t.Errorf("MinMemoryBytes = %v, want %v (100 MiB → bytes)", s.MinMemoryBytes, 100*1024*1024)
+	}
+	if s.CPUPercentile != defaultPercentile {
+		t.Errorf("CPUPercentile = %v, want default %v (0 → NB Algo)", s.CPUPercentile, defaultPercentile)
+	}
+	if s.MemoryPercentile != 95 {
+		t.Errorf("MemoryPercentile = %v, want 95", s.MemoryPercentile)
+	}
+	if s.MaxChangeThreshold != defaultMaxChangeThreshold {
+		t.Errorf("MaxChangeThreshold = %v, want default %v (not sent)", s.MaxChangeThreshold, defaultMaxChangeThreshold)
+	}
+	if s.ChangeThreshold != 10 {
+		t.Errorf("ChangeThreshold = %v, want 10", s.ChangeThreshold)
+	}
+	if s.Identifier != "tenant/acct/wf/uuid" {
+		t.Errorf("Identifier = %q", s.Identifier)
+	}
+}
+
+func TestParseApplications(t *testing.T) {
+	raw := []any{
+		map[string]any{"name": "ad", "namespace": "demo", "kind": "Deployment"},
+	}
+	apps, err := parseApplications(raw)
+	if err != nil {
+		t.Fatalf("parseApplications error: %v", err)
+	}
+	if len(apps) != 1 || apps[0].Name != "ad" || apps[0].Kind != "Deployment" {
+		t.Fatalf("unexpected apps: %+v", apps)
+	}
+
+	// missing kind → error
+	if _, err := parseApplications([]any{map[string]any{"name": "ad", "namespace": "demo"}}); err == nil {
+		t.Error("expected error for application missing kind")
+	}
+}
+
+func TestSetContainerResources(t *testing.T) {
+	c := map[string]any{
+		"name": "app",
+		"resources": map[string]any{
+			"requests": map[string]any{"cpu": "100m", "memory": "64Mi"},
+			"limits":   map[string]any{"cpu": "200m", "memory": "128Mi"},
+		},
+	}
+	// new cpu request, drop cpu limit, bump memory
+	setContainerResources(c, "250m", "200Mi", "", "280Mi")
+
+	res := c["resources"].(map[string]any)
+	req := res["requests"].(map[string]any)
+	if req["cpu"] != "250m" || req["memory"] != "200Mi" {
+		t.Errorf("requests = %+v", req)
+	}
+	lim, _ := res["limits"].(map[string]any)
+	if lim == nil {
+		t.Fatalf("limits dropped entirely, want memory limit retained")
+	}
+	if _, ok := lim["cpu"]; ok {
+		t.Errorf("cpu limit should be removed, got %+v", lim)
+	}
+	if lim["memory"] != "280Mi" {
+		t.Errorf("memory limit = %v, want 280Mi", lim["memory"])
+	}
+}

--- a/runner/pkg/rightsize/units.go
+++ b/runner/pkg/rightsize/units.go
@@ -1,0 +1,72 @@
+package rightsize
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// parseCPUCores parses a Kubernetes CPU quantity string ("250m", "0.5", "2")
+// into cores. Mirrors the legacy PodResources.parse_cpu; returns 0 on empty /
+// unparseable input (the original was equally defensive).
+func parseCPUCores(cpu string) float64 {
+	cpu = strings.TrimSpace(cpu)
+	if cpu == "" {
+		return 0
+	}
+	q, err := resource.ParseQuantity(cpu)
+	if err != nil {
+		return 0
+	}
+	return q.AsApproximateFloat64()
+}
+
+// parseMemBytes parses a Kubernetes memory quantity ("100Mi", "1Gi", "1000000")
+// into bytes. Returns 0 on empty / unparseable input.
+func parseMemBytes(mem string) float64 {
+	mem = strings.TrimSpace(mem)
+	if mem == "" {
+		return 0
+	}
+	q, err := resource.ParseQuantity(mem)
+	if err != nil {
+		return 0
+	}
+	return q.AsApproximateFloat64()
+}
+
+// formatAndRoundUnit renders a resource amount the way the recommendation is
+// applied to the workload, mirroring the legacy format_and_round_unit:
+//
+//   - x < 1            → millicpu, e.g. 0.05 → "50m"
+//   - 1 <= x < 500     → bare CPU cores, e.g. 2 → "2"
+//   - x >= 500         → binary memory unit (Ki/Mi/Gi/…), value rounded UP to
+//     the nearest 10 in the chosen unit, e.g. 104857600 → "100Mi"
+//
+// The >=500 branch assumes a memory byte count (no workload requests 500 CPUs,
+// and 500 bytes of memory is never a real allocation) — the same heuristic the
+// original relied on.
+func formatAndRoundUnit(x float64) string {
+	const base = 1024.0
+	if x < 1 {
+		return fmt.Sprintf("%dm", int(x*1000))
+	}
+	if x < 500 { // CPU cores
+		return strconv.FormatFloat(x, 'g', -1, 64)
+	}
+
+	units := []string{"", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei"}
+	xi := math.Floor(x)
+	for i, unit := range units {
+		nextPow := math.Pow(base, float64(i+1))
+		if xi < nextPow || i == len(units)-1 || xi/nextPow < 10 {
+			value := xi / math.Pow(base, float64(i))
+			value = math.Ceil(value/10) * 10 // round up to nearest 10
+			return fmt.Sprintf("%.0f%s", value, unit)
+		}
+	}
+	return fmt.Sprintf("%d", int(xi))
+}


### PR DESCRIPTION
## Summary

The runbook-server optimizer drives a `continuous_rightsizing` agent action (task `k8s.continuous_rightsize`) over the relay, but it was **never ported** when the legacy agent was replaced — the runner had no handler, so requests failed auth (`auth: action "continuous_rightsizing" not in light-action allowlist`, HTTP 401) and would otherwise have 404'd.

This adds `runner/pkg/rightsize` implementing the action:

- Samples CPU p99 / memory percentile / OOM-kill limit from Prometheus.
- Computes recommendations (CPU/memory floors, OOM-kill increase factor, change-threshold gating).
- Reads + patches workload container requests/limits via the **dynamic client** across `Deployment`/`StatefulSet`/`DaemonSet`/`ReplicaSet`/`Rollout` (`recommend_only` skips the patch); stamps the `workloads.nudgebee.com/V1.continuous-rightsize.vertical-scaler` annotation on apply.
- Returns the legacy `{success, data:[ApplicationResource]}` envelope so `runbook-server`'s `checkContinuousRightsizeAgentResp` consumes it unchanged.

Registered in `cmd/agent` and added to the **light-action allowlist**: it arrives unsigned over the relay's shared-secret `/request` path — the same trust posture as the alert-rule mutations already carved into `lightActions` (and `pod_script_run_enricher` in #453). No cloud-side request signing exists today.

### Deviations from the legacy original (all commented at the call site)

- `default_min_memory` is treated as **MiB** (the unit the backend actually sends) and converted to bytes, so the memory floor applies — the Python `max()` compared bytes against a MiB-magnitude number and silently no-op'd the floor.
- Memory percentile window uses the **full analysis duration** instead of a hard-coded 1h.
- Percentile `0` ("NB Algo") falls back to the default percentile.
- An out-of-bounds (`>= max-change`) recommendation is **skipped per-resource** and surfaced in the container's `skipped` list, instead of aborting the whole run as the legacy code did.

## How it gets called

Two triggers in `runbook-server`, both converging on the same task and relay call:

1. **Manual / on-demand** — RPC `workflow_trigger_task` with `task_type: "k8s.continuous_rightsize"` (+ form params) → `handleExecuteTask` → `workflowService.ExecuteTask(...)`.
2. **AutoOptimize scheduler** — a `continuous_rightsize` rule runs on cron `*/15 * * * *`; `ContinuousRightsizeGenerator` emits a task whose `Meta` already carries `action_name: "continuous_rightsizing"` + a built `action_params` (`recommend_only` from dry-run).

Both land in `ContinuousRightsizeTask.Execute`, which shapes `{settings, applications}` (manual path) or uses the generator's `action_params`, then calls `relay.ExecuteRelay(ActionExecuteBody{ ActionName: "continuous_rightsizing", ... })`:

```
runbook-server ──POST /request (X-SECRET-KEY)──▶ relay-server
relay-server ──RabbitMQ relay_requests_{accountID} + agent WebSocket──▶ k8s-agent
k8s-agent relay.Client (persistent WS to /register) ──▶ dispatch.Handle
   ├─ body.action_name = "continuous_rightsizing"
   ├─ auth: no signature/partial-keys → light-action check → PASS (this PR's allowlist entry; was the 401)
   └─ handlers["continuous_rightsizing"] → Rightsizer.handle
         └─ read workload (dynamic client) → query Prometheus per container
            → compute recommendation → patch + annotate (unless recommend_only)
            → reply {success, data:[ApplicationResource]}
```

`runbook-server`'s `checkContinuousRightsizeAgentResp` then reads `success`/`status_code` and marks the task COMPLETED or FAILED.

> The action is only registered when the agent has **both** a Prometheus URL and a dynamic K8s client at startup; otherwise `cmd/agent` logs `continuous_rightsizing disabled` and the dispatcher 404s the action.

## Type of change

- [x] New feature (non-breaking)

## Chart version

- [ ] ~~I bumped `version` in `charts/nudgebee-agent/Chart.yaml`~~
- [x] No chart change in this PR — this is **runner (Go) code only**; the chart/image release handles versioning. Flag if a chart bump should ride along.

## Test plan

This is a runner Go change, so the Helm/`ct` checks below don't apply; the relevant verification:

- [x] `go build ./...` passes
- [x] `go test ./pkg/rightsize/...` passes (units, recommendation math, settings/app parsing, container patch)
- [x] `gofmt -l` clean, `go vet ./pkg/rightsize/... ./cmd/agent/...` clean
- [ ] `golangci-lint` — **not run locally** (local binary is go1.25; module targets go1.26.3). Relying on CI.
- [ ] **Not yet installed / verified on a real cluster** — PromQL query shapes and the dynamic read/patch are unit-tested but not integration-verified end-to-end.

## Related issues

<!-- No tracking issue linked yet — add one if there is a feature-request issue for this. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

