### PR TITLE
fix(collector): emit container resource requests/limits in workload spec

### DIFF
--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -61,7 +61,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-06-03T15-43-09_e336bf46149b67360b5bff113f5f17fb342c96b0
+    tag: 2026-06-05T05-00-58_65c09f10dc934851683f8bec946e0df23c4561a2
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/runner/pkg/discovery/converters.go
+++ b/runner/pkg/discovery/converters.go
@@ -625,12 +625,56 @@ func nodeInfoMap(n *corev1.Node) map[string]any {
 func containersFromTemplate(tpl corev1.PodTemplateSpec) []map[string]any {
 	out := make([]map[string]any, 0, len(tpl.Spec.Containers))
 	for _, c := range tpl.Spec.Containers {
-		out = append(out, map[string]any{
+		entry := map[string]any{
 			"name":  c.Name,
 			"image": c.Image,
-		})
+		}
+		// Resource requests/limits feed the right-sizing engine's "allocated"
+		// baseline. Emit raw k8s quantity strings (e.g. "500m", "2Gi"), only
+		// the keys that are set, to match the format the collector consumes.
+		if res := resourceRequirementsDict(c.Resources); res != nil {
+			entry["resources"] = res
+		}
+		out = append(out, entry)
 	}
 	return out
+}
+
+// resourceRequirementsDict serializes a container's requests/limits as raw k8s
+// quantity strings. Returns nil when neither requests nor limits are set so the
+// "resources" key is omitted rather than emitted empty.
+func resourceRequirementsDict(r corev1.ResourceRequirements) map[string]any {
+	req := serializeResourceList(r.Requests)
+	lim := serializeResourceList(r.Limits)
+	if req == nil && lim == nil {
+		return nil
+	}
+	out := map[string]any{}
+	if req != nil {
+		out["requests"] = req
+	}
+	if lim != nil {
+		out["limits"] = lim
+	}
+	return out
+}
+
+// serializeResourceList emits cpu/memory from a ResourceList as raw k8s quantity
+// strings. The map is allocated lazily so a list carrying only other resources
+// (ephemeral-storage, GPUs, ...) returns nil instead of an empty map.
+func serializeResourceList(list corev1.ResourceList) map[string]any {
+	var m map[string]any
+	if v, ok := list[corev1.ResourceCPU]; ok {
+		m = make(map[string]any, 2)
+		m["cpu"] = v.String()
+	}
+	if v, ok := list[corev1.ResourceMemory]; ok {
+		if m == nil {
+			m = make(map[string]any, 1)
+		}
+		m["memory"] = v.String()
+	}
+	return m
 }
 
 func ownerInfos(owners []metav1.OwnerReference) []map[string]any {

--- a/runner/pkg/discovery/converters_test.go
+++ b/runner/pkg/discovery/converters_test.go
@@ -533,3 +533,57 @@ func TestServiceDict_PodLookupFillsRuntimeFields(t *testing.T) {
 		t.Errorf("conditions = %v", conds)
 	}
 }
+
+// containersFromTemplate must emit per-container resources (requests/limits) as
+// raw k8s quantity strings — this is the "allocated" baseline the right-sizing
+// engine reads. A regression that dropped this field left CPU/memory request
+// columns and savings blank for every workload on the cluster.
+func TestContainersFromTemplate_EmitsResources(t *testing.T) {
+	tpl := corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{
+			Name:  "app",
+			Image: "nginx:1.27",
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+			},
+		}}},
+	}
+	got := containersFromTemplate(tpl)
+	if len(got) != 1 {
+		t.Fatalf("len = %d; want 1", len(got))
+	}
+	res, ok := got[0]["resources"].(map[string]any)
+	if !ok {
+		t.Fatalf("resources missing or wrong type: %T", got[0]["resources"])
+	}
+	req := res["requests"].(map[string]any)
+	if req["cpu"] != "500m" || req["memory"] != "2Gi" {
+		t.Errorf("requests = %v; want cpu=500m memory=2Gi", req)
+	}
+	lim := res["limits"].(map[string]any)
+	if lim["memory"] != "2Gi" {
+		t.Errorf("limits memory = %v; want 2Gi", lim["memory"])
+	}
+	// Limit CPU was unset → key must be absent, not zero.
+	if _, present := lim["cpu"]; present {
+		t.Errorf("limits cpu should be absent when unset; got %v", lim["cpu"])
+	}
+}
+
+// When a container sets no requests or limits, the "resources" key is omitted
+// entirely rather than emitted empty.
+func TestContainersFromTemplate_OmitsResourcesWhenUnset(t *testing.T) {
+	tpl := corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "busybox"}}},
+	}
+	got := containersFromTemplate(tpl)
+	if _, present := got[0]["resources"]; present {
+		t.Errorf("resources should be absent when unset; got %v", got[0]["resources"])
+	}
+}


### PR DESCRIPTION
# Description

`containersFromTemplate` in `runner/pkg/discovery/converters.go` serialized each container in a workload's config as `{name, image}` only — it dropped the `resources` (requests/limits) field. That field is the **allocated** baseline the vertical right-sizing engine reads from `k8s_workloads.meta->config->containers[].resources`.

With it absent, ml-k8s-server reads `allocated = null`, so on every cluster running this agent line the right-sizing tab shows **blank CPU/Memory request columns** and the savings calculation is skipped (`estimated_savings = 0`, since the savings loop `continue`s when there is no allocated request).

This was observed on the `iteration-prod` cluster (agent `0.1.2-rc-2`): all 307 active workloads stored container specs with no `resources`, despite pods reporting `qos_class = Burstable` (which only occurs when requests/limits are actually set). Clusters on the older `0.0.x` agent serialized `resources` correctly and have populated allocation + real savings.

## Fix

Serialize `resources` as raw k8s quantity strings (e.g. `500m`, `2Gi`), matching the format the collector and ml-k8s-server already consume:
- only the keys that are set are included (an unset CPU limit is absent, not zero);
- the `resources` key is omitted entirely when a container declares neither requests nor limits.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `go build ./pkg/discovery/`, `go vet`, `gofmt` clean
- [x] Full `pkg/discovery` test package passes
- [x] Added `TestContainersFromTemplate_EmitsResources` (verifies quantity strings; unset CPU limit absent) and `TestContainersFromTemplate_OmitsResourcesWhenUnset`

Once deployed, the next workload sync repopulates `meta->config->containers[].resources` and the right-sizing UI fills in automatically — no DB backfill required.