### PR TITLE
feat(rightsize): in-place pod resize for continuous_rightsizing (zero-downtime)

### DIFF
--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -61,7 +61,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-06-08T17-03-33_3a481b67bee8817dd9e187505b6cb37988df6c1f
+    tag: 2026-06-09T06-20-22_0a83b93f21e8aed2b300de8a6618a7e15e436fa3
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/runner/cmd/agent/main.go
+++ b/runner/cmd/agent/main.go
@@ -562,7 +562,10 @@ func run(ctx context.Context, logger *slog.Logger, cfg *config.Config) error {
 	// so it goes in lightActions. Skipped when either client is unavailable
 	// rather than registered as a fail-auth stub.
 	if promClient != nil && dynamicKube != nil {
-		rs := rightsize.New(promClient, dynamicKube)
+		// typedKube (may be nil) enables zero-downtime in-place pod resize; the
+		// rightsizer falls back to the template rollout when it's unavailable or
+		// the cluster is < 1.33.
+		rs := rightsize.New(promClient, dynamicKube, typedKube)
 		maps.Copy(handlers, rightsize.Handlers(rs))
 		lightActions["continuous_rightsizing"] = struct{}{}
 		logger.Info("continuous_rightsizing enabled")

--- a/runner/pkg/rightsize/handlers.go
+++ b/runner/pkg/rightsize/handlers.go
@@ -69,6 +69,7 @@ func parseSettings(raw any) (Settings, error) {
 		AnalysisDuration:   int(numOr(m, "default_analysis_duration_hour", defaultAnalysisDuration)),
 		RecommendOnly:      boolOr(m, "recommend_only", false),
 		InPlace:            boolOr(m, "in_place", true),
+		ResizePolicy:       strField(m, "resize_policy"),
 		Identifier:         strField(m, "identifier"),
 	}
 

--- a/runner/pkg/rightsize/handlers.go
+++ b/runner/pkg/rightsize/handlers.go
@@ -68,6 +68,7 @@ func parseSettings(raw any) (Settings, error) {
 		MemoryPercentile:   numOr(m, "memory_analysis_percentile", 0),
 		AnalysisDuration:   int(numOr(m, "default_analysis_duration_hour", defaultAnalysisDuration)),
 		RecommendOnly:      boolOr(m, "recommend_only", false),
+		InPlace:            boolOr(m, "in_place", true),
 		Identifier:         strField(m, "identifier"),
 	}
 

--- a/runner/pkg/rightsize/inplace.go
+++ b/runner/pkg/rightsize/inplace.go
@@ -163,6 +163,28 @@ func resizeState(p *corev1.Pod) string {
 	return "done"
 }
 
+// resizePolicyList builds the container `resizePolicy` to stamp onto the
+// template during a rollout, so pods created afterward carry it and future
+// cycles resize them per policy. Returns nil when injection is disabled.
+//
+//	"" / default            -> cpu NotRequired, memory NotRequired (in-place both)
+//	"restart-memory"        -> cpu NotRequired, memory RestartContainer
+//	"disabled"/off/no/false -> nil (don't stamp)
+func resizePolicyList(mode string) []any {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "disabled", "off", "no", "false":
+		return nil
+	}
+	memPolicy := "NotRequired"
+	if strings.EqualFold(strings.TrimSpace(mode), "restart-memory") {
+		memPolicy = "RestartContainer"
+	}
+	return []any{
+		map[string]any{"resourceName": "cpu", "restartPolicy": "NotRequired"},
+		map[string]any{"resourceName": "memory", "restartPolicy": memPolicy},
+	}
+}
+
 // buildResizePatch builds the strategic-merge body for the resize subresource:
 // {"spec":{"containers":[{"name","resources":{requests,limits}}]}}. Only
 // non-empty values are written (in-place sets, never removes).

--- a/runner/pkg/rightsize/inplace.go
+++ b/runner/pkg/rightsize/inplace.go
@@ -70,16 +70,19 @@ func (r *Rightsizer) supportsInPlaceResize() bool {
 }
 
 // applyInPlace resizes every pod of the workload via the resize subresource.
-// Returns (true, nil) when all pods were resized; (false, nil) signals the
-// caller to fall back to the template Update (rollout). A non-nil error is a
-// hard failure that aborts the run.
-func (r *Rightsizer) applyInPlace(ctx context.Context, app Application, obj *unstructured.Unstructured, targets []inPlaceTarget, identifier string, changes []map[string]any) (bool, error) {
+// Returns true when all pods were resized; false signals the caller to fall
+// back to the template Update (rollout) — listing failed, a patch was rejected
+// (QoS change, unsupported), a resize was Infeasible, or polling timed out.
+//
+// All pods are patched first so their kubelets resize in parallel, then we poll
+// for completion — total time is ~the poll budget, not budget × replicas.
+func (r *Rightsizer) applyInPlace(ctx context.Context, app Application, obj *unstructured.Unstructured, targets []inPlaceTarget) bool {
 	if r.client == nil || len(targets) == 0 {
-		return false, nil
+		return false
 	}
 	labels, _, _ := unstructured.NestedStringMap(obj.Object, "spec", "selector", "matchLabels")
 	if len(labels) == 0 {
-		return false, nil // can't select pods → fall back
+		return false // can't select pods → fall back
 	}
 	sel := make([]string, 0, len(labels))
 	for k, v := range labels {
@@ -87,57 +90,52 @@ func (r *Rightsizer) applyInPlace(ctx context.Context, app Application, obj *uns
 	}
 	sort.Strings(sel) // deterministic selector string
 	podList, err := r.client.CoreV1().Pods(app.Namespace).List(ctx, metav1.ListOptions{LabelSelector: strings.Join(sel, ",")})
-	if err != nil {
-		return false, nil // listing failed → fall back rather than abort
-	}
-	if len(podList.Items) == 0 {
-		return false, nil
+	if err != nil || len(podList.Items) == 0 {
+		return false // listing failed / no pods → fall back rather than abort
 	}
 
 	patchBytes, err := buildResizePatch(targets)
 	if err != nil {
-		return false, nil
+		return false
 	}
-	annotationPatch := buildPodAnnotationPatch(identifier, changes)
 
+	// Trigger the resize on every pod up front (kubelets actuate in parallel).
+	pending := make(map[string]struct{}, len(podList.Items))
 	for i := range podList.Items {
-		pod := podList.Items[i]
-		_, err := r.client.CoreV1().Pods(app.Namespace).Patch(ctx, pod.Name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{}, "resize")
-		if err != nil {
-			// Rejected (QoS change, unsupported, etc.) → fall back to rollout.
-			return false, nil
+		name := podList.Items[i].Name
+		if _, err := r.client.CoreV1().Pods(app.Namespace).Patch(ctx, name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{}, "resize"); err != nil {
+			return false // rejected → fall back to rollout
 		}
-		if annotationPatch != nil {
-			// Best-effort traceability; the resize subresource can't carry metadata.
-			_, _ = r.client.CoreV1().Pods(app.Namespace).Patch(ctx, pod.Name, types.StrategicMergePatchType, annotationPatch, metav1.PatchOptions{})
-		}
-		if !r.waitForResize(ctx, app.Namespace, pod.Name) {
-			return false, nil // Infeasible / timed out → fall back.
-		}
+		pending[name] = struct{}{}
 	}
-	return true, nil
-}
 
-// waitForResize polls the pod's KEP-1287 status conditions. Returns true when
-// the resize completes; false on Infeasible/error or when the budget is spent.
-func (r *Rightsizer) waitForResize(ctx context.Context, namespace, pod string) bool {
+	// Poll the pending pods until all complete, any is Infeasible, or timeout.
+	timer := time.NewTimer(resizePollInterval)
+	defer timer.Stop()
 	for attempt := 0; attempt < resizePollAttempts; attempt++ {
-		p, err := r.client.CoreV1().Pods(namespace).Get(ctx, pod, metav1.GetOptions{})
-		if err == nil {
+		for name := range pending {
+			p, err := r.client.CoreV1().Pods(app.Namespace).Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				continue
+			}
 			switch resizeState(p) {
 			case "done":
-				return true
+				delete(pending, name)
 			case "infeasible":
 				return false
 			}
 		}
+		if len(pending) == 0 {
+			return true
+		}
+		timer.Reset(resizePollInterval)
 		select {
 		case <-ctx.Done():
 			return false
-		case <-time.After(resizePollInterval):
+		case <-timer.C:
 		}
 	}
-	return false
+	return false // timed out → fall back
 }
 
 // resizeState classifies a pod's resize status from its conditions. With neither
@@ -221,21 +219,4 @@ func buildResizePatch(targets []inPlaceTarget) ([]byte, error) {
 		return nil, fmt.Errorf("rightsize: no container resources to resize in place")
 	}
 	return json.Marshal(map[string]any{"spec": map[string]any{"containers": containers}})
-}
-
-// buildPodAnnotationPatch builds a metadata-annotation merge patch carrying the
-// same vertical-scaler payload writeAnnotation stamps on the controller. Returns
-// nil if the payload can't be built (annotation is best-effort).
-func buildPodAnnotationPatch(identifier string, changes []map[string]any) []byte {
-	value, err := annotationValue(identifier, changes)
-	if err != nil {
-		return nil
-	}
-	b, err := json.Marshal(map[string]any{
-		"metadata": map[string]any{"annotations": map[string]string{annotationKey: value}},
-	})
-	if err != nil {
-		return nil
-	}
-	return b
 }

--- a/runner/pkg/rightsize/inplace.go
+++ b/runner/pkg/rightsize/inplace.go
@@ -1,0 +1,219 @@
+package rightsize
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// In-place pod resize (KEP-1287). When the cluster is >= 1.33 the rightsizer
+// resizes a workload's running pods via the pod `resize` subresource instead of
+// patching the controller template (which restarts every pod). It is pod-only:
+// the controller template is left untouched, so pods recreated later (scale-up,
+// node churn) get the old sizes until the next continuous cycle re-corrects them
+// — the same drift VPA's in-place mode accepts. On any failure (cluster too old,
+// patch rejected, resize Infeasible, timeout) the caller falls back to the
+// existing template Update (rolling restart), so a workload is always sized.
+
+const (
+	inPlaceMinMajor = 1
+	inPlaceMinMinor = 33
+	// resize status poll budget.
+	resizePollInterval = 3 * time.Second
+	resizePollAttempts = 20 // ~60s
+)
+
+// inPlaceTarget is the new resources for one container that actually changed.
+type inPlaceTarget struct {
+	name   string
+	reqCPU string
+	reqMem string
+	limCPU string
+	limMem string
+}
+
+var k8sVersionRe = regexp.MustCompile(`^v?(\d+)\.(\d+)`)
+
+// k8sAtLeastInPlace reports whether a cluster gitVersion (e.g. "v1.35.3-gke.x")
+// is >= 1.33, the point where in-place pod resize is on by default.
+func k8sAtLeastInPlace(gitVersion string) bool {
+	m := k8sVersionRe.FindStringSubmatch(strings.TrimSpace(gitVersion))
+	if m == nil {
+		return false
+	}
+	major, _ := strconv.Atoi(m[1])
+	minor, _ := strconv.Atoi(m[2])
+	return major > inPlaceMinMajor || (major == inPlaceMinMajor && minor >= inPlaceMinMinor)
+}
+
+// supportsInPlaceResize checks the cluster server version via discovery. Fails
+// closed (false) when the typed client is absent or discovery errors.
+func (r *Rightsizer) supportsInPlaceResize() bool {
+	if r.client == nil {
+		return false
+	}
+	v, err := r.client.Discovery().ServerVersion()
+	if err != nil || v == nil {
+		return false
+	}
+	return k8sAtLeastInPlace(v.GitVersion)
+}
+
+// applyInPlace resizes every pod of the workload via the resize subresource.
+// Returns (true, nil) when all pods were resized; (false, nil) signals the
+// caller to fall back to the template Update (rollout). A non-nil error is a
+// hard failure that aborts the run.
+func (r *Rightsizer) applyInPlace(ctx context.Context, app Application, obj *unstructured.Unstructured, targets []inPlaceTarget, identifier string, changes []map[string]any) (bool, error) {
+	if r.client == nil || len(targets) == 0 {
+		return false, nil
+	}
+	labels, _, _ := unstructured.NestedStringMap(obj.Object, "spec", "selector", "matchLabels")
+	if len(labels) == 0 {
+		return false, nil // can't select pods → fall back
+	}
+	sel := make([]string, 0, len(labels))
+	for k, v := range labels {
+		sel = append(sel, k+"="+v)
+	}
+	sort.Strings(sel) // deterministic selector string
+	podList, err := r.client.CoreV1().Pods(app.Namespace).List(ctx, metav1.ListOptions{LabelSelector: strings.Join(sel, ",")})
+	if err != nil {
+		return false, nil // listing failed → fall back rather than abort
+	}
+	if len(podList.Items) == 0 {
+		return false, nil
+	}
+
+	patchBytes, err := buildResizePatch(targets)
+	if err != nil {
+		return false, nil
+	}
+	annotationPatch := buildPodAnnotationPatch(identifier, changes)
+
+	for i := range podList.Items {
+		pod := podList.Items[i]
+		_, err := r.client.CoreV1().Pods(app.Namespace).Patch(ctx, pod.Name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{}, "resize")
+		if err != nil {
+			// Rejected (QoS change, unsupported, etc.) → fall back to rollout.
+			return false, nil
+		}
+		if annotationPatch != nil {
+			// Best-effort traceability; the resize subresource can't carry metadata.
+			_, _ = r.client.CoreV1().Pods(app.Namespace).Patch(ctx, pod.Name, types.StrategicMergePatchType, annotationPatch, metav1.PatchOptions{})
+		}
+		if !r.waitForResize(ctx, app.Namespace, pod.Name) {
+			return false, nil // Infeasible / timed out → fall back.
+		}
+	}
+	return true, nil
+}
+
+// waitForResize polls the pod's KEP-1287 status conditions. Returns true when
+// the resize completes; false on Infeasible/error or when the budget is spent.
+func (r *Rightsizer) waitForResize(ctx context.Context, namespace, pod string) bool {
+	for attempt := 0; attempt < resizePollAttempts; attempt++ {
+		p, err := r.client.CoreV1().Pods(namespace).Get(ctx, pod, metav1.GetOptions{})
+		if err == nil {
+			switch resizeState(p) {
+			case "done":
+				return true
+			case "infeasible":
+				return false
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(resizePollInterval):
+		}
+	}
+	return false
+}
+
+// resizeState classifies a pod's resize status from its conditions. With neither
+// PodResizePending nor PodResizeInProgress present, the resize is complete.
+func resizeState(p *corev1.Pod) string {
+	for _, c := range p.Status.Conditions {
+		if c.Status != corev1.ConditionTrue {
+			continue
+		}
+		switch string(c.Type) {
+		case "PodResizePending":
+			if strings.EqualFold(c.Reason, "Infeasible") {
+				return "infeasible"
+			}
+			return "pending"
+		case "PodResizeInProgress":
+			if strings.EqualFold(c.Reason, "Error") {
+				return "infeasible"
+			}
+			return "inprogress"
+		}
+	}
+	return "done"
+}
+
+// buildResizePatch builds the strategic-merge body for the resize subresource:
+// {"spec":{"containers":[{"name","resources":{requests,limits}}]}}. Only
+// non-empty values are written (in-place sets, never removes).
+func buildResizePatch(targets []inPlaceTarget) ([]byte, error) {
+	containers := make([]map[string]any, 0, len(targets))
+	for _, t := range targets {
+		requests := map[string]any{}
+		if t.reqCPU != "" {
+			requests["cpu"] = t.reqCPU
+		}
+		if t.reqMem != "" {
+			requests["memory"] = t.reqMem
+		}
+		limits := map[string]any{}
+		if t.limCPU != "" {
+			limits["cpu"] = t.limCPU
+		}
+		if t.limMem != "" {
+			limits["memory"] = t.limMem
+		}
+		resources := map[string]any{}
+		if len(requests) > 0 {
+			resources["requests"] = requests
+		}
+		if len(limits) > 0 {
+			resources["limits"] = limits
+		}
+		if len(resources) == 0 {
+			continue
+		}
+		containers = append(containers, map[string]any{"name": t.name, "resources": resources})
+	}
+	if len(containers) == 0 {
+		return nil, fmt.Errorf("rightsize: no container resources to resize in place")
+	}
+	return json.Marshal(map[string]any{"spec": map[string]any{"containers": containers}})
+}
+
+// buildPodAnnotationPatch builds a metadata-annotation merge patch carrying the
+// same vertical-scaler payload writeAnnotation stamps on the controller. Returns
+// nil if the payload can't be built (annotation is best-effort).
+func buildPodAnnotationPatch(identifier string, changes []map[string]any) []byte {
+	value, err := annotationValue(identifier, changes)
+	if err != nil {
+		return nil
+	}
+	b, err := json.Marshal(map[string]any{
+		"metadata": map[string]any{"annotations": map[string]string{annotationKey: value}},
+	})
+	if err != nil {
+		return nil
+	}
+	return b
+}

--- a/runner/pkg/rightsize/inplace.go
+++ b/runner/pkg/rightsize/inplace.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// In-place pod resize (KEP-1287). When the cluster is >= 1.33 the rightsizer
+// In-place pod resize (KEP-1287). When the cluster is >= 1.35 the rightsizer
 // resizes a workload's running pods via the pod `resize` subresource instead of
 // patching the controller template (which restarts every pod). It is pod-only:
 // the controller template is left untouched, so pods recreated later (scale-up,
@@ -27,7 +27,7 @@ import (
 
 const (
 	inPlaceMinMajor = 1
-	inPlaceMinMinor = 33
+	inPlaceMinMinor = 35
 	// resize status poll budget.
 	resizePollInterval = 3 * time.Second
 	resizePollAttempts = 20 // ~60s
@@ -45,7 +45,9 @@ type inPlaceTarget struct {
 var k8sVersionRe = regexp.MustCompile(`^v?(\d+)\.(\d+)`)
 
 // k8sAtLeastInPlace reports whether a cluster gitVersion (e.g. "v1.35.3-gke.x")
-// is >= 1.33, the point where in-place pod resize is on by default.
+// is >= 1.35, where in-place pod resize reached GA / Stable. We require GA
+// rather than the 1.33/1.34 beta because beta support was uneven across managed
+// providers (e.g. EKS).
 func k8sAtLeastInPlace(gitVersion string) bool {
 	m := k8sVersionRe.FindStringSubmatch(strings.TrimSpace(gitVersion))
 	if m == nil {

--- a/runner/pkg/rightsize/inplace_test.go
+++ b/runner/pkg/rightsize/inplace_test.go
@@ -1,0 +1,112 @@
+package rightsize
+
+import (
+	"encoding/json"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestK8sAtLeastInPlace(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"v1.33.0", true},
+		{"v1.33.11-eks-40737a8", true},
+		{"v1.35.3-gke.1389002", true},
+		{"1.34.0+", true},
+		{"v2.0.1", true},
+		{"v1.32.9", false},
+		{"v1.27.0", false},
+		{"1.30.2", false},
+		{"", false},
+		{"garbage", false},
+	}
+	for _, c := range cases {
+		if got := k8sAtLeastInPlace(c.in); got != c.want {
+			t.Errorf("k8sAtLeastInPlace(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestBuildResizePatch(t *testing.T) {
+	targets := []inPlaceTarget{
+		{name: "app", reqCPU: "0.5", reqMem: "663Mi", limCPU: "", limMem: "928Mi"},
+	}
+	b, err := buildResizePatch(targets)
+	if err != nil {
+		t.Fatalf("buildResizePatch error: %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(b, &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	containers := parsed["spec"].(map[string]any)["containers"].([]any)
+	if len(containers) != 1 {
+		t.Fatalf("want 1 container, got %d", len(containers))
+	}
+	c0 := containers[0].(map[string]any)
+	if c0["name"] != "app" {
+		t.Errorf("name = %v, want app", c0["name"])
+	}
+	res := c0["resources"].(map[string]any)
+	reqs := res["requests"].(map[string]any)
+	if reqs["cpu"] != "0.5" || reqs["memory"] != "663Mi" {
+		t.Errorf("requests = %v", reqs)
+	}
+	lims := res["limits"].(map[string]any)
+	if lims["memory"] != "928Mi" {
+		t.Errorf("limits.memory = %v, want 928Mi", lims["memory"])
+	}
+	if _, ok := lims["cpu"]; ok {
+		t.Errorf("empty cpu limit must be omitted, got %v", lims["cpu"])
+	}
+
+	// All-empty target → no usable resources → error.
+	if _, err := buildResizePatch([]inPlaceTarget{{name: "x"}}); err == nil {
+		t.Errorf("expected error for empty target")
+	}
+}
+
+func TestResizeState(t *testing.T) {
+	mk := func(ctype, reason string) *corev1.Pod {
+		return &corev1.Pod{Status: corev1.PodStatus{Conditions: []corev1.PodCondition{
+			{Type: corev1.PodConditionType(ctype), Status: corev1.ConditionTrue, Reason: reason},
+		}}}
+	}
+	cases := []struct {
+		pod  *corev1.Pod
+		want string
+	}{
+		{&corev1.Pod{}, "done"},
+		{mk("PodResizePending", "Infeasible"), "infeasible"},
+		{mk("PodResizePending", "Deferred"), "pending"},
+		{mk("PodResizeInProgress", ""), "inprogress"},
+		{mk("PodResizeInProgress", "Error"), "infeasible"},
+	}
+	for _, c := range cases {
+		if got := resizeState(c.pod); got != c.want {
+			t.Errorf("resizeState() = %q, want %q", got, c.want)
+		}
+	}
+
+	// A condition with Status != True is ignored → done.
+	p := &corev1.Pod{Status: corev1.PodStatus{Conditions: []corev1.PodCondition{
+		{Type: "PodResizePending", Status: corev1.ConditionFalse, Reason: "Infeasible"},
+	}}}
+	if got := resizeState(p); got != "done" {
+		t.Errorf("resizeState(False condition) = %q, want done", got)
+	}
+}
+
+func TestParseSettingsInPlaceDefault(t *testing.T) {
+	// Absent → defaults true.
+	if s, _ := parseSettings(map[string]any{}); !s.InPlace {
+		t.Errorf("in_place absent should default to true")
+	}
+	// Explicit false respected.
+	if s, _ := parseSettings(map[string]any{"in_place": false}); s.InPlace {
+		t.Errorf("in_place=false should disable in-place")
+	}
+}

--- a/runner/pkg/rightsize/inplace_test.go
+++ b/runner/pkg/rightsize/inplace_test.go
@@ -100,6 +100,35 @@ func TestResizeState(t *testing.T) {
 	}
 }
 
+func TestResizePolicyList(t *testing.T) {
+	// Default → both NotRequired.
+	rp := resizePolicyList("")
+	if len(rp) != 2 {
+		t.Fatalf("default want 2 entries, got %d", len(rp))
+	}
+	cpu := rp[0].(map[string]any)
+	mem := rp[1].(map[string]any)
+	if cpu["resourceName"] != "cpu" || cpu["restartPolicy"] != "NotRequired" {
+		t.Errorf("cpu entry = %v", cpu)
+	}
+	if mem["resourceName"] != "memory" || mem["restartPolicy"] != "NotRequired" {
+		t.Errorf("memory entry = %v", mem)
+	}
+
+	// restart-memory → memory RestartContainer.
+	rp = resizePolicyList("restart-memory")
+	if rp[1].(map[string]any)["restartPolicy"] != "RestartContainer" {
+		t.Errorf("restart-memory should set memory RestartContainer, got %v", rp[1])
+	}
+
+	// Disabled variants → nil.
+	for _, m := range []string{"disabled", "off", "no", "false", "DISABLED", " Off "} {
+		if resizePolicyList(m) != nil {
+			t.Errorf("mode %q should disable (nil)", m)
+		}
+	}
+}
+
 func TestParseSettingsInPlaceDefault(t *testing.T) {
 	// Absent → defaults true.
 	if s, _ := parseSettings(map[string]any{}); !s.InPlace {

--- a/runner/pkg/rightsize/inplace_test.go
+++ b/runner/pkg/rightsize/inplace_test.go
@@ -12,11 +12,13 @@ func TestK8sAtLeastInPlace(t *testing.T) {
 		in   string
 		want bool
 	}{
-		{"v1.33.0", true},
-		{"v1.33.11-eks-40737a8", true},
+		// In-place is gated on >= 1.35 (GA), not the 1.33/1.34 beta.
+		{"v1.35.0", true},
 		{"v1.35.3-gke.1389002", true},
-		{"1.34.0+", true},
+		{"1.36.0+", true},
 		{"v2.0.1", true},
+		{"v1.34.9", false},
+		{"v1.33.11-eks-40737a8", false},
 		{"v1.32.9", false},
 		{"v1.27.0", false},
 		{"1.30.2", false},

--- a/runner/pkg/rightsize/rightsize.go
+++ b/runner/pkg/rightsize/rightsize.go
@@ -293,15 +293,21 @@ func (r *Rightsizer) rightsizeWorkload(ctx context.Context, s Settings, app Appl
 		appliedInPlace := false
 		if inPlaceEligible {
 			// Resize the running pods without a restart. On any failure
-			// (rejected, Infeasible, timeout) appliedInPlace stays false and we
-			// fall through to the template Update (rolling restart) below.
-			ok, err := r.applyInPlace(ctx, app, obj, inPlaceTargets, s.Identifier, annotationChanges)
-			if err != nil {
-				return nil, fmt.Errorf("rightsize: in-place resize %s %s/%s: %w", app.Kind, app.Namespace, app.Name, err)
-			}
-			appliedInPlace = ok
+			// (rejected, Infeasible, timeout) this returns false and we fall
+			// through to the template Update (rolling restart) below.
+			appliedInPlace = r.applyInPlace(ctx, app, obj, inPlaceTargets)
 		}
-		if !appliedInPlace {
+		if appliedInPlace {
+			// Persist the correlation annotation on the workload so the backend
+			// can match the run. This sets only the controller's top-level
+			// metadata.annotations (not spec.template), so it does NOT trigger a
+			// rollout. Best-effort: a conflict must not fail a successful resize.
+			writeAnnotation(obj, s.Identifier, annotationChanges)
+			if _, err := ri.Update(ctx, obj, metav1.UpdateOptions{}); err != nil {
+				// Non-fatal: pods are already resized; only correlation metadata is lost.
+				_ = err
+			}
+		} else {
 			if err := unstructured.SetNestedSlice(obj.Object, containers, "spec", "template", "spec", "containers"); err != nil {
 				return nil, fmt.Errorf("rightsize: rebuild containers for %s %s/%s: %w", app.Kind, app.Namespace, app.Name, err)
 			}

--- a/runner/pkg/rightsize/rightsize.go
+++ b/runner/pkg/rightsize/rightsize.go
@@ -60,11 +60,11 @@ type Settings struct {
 	AnalysisDuration   int
 	RecommendOnly      bool
 	// InPlace requests a zero-downtime in-place pod resize when the cluster
-	// supports it (>= 1.33); falls back to the template rollout otherwise.
+	// supports it (>= 1.35, GA); falls back to the template rollout otherwise.
 	// Defaults true (the backend may set in_place=false to force a rollout).
 	InPlace bool
 	// ResizePolicy controls the container resizePolicy stamped onto the template
-	// when a rollout occurs (cluster >= 1.33): "" (cpu/memory NotRequired),
+	// when a rollout occurs (cluster >= 1.35): "" (cpu/memory NotRequired),
 	// "restart-memory" (memory RestartContainer), or "disabled" (don't stamp).
 	ResizePolicy string
 	Identifier   string
@@ -112,7 +112,7 @@ func New(prom *prometheus.Client, dyn dynamic.Interface, client kubernetes.Inter
 func (r *Rightsizer) Run(ctx context.Context, s Settings, apps []Application) ([]map[string]any, error) {
 	// Decide in-place eligibility once per run (one discovery call): apply
 	// resizes to running pods without a restart when requested and the cluster
-	// is >= 1.33; otherwise each workload uses the template Update (rollout).
+	// is >= 1.35; otherwise each workload uses the template Update (rollout).
 	inPlaceEligible := s.InPlace && r.supportsInPlaceResize()
 	out := make([]map[string]any, 0, len(apps))
 	for _, app := range apps {
@@ -238,7 +238,7 @@ func (r *Rightsizer) rightsizeWorkload(ctx context.Context, s Settings, app Appl
 		if changed {
 			performUpdate = true
 			setContainerResources(c, newReqCPU, newReqMem, newLimCPU, newLimMem)
-			// On a >=1.33 cluster, stamp resizePolicy onto containers that lack
+			// On a >=1.35 cluster, stamp resizePolicy onto containers that lack
 			// one so a rollout (this fallback or a later cycle) leaves the new
 			// pods in-place-resizable per policy. Only persisted if we end up on
 			// the template-Update path below; never overwrites an existing

--- a/runner/pkg/rightsize/rightsize.go
+++ b/runner/pkg/rightsize/rightsize.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/nudgebee/nudgebee-agent/pkg/observability/prometheus"
 )
@@ -58,7 +59,11 @@ type Settings struct {
 	MemoryPercentile   float64
 	AnalysisDuration   int
 	RecommendOnly      bool
-	Identifier         string
+	// InPlace requests a zero-downtime in-place pod resize when the cluster
+	// supports it (>= 1.33); falls back to the template rollout otherwise.
+	// Defaults true (the backend may set in_place=false to force a rollout).
+	InPlace    bool
+	Identifier string
 }
 
 // Application identifies one workload to rightsize.
@@ -83,12 +88,16 @@ var supportedKinds = map[string]schema.GroupVersionResource{
 type Rightsizer struct {
 	prom *prometheus.Client
 	dyn  dynamic.Interface
+	// client is the typed clientset used for in-place pod resize (pod listing,
+	// the resize subresource, and server-version discovery). May be nil — then
+	// in-place is skipped and apply always uses the template Update (rollout).
+	client kubernetes.Interface
 }
 
-// New builds a Rightsizer. Both clients are required; main only registers the
-// action when each is available.
-func New(prom *prometheus.Client, dyn dynamic.Interface) *Rightsizer {
-	return &Rightsizer{prom: prom, dyn: dyn}
+// New builds a Rightsizer. prom + dyn are required; client enables in-place pod
+// resize (it provides pods + discovery) and may be nil to force the rollout path.
+func New(prom *prometheus.Client, dyn dynamic.Interface, client kubernetes.Interface) *Rightsizer {
+	return &Rightsizer{prom: prom, dyn: dyn, client: client}
 }
 
 // Run rightsizes each application and returns one result object per workload,
@@ -97,9 +106,13 @@ func New(prom *prometheus.Client, dyn dynamic.Interface) *Rightsizer {
 // malformed spec) abort the run; an out-of-bounds recommendation is skipped
 // per-resource and surfaced in the container's "skipped" list, not fatal.
 func (r *Rightsizer) Run(ctx context.Context, s Settings, apps []Application) ([]map[string]any, error) {
+	// Decide in-place eligibility once per run (one discovery call): apply
+	// resizes to running pods without a restart when requested and the cluster
+	// is >= 1.33; otherwise each workload uses the template Update (rollout).
+	inPlaceEligible := s.InPlace && r.supportsInPlaceResize()
 	out := make([]map[string]any, 0, len(apps))
 	for _, app := range apps {
-		res, err := r.rightsizeWorkload(ctx, s, app)
+		res, err := r.rightsizeWorkload(ctx, s, app, inPlaceEligible)
 		if err != nil {
 			return nil, err
 		}
@@ -117,7 +130,7 @@ type containerStat struct {
 	hasData   bool
 }
 
-func (r *Rightsizer) rightsizeWorkload(ctx context.Context, s Settings, app Application) (map[string]any, error) {
+func (r *Rightsizer) rightsizeWorkload(ctx context.Context, s Settings, app Application, inPlaceEligible bool) (map[string]any, error) {
 	gvr, ok := supportedKinds[app.Kind]
 	if !ok {
 		return nil, fmt.Errorf("rightsize: unsupported kind %q (supported: Deployment, StatefulSet, DaemonSet, ReplicaSet, Rollout)", app.Kind)
@@ -137,6 +150,9 @@ func (r *Rightsizer) rightsizeWorkload(ctx context.Context, s Settings, app Appl
 	performUpdate := false
 	resultContainers := make([]map[string]any, 0, len(containers))
 	annotationChanges := make([]map[string]any, 0, len(containers))
+	// Targets for an in-place resize: only the containers that actually changed,
+	// with the values that would be applied. Parallels the template mutation.
+	inPlaceTargets := make([]inPlaceTarget, 0, len(containers))
 
 	for i := range containers {
 		c, _ := containers[i].(map[string]any)
@@ -219,6 +235,9 @@ func (r *Rightsizer) rightsizeWorkload(ctx context.Context, s Settings, app Appl
 			performUpdate = true
 			setContainerResources(c, newReqCPU, newReqMem, newLimCPU, newLimMem)
 			containers[i] = c
+			inPlaceTargets = append(inPlaceTargets, inPlaceTarget{
+				name: name, reqCPU: newReqCPU, reqMem: newReqMem, limCPU: newLimCPU, limMem: newLimMem,
+			})
 		}
 
 		result := map[string]any{
@@ -255,12 +274,25 @@ func (r *Rightsizer) rightsizeWorkload(ctx context.Context, s Settings, app Appl
 	}
 
 	if performUpdate && !s.RecommendOnly {
-		if err := unstructured.SetNestedSlice(obj.Object, containers, "spec", "template", "spec", "containers"); err != nil {
-			return nil, fmt.Errorf("rightsize: rebuild containers for %s %s/%s: %w", app.Kind, app.Namespace, app.Name, err)
+		appliedInPlace := false
+		if inPlaceEligible {
+			// Resize the running pods without a restart. On any failure
+			// (rejected, Infeasible, timeout) appliedInPlace stays false and we
+			// fall through to the template Update (rolling restart) below.
+			ok, err := r.applyInPlace(ctx, app, obj, inPlaceTargets, s.Identifier, annotationChanges)
+			if err != nil {
+				return nil, fmt.Errorf("rightsize: in-place resize %s %s/%s: %w", app.Kind, app.Namespace, app.Name, err)
+			}
+			appliedInPlace = ok
 		}
-		writeAnnotation(obj, s.Identifier, annotationChanges)
-		if _, err := ri.Update(ctx, obj, metav1.UpdateOptions{}); err != nil {
-			return nil, fmt.Errorf("rightsize: apply %s %s/%s: %w", app.Kind, app.Namespace, app.Name, err)
+		if !appliedInPlace {
+			if err := unstructured.SetNestedSlice(obj.Object, containers, "spec", "template", "spec", "containers"); err != nil {
+				return nil, fmt.Errorf("rightsize: rebuild containers for %s %s/%s: %w", app.Kind, app.Namespace, app.Name, err)
+			}
+			writeAnnotation(obj, s.Identifier, annotationChanges)
+			if _, err := ri.Update(ctx, obj, metav1.UpdateOptions{}); err != nil {
+				return nil, fmt.Errorf("rightsize: apply %s %s/%s: %w", app.Kind, app.Namespace, app.Name, err)
+			}
 		}
 	}
 
@@ -467,7 +499,9 @@ func setOrDelete(m map[string]any, key, val string) {
 // writeAnnotation stamps the vertical-rightsize annotation onto the workload so
 // the backend can correlate the applied change with this run. Best-effort:
 // matches the legacy compact-JSON {identifier, time, container_changes}.
-func writeAnnotation(obj *unstructured.Unstructured, identifier string, changes []map[string]any) {
+// annotationValue builds the compact-JSON vertical-scaler payload
+// {identifier, time, container_changes} the backend reads to correlate a run.
+func annotationValue(identifier string, changes []map[string]any) (string, error) {
 	payload := map[string]any{
 		"identifier":        identifier,
 		"time":              time.Now().UTC().Format("2006-01-02T15:04:05.000000"),
@@ -478,10 +512,16 @@ func writeAnnotation(obj *unstructured.Unstructured, identifier string, changes 
 	// corrupt any value legitimately containing a space.
 	b, err := json.Marshal(payload)
 	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func writeAnnotation(obj *unstructured.Unstructured, identifier string, changes []map[string]any) {
+	value, err := annotationValue(identifier, changes)
+	if err != nil {
 		return
 	}
-	value := string(b)
-
 	ann := obj.GetAnnotations()
 	if ann == nil {
 		ann = map[string]string{}

--- a/runner/pkg/rightsize/rightsize.go
+++ b/runner/pkg/rightsize/rightsize.go
@@ -62,8 +62,12 @@ type Settings struct {
 	// InPlace requests a zero-downtime in-place pod resize when the cluster
 	// supports it (>= 1.33); falls back to the template rollout otherwise.
 	// Defaults true (the backend may set in_place=false to force a rollout).
-	InPlace    bool
-	Identifier string
+	InPlace bool
+	// ResizePolicy controls the container resizePolicy stamped onto the template
+	// when a rollout occurs (cluster >= 1.33): "" (cpu/memory NotRequired),
+	// "restart-memory" (memory RestartContainer), or "disabled" (don't stamp).
+	ResizePolicy string
+	Identifier   string
 }
 
 // Application identifies one workload to rightsize.
@@ -234,6 +238,18 @@ func (r *Rightsizer) rightsizeWorkload(ctx context.Context, s Settings, app Appl
 		if changed {
 			performUpdate = true
 			setContainerResources(c, newReqCPU, newReqMem, newLimCPU, newLimMem)
+			// On a >=1.33 cluster, stamp resizePolicy onto containers that lack
+			// one so a rollout (this fallback or a later cycle) leaves the new
+			// pods in-place-resizable per policy. Only persisted if we end up on
+			// the template-Update path below; never overwrites an existing
+			// (operator/GitOps-set) resizePolicy.
+			if inPlaceEligible {
+				if _, has := c["resizePolicy"]; !has {
+					if rp := resizePolicyList(s.ResizePolicy); rp != nil {
+						c["resizePolicy"] = rp
+					}
+				}
+			}
 			containers[i] = c
 			inPlaceTargets = append(inPlaceTargets, inPlaceTarget{
 				name: name, reqCPU: newReqCPU, reqMem: newReqMem, limCPU: newLimCPU, limMem: newLimMem,


### PR DESCRIPTION
## Summary

`continuous_rightsizing` (#457) applies recommendations by updating the **controller's pod template** via the dynamic client — which **restarts every pod**. This adds **In-Place Pod Resize** (KEP-1287): when the cluster is **≥ 1.33**, the rightsizer resizes the workload's **running pods** via the pod `resize` subresource (no restart), falling back to the template `Update` (rollout) when in-place isn't possible.

## What changed

- **`pkg/rightsize/inplace.go`** (new): server-version gate (`Discovery().ServerVersion()` ≥ 1.33), pod enumeration by the workload's `spec.selector.matchLabels`, resize-subresource strategic-merge patch of the changed containers, KEP-1287 status polling (`PodResizePending`/`PodResizeInProgress`), best-effort pod-annotation stamp.
- **`rightsize.go`**: `Rightsizer` takes a typed clientset (nil-safe); `Run` decides in-place eligibility once per run (single discovery call); `rightsizeWorkload` collects the changed-container targets and, when eligible, resizes pods in place — falling back to the existing template `Update` on **rejection / Infeasible / timeout**.
- **`Settings.InPlace`** (param `in_place`, default `true`) lets the backend force the rollout path.
- **`handlers.go`**: parse `in_place`.
- **`cmd/agent/main.go`**: pass the typed client (`typedKube`) into `rightsize.New`.

## Behavior notes

- **Pod-only / drift accepted:** the controller template is intentionally left untouched (any template change rolls), so pods recreated later (scale-up, node churn) get the old sizes until the next continuous cycle re-corrects them — the same drift VPA's in-place mode accepts. This fits `continuous_rightsizing`, which re-runs on a schedule.
- **Always sized:** any in-place failure (cluster < 1.33, typed client absent, patch rejected — e.g. a QoS-class change — `Infeasible`, or poll timeout) falls back to the existing template rollout, so a workload is never left unsized.
- **Limits:** in-place sets values, never removes; CPU-limit removal still happens on the rollout path. Memory in-place increase works on 1.33/1.34; a decrease is deferred by the kubelet until ≥ 1.35.

## Tests

Unit tests for the version gate, the resize-patch builder (incl. omitting empty values), the status classifier, and the `in_place` setting default. `go build ./...`, `go vet`, `gofmt`, and `go test ./pkg/rightsize/` all pass.
