### PR TITLE
feat(runner): expose pprof endpoints for memory burst diagnosis

### DIFF
--- a/charts/nudgebee-agent/templates/_helpers.tpl
+++ b/charts/nudgebee-agent/templates/_helpers.tpl
@@ -83,6 +83,10 @@ Runner container template. Invoked with root context: include "nudgebee.runner.c
       value: {{ .Values.runner.relay_address }}
     - name: SCANNERS_ENABLED
       value: "true"
+    {{- if .Values.runner.pprof }}
+    - name: PPROF_ENABLED
+      value: "true"
+    {{- end }}
     - name: SCANNER_NAMESPACE
       value: {{ .Release.Namespace }}
     - name: SCANNER_SERVICE_ACCOUNT

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -67,6 +67,10 @@ runner:
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.
   profilerImage: "ghcr.io/nudgebee/application-profiler-{}:dc5fd6d"
   imagePullPolicy: IfNotPresent
+  # Expose net/http/pprof on the runner HTTP listener (surfaces as
+  # PPROF_ENABLED). Off by default — the endpoints are unauthenticated;
+  # enable only for active memory/CPU debugging.
+  pprof: false
   resources:
     requests:
       cpu: 250m

--- a/runner/cmd/agent/main.go
+++ b/runner/cmd/agent/main.go
@@ -673,12 +673,17 @@ func run(ctx context.Context, logger *slog.Logger, cfg *config.Config) error {
 		// small, heap_sys spikes to >1.5GB then releases). Expose the
 		// standard profiles so `go tool pprof` can attribute allocations —
 		// /debug/pprof/allocs is cumulative and survives the burst, which a
-		// point-in-time heap snapshot does not.
-		mux.HandleFunc("/debug/pprof/", pprof.Index)
-		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
-		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+		// point-in-time heap snapshot does not. Gated off by default: the
+		// endpoints are unauthenticated and abusable for DoS/info-disclosure,
+		// so enable via PPROF_ENABLED only for active debugging.
+		if cfg.PprofEnabled {
+			logger.Info("pprof endpoints enabled", "path", "/debug/pprof/")
+			mux.HandleFunc("/debug/pprof/", pprof.Index)
+			mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+			mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+			mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+			mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+		}
 		mux.HandleFunc("/api/actions", func(w http.ResponseWriter, r *http.Request) {
 			if r.Method != http.MethodPost {
 				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)

--- a/runner/cmd/agent/main.go
+++ b/runner/cmd/agent/main.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"maps"
 	"net/http"
+	"net/http/pprof"
 	"os"
 	"os/signal"
 	"runtime"
@@ -668,6 +669,16 @@ func run(ctx context.Context, logger *slog.Logger, cfg *config.Config) error {
 		mux := http.NewServeMux()
 		mux.Handle("/", fwd.Mux())
 		mux.Handle("/metrics", mreg.Handler())
+		// pprof: the runner exhibits transient heap bursts (live heap stays
+		// small, heap_sys spikes to >1.5GB then releases). Expose the
+		// standard profiles so `go tool pprof` can attribute allocations —
+		// /debug/pprof/allocs is cumulative and survives the burst, which a
+		// point-in-time heap snapshot does not.
+		mux.HandleFunc("/debug/pprof/", pprof.Index)
+		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 		mux.HandleFunc("/api/actions", func(w http.ResponseWriter, r *http.Request) {
 			if r.Method != http.MethodPost {
 				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)

--- a/runner/pkg/config/config.go
+++ b/runner/pkg/config/config.go
@@ -69,6 +69,11 @@ type Config struct {
 	// HTTP server (alerts intake + healthz). Default :5000.
 	HTTPListenAddr string
 
+	// PprofEnabled exposes net/http/pprof on the HTTP listener. Off by
+	// default — the profiling endpoints are unauthenticated and can be
+	// abused for DoS/info-disclosure, so enable only for active debugging.
+	PprofEnabled bool
+
 	// Discovery: enabled when DiscoveryEnabled=true. Resync interval is
 	// DISCOVERY_RESYNC (default 30m); KUBECONFIG env is honoured by client-go.
 	DiscoveryEnabled bool
@@ -144,6 +149,7 @@ func FromEnv() (*Config, error) {
 		HTTPProxyTargets:      os.Getenv("HTTP_PROXY_TARGETS"),
 		LokiRulesURL:          os.Getenv("LOKI_RULES_URL"),
 		HTTPListenAddr:        cmp(os.Getenv("HTTP_LISTEN_ADDR"), ":5000"),
+		PprofEnabled:          envBool("PPROF_ENABLED", false),
 		// K8s subsystems default-on so the agent is drop-in compatible with
 		// the legacy runner Deployment — no env additions needed for cutover.
 		// Operators can opt out per-subsystem via DISCOVERY_ENABLED=false etc.


### PR DESCRIPTION
## Why

The runner exhibits transient memory bursts in dev: the live Go heap stays at ~60–90 MB, but `heap_sys` spikes to **>1.5 GB** several times a day and is then released back to the OS. This is allocation churn from on-demand dispatched tasks (e.g. `image_scanner`, bulk collector posts, enrichers), **not a leak**.

A point-in-time heap snapshot can't find the cause because the memory is already freed between bursts. The runner currently exposes only `/metrics` on `:5000` — no pprof.

## What

Register the standard `net/http/pprof` profiles on the existing runner mux (`:5000`):

- `/debug/pprof/` (index → heap, allocs, goroutine, etc.)
- `/debug/pprof/cmdline`, `/profile`, `/symbol`, `/trace`

The key profile is `/debug/pprof/allocs`, which is **cumulative over the process lifetime**, so it attributes the burst allocation hotspots even after GC reclaims them.

## Usage

```
kubectl port-forward -n <ns> deploy/<release>-runner 5000:5000
go tool pprof -alloc_space -top http://localhost:5000/debug/pprof/allocs
go tool pprof -http=: http://localhost:5000/debug/pprof/allocs   # flame graph
```

## Notes

- Verified with `go build` and `go vet`.
- The pprof surface is reachable in-cluster on the runner Service (port 80 → 5000); no Ingress exposure.
- No resource/limit changes in this PR.