### PR TITLE
fix(agent): correct logs-provider selection and health probes

### DIFF
--- a/charts/nudgebee-agent/templates/runner.yaml
+++ b/charts/nudgebee-agent/templates/runner.yaml
@@ -133,9 +133,6 @@ stringData:
   {{- if not .Values.runner.es.enabled }}
   ELASTICSEARCH_ENABLED: {{ .Values.runner.es.enabled | quote }}
   {{- end }}
-  {{- if not .Values.runner.es.sslVerify }}
-  ELASTICSEARCH_SSL_VERIFY: {{ .Values.runner.es.sslVerify | quote }}
-  {{- end }}
   {{- if .Values.runner.signoz.apiKey }}
   SIGNOZ_API_KEY: {{ .Values.runner.signoz.apiKey }}
   {{- end }}

--- a/charts/nudgebee-agent/templates/runner.yaml
+++ b/charts/nudgebee-agent/templates/runner.yaml
@@ -130,6 +130,12 @@ stringData:
   {{- if .Values.runner.es.apiKey }}
   ELASTICSEARCH_APIKEY: {{ .Values.runner.es.apiKey }}
   {{- end }}
+  {{- if not .Values.runner.es.enabled }}
+  ELASTICSEARCH_ENABLED: {{ .Values.runner.es.enabled | quote }}
+  {{- end }}
+  {{- if not .Values.runner.es.sslVerify }}
+  ELASTICSEARCH_SSL_VERIFY: {{ .Values.runner.es.sslVerify | quote }}
+  {{- end }}
   {{- if .Values.runner.signoz.apiKey }}
   SIGNOZ_API_KEY: {{ .Values.runner.signoz.apiKey }}
   {{- end }}

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -141,9 +141,6 @@ runner:
     # configured `url` from overriding another logs provider (e.g. Loki) while
     # still exposing the ES query actions. Surfaces as ELASTICSEARCH_ENABLED.
     enabled: true
-    # TLS certificate verification for ES health probe + queries. Set false for
-    # self-signed OpenSearch/ES. Surfaces as ELASTICSEARCH_SSL_VERIFY.
-    sslVerify: true
   signoz:
     # Set to enable SigNoz actions. Surfaces as SIGNOZ_URL.
     url: ""

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -137,6 +137,13 @@ runner:
     # Set to enable Elasticsearch actions. Surfaces as ELASTICSEARCH_URL.
     url: ""
     apiKey: ""
+    # Gate ES as a logs provider independent of the URL. Set false to keep a
+    # configured `url` from overriding another logs provider (e.g. Loki) while
+    # still exposing the ES query actions. Surfaces as ELASTICSEARCH_ENABLED.
+    enabled: true
+    # TLS certificate verification for ES health probe + queries. Set false for
+    # self-signed OpenSearch/ES. Surfaces as ELASTICSEARCH_SSL_VERIFY.
+    sslVerify: true
   signoz:
     # Set to enable SigNoz actions. Surfaces as SIGNOZ_URL.
     url: ""

--- a/runner/cmd/agent/main.go
+++ b/runner/cmd/agent/main.go
@@ -6,6 +6,8 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -296,8 +298,8 @@ func run(ctx context.Context, logger *slog.Logger, cfg *config.Config) error {
 		logger.Info("loki enabled", "url", cfg.LokiURL, "actions", len(lh)+len(ch))
 	}
 
-	if cfg.ElasticsearchURL != "" {
-		ec := elasticsearch.New(cfg.ElasticsearchURL, nil)
+	if cfg.ElasticsearchEnabled && cfg.ElasticsearchURL != "" {
+		ec := elasticsearch.New(cfg.ElasticsearchURL, esHTTPClient(cfg, 60*time.Second))
 		ec.Username = cfg.ElasticsearchUser
 		ec.Password = cfg.ElasticsearchPassword
 		ec.APIKey = cfg.ElasticsearchAPIKey
@@ -1081,9 +1083,13 @@ func probeLogsProvider(ctx context.Context, cfg *config.Config) (provider, url s
 	case cfg.PinotURL != "":
 		ok = httpProbe(ctx, httpClient, cfg.PinotURL+"/health")
 		return "pinot", cfg.PinotURL, ok, map[string]any{}
-	case cfg.ElasticsearchURL != "":
+	case cfg.ElasticsearchEnabled && cfg.ElasticsearchURL != "":
 		// ES exposes a `_cluster/health` endpoint; we treat 200 as healthy.
-		ok = httpProbe(ctx, httpClient, cfg.ElasticsearchURL+"/_cluster/health")
+		// Probe with the same auth + TLS posture as the query client so the
+		// badge reflects whether queries will actually succeed — a secured
+		// OpenSearch/ES otherwise 401s (or fails TLS) on an unauthenticated,
+		// strict-verify probe even when the configured creds work fine.
+		ok = httpProbe(ctx, esHTTPClient(cfg, 5*time.Second), cfg.ElasticsearchURL+"/_cluster/health", esAuthHeader(cfg))
 		providerCfg = map[string]any{}
 		if v := os.Getenv("ELASTICSEARCH_LOG_INDEX"); v != "" {
 			providerCfg["default_index"] = v
@@ -1094,7 +1100,11 @@ func probeLogsProvider(ctx context.Context, cfg *config.Config) (provider, url s
 		ok = httpProbe(ctx, httpClient, cfg.SignozURL+"/api/v1/health")
 		return "signoz", cfg.SignozURL, ok, map[string]any{}
 	case cfg.LokiURL != "":
-		ok = httpProbe(ctx, httpClient, cfg.LokiURL+"/ready")
+		// LOKI_URL points at the loki gateway, whose nginx only proxies the
+		// `/loki/...` API paths — the backend `/ready` is not exposed there and
+		// 404s. Probe a gateway-served API endpoint instead so the badge
+		// reflects query reachability.
+		ok = httpProbe(ctx, httpClient, cfg.LokiURL+"/loki/api/v1/status/buildinfo")
 		providerCfg = map[string]any{"url": cfg.LokiURL}
 		return "loki", cfg.LokiURL, ok, providerCfg
 	default:
@@ -1126,10 +1136,15 @@ func probeClickhouse(ctx context.Context, c *http.Client, host, port string) boo
 //
 // URL is sourced from operator-provided config (PROMETHEUS_URL, LOKI_URL,
 // etc.), not request-derived — taint flow is operator → probe by design.
-func httpProbe(ctx context.Context, c *http.Client, url string) bool {
+func httpProbe(ctx context.Context, c *http.Client, url string, headers ...map[string]string) bool {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil) //nolint:gosec // operator-provided URL
 	if err != nil {
 		return false
+	}
+	for _, h := range headers {
+		for k, v := range h {
+			req.Header.Set(k, v)
+		}
 	}
 	resp, err := c.Do(req) //nolint:gosec // operator-provided URL
 	if err != nil {
@@ -1137,6 +1152,33 @@ func httpProbe(ctx context.Context, c *http.Client, url string) bool {
 	}
 	defer func() { _ = resp.Body.Close() }()
 	return resp.StatusCode >= 200 && resp.StatusCode < 300
+}
+
+// esHTTPClient returns an HTTP client honouring ELASTICSEARCH_SSL_VERIFY. When
+// verification is disabled the client skips TLS cert checks, matching the query
+// client so the health probe and real queries behave identically against
+// self-signed OpenSearch/ES endpoints.
+func esHTTPClient(cfg *config.Config, timeout time.Duration) *http.Client {
+	c := &http.Client{Timeout: timeout}
+	if !cfg.ElasticsearchSSLVerify {
+		c.Transport = &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}} //nolint:gosec // operator opted out via ELASTICSEARCH_SSL_VERIFY=false
+	}
+	return c
+}
+
+// esAuthHeader builds the Authorization header for ES probes from the
+// configured credentials (API key takes precedence over basic auth), mirroring
+// elasticsearch.Client.do. Returns nil when no credentials are set.
+func esAuthHeader(cfg *config.Config) map[string]string {
+	switch {
+	case cfg.ElasticsearchAPIKey != "":
+		return map[string]string{"Authorization": "ApiKey " + cfg.ElasticsearchAPIKey}
+	case cfg.ElasticsearchUser != "":
+		creds := base64.StdEncoding.EncodeToString([]byte(cfg.ElasticsearchUser + ":" + cfg.ElasticsearchPassword))
+		return map[string]string{"Authorization": "Basic " + creds}
+	default:
+		return nil
+	}
 }
 
 // parseTelemetryPeriod reads CLUSTER_STATUS_PERIOD_SEC (default 60s).

--- a/runner/cmd/agent/main.go
+++ b/runner/cmd/agent/main.go
@@ -1154,14 +1154,28 @@ func httpProbe(ctx context.Context, c *http.Client, url string, headers ...map[s
 	return resp.StatusCode >= 200 && resp.StatusCode < 300
 }
 
+// esInsecureTransport is shared across esHTTPClient calls so the per-tick probe
+// reuses one connection pool instead of allocating a new http.Transport each
+// time (which would leak idle TCP connections / file descriptors). Cloned from
+// the default transport to keep its dial/idle timeouts, overriding only TLS.
+var esInsecureTransport = func() *http.Transport {
+	if tr, ok := http.DefaultTransport.(*http.Transport); ok {
+		cloned := tr.Clone()
+		cloned.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // operator opted out via ELASTICSEARCH_SSL_VERIFY=false
+		return cloned
+	}
+	return &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}} //nolint:gosec // operator opted out via ELASTICSEARCH_SSL_VERIFY=false
+}()
+
 // esHTTPClient returns an HTTP client honouring ELASTICSEARCH_SSL_VERIFY. When
 // verification is disabled the client skips TLS cert checks, matching the query
 // client so the health probe and real queries behave identically against
-// self-signed OpenSearch/ES endpoints.
+// self-signed OpenSearch/ES endpoints. Verify-on clients use the shared default
+// transport; verify-off clients share esInsecureTransport.
 func esHTTPClient(cfg *config.Config, timeout time.Duration) *http.Client {
 	c := &http.Client{Timeout: timeout}
 	if !cfg.ElasticsearchSSLVerify {
-		c.Transport = &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}} //nolint:gosec // operator opted out via ELASTICSEARCH_SSL_VERIFY=false
+		c.Transport = esInsecureTransport
 	}
 	return c
 }

--- a/runner/cmd/agent/main.go
+++ b/runner/cmd/agent/main.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -299,7 +298,7 @@ func run(ctx context.Context, logger *slog.Logger, cfg *config.Config) error {
 	}
 
 	if cfg.ElasticsearchEnabled && cfg.ElasticsearchURL != "" {
-		ec := elasticsearch.New(cfg.ElasticsearchURL, esHTTPClient(cfg, 60*time.Second))
+		ec := elasticsearch.New(cfg.ElasticsearchURL, nil)
 		ec.Username = cfg.ElasticsearchUser
 		ec.Password = cfg.ElasticsearchPassword
 		ec.APIKey = cfg.ElasticsearchAPIKey
@@ -1085,11 +1084,10 @@ func probeLogsProvider(ctx context.Context, cfg *config.Config) (provider, url s
 		return "pinot", cfg.PinotURL, ok, map[string]any{}
 	case cfg.ElasticsearchEnabled && cfg.ElasticsearchURL != "":
 		// ES exposes a `_cluster/health` endpoint; we treat 200 as healthy.
-		// Probe with the same auth + TLS posture as the query client so the
-		// badge reflects whether queries will actually succeed — a secured
-		// OpenSearch/ES otherwise 401s (or fails TLS) on an unauthenticated,
-		// strict-verify probe even when the configured creds work fine.
-		ok = httpProbe(ctx, esHTTPClient(cfg, 5*time.Second), cfg.ElasticsearchURL+"/_cluster/health", esAuthHeader(cfg))
+		// Probe with the configured credentials so the badge reflects whether
+		// queries will actually succeed — a secured OpenSearch/ES otherwise 401s
+		// on an unauthenticated probe even when the configured creds work fine.
+		ok = httpProbe(ctx, httpClient, cfg.ElasticsearchURL+"/_cluster/health", esAuthHeader(cfg))
 		providerCfg = map[string]any{}
 		if v := os.Getenv("ELASTICSEARCH_LOG_INDEX"); v != "" {
 			providerCfg["default_index"] = v
@@ -1152,32 +1150,6 @@ func httpProbe(ctx context.Context, c *http.Client, url string, headers ...map[s
 	}
 	defer func() { _ = resp.Body.Close() }()
 	return resp.StatusCode >= 200 && resp.StatusCode < 300
-}
-
-// esInsecureTransport is shared across esHTTPClient calls so the per-tick probe
-// reuses one connection pool instead of allocating a new http.Transport each
-// time (which would leak idle TCP connections / file descriptors). Cloned from
-// the default transport to keep its dial/idle timeouts, overriding only TLS.
-var esInsecureTransport = func() *http.Transport {
-	if tr, ok := http.DefaultTransport.(*http.Transport); ok {
-		cloned := tr.Clone()
-		cloned.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // operator opted out via ELASTICSEARCH_SSL_VERIFY=false
-		return cloned
-	}
-	return &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}} //nolint:gosec // operator opted out via ELASTICSEARCH_SSL_VERIFY=false
-}()
-
-// esHTTPClient returns an HTTP client honouring ELASTICSEARCH_SSL_VERIFY. When
-// verification is disabled the client skips TLS cert checks, matching the query
-// client so the health probe and real queries behave identically against
-// self-signed OpenSearch/ES endpoints. Verify-on clients use the shared default
-// transport; verify-off clients share esInsecureTransport.
-func esHTTPClient(cfg *config.Config, timeout time.Duration) *http.Client {
-	c := &http.Client{Timeout: timeout}
-	if !cfg.ElasticsearchSSLVerify {
-		c.Transport = esInsecureTransport
-	}
-	return c
 }
 
 // esAuthHeader builds the Authorization header for ES probes from the

--- a/runner/cmd/agent/probe_test.go
+++ b/runner/cmd/agent/probe_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/nudgebee/nudgebee-agent/pkg/config"
+)
+
+// ELASTICSEARCH_ENABLED=false must keep a configured ELASTICSEARCH_URL from
+// hijacking logs-provider selection — the agent should fall through to the next
+// configured provider (here, Loki).
+func TestProbeLogsProvider_ESDisabledFallsThroughToLoki(t *testing.T) {
+	loki := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Mirror the loki gateway: only the API paths are served; /ready 404s.
+		if r.URL.Path == "/loki/api/v1/status/buildinfo" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer loki.Close()
+
+	cfg := &config.Config{
+		ElasticsearchURL:     "http://es.invalid:9200",
+		ElasticsearchEnabled: false,
+		LokiURL:              loki.URL,
+	}
+	provider, url, ok, _ := probeLogsProvider(context.Background(), cfg)
+	if provider != "loki" {
+		t.Fatalf("provider = %q, want loki", provider)
+	}
+	if url != loki.URL {
+		t.Fatalf("url = %q, want %q", url, loki.URL)
+	}
+	if !ok {
+		t.Fatal("ok = false, want true (buildinfo path should be reachable)")
+	}
+}
+
+// The ES probe must send the configured credentials and honour
+// ELASTICSEARCH_SSL_VERIFY=false, so the badge reflects query reachability
+// against a secured, self-signed OpenSearch/ES endpoint.
+func TestProbeLogsProvider_ESAuthAndInsecureTLS(t *testing.T) {
+	var gotAuth string
+	es := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		if r.URL.Path == "/_cluster/health" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer es.Close()
+
+	cfg := &config.Config{
+		ElasticsearchEnabled:   true,
+		ElasticsearchURL:       es.URL, // https with a self-signed cert
+		ElasticsearchUser:      "admin",
+		ElasticsearchPassword:  "pw",
+		ElasticsearchSSLVerify: false,
+	}
+	provider, _, ok, _ := probeLogsProvider(context.Background(), cfg)
+	if provider != "ES" {
+		t.Fatalf("provider = %q, want ES", provider)
+	}
+	if !ok {
+		t.Fatal("ok = false, want true (insecure TLS + basic auth should succeed)")
+	}
+	want := "Basic " + base64.StdEncoding.EncodeToString([]byte("admin:pw"))
+	if gotAuth != want {
+		t.Fatalf("Authorization = %q, want %q", gotAuth, want)
+	}
+}
+
+// With strict TLS verification (the default) the probe cannot complete the
+// handshake against a self-signed endpoint, so the badge reports unhealthy.
+func TestProbeLogsProvider_ESStrictTLSFailsOnSelfSigned(t *testing.T) {
+	es := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer es.Close()
+
+	cfg := &config.Config{
+		ElasticsearchEnabled:   true,
+		ElasticsearchURL:       es.URL,
+		ElasticsearchSSLVerify: true,
+	}
+	provider, _, ok, _ := probeLogsProvider(context.Background(), cfg)
+	if provider != "ES" {
+		t.Fatalf("provider = %q, want ES", provider)
+	}
+	if ok {
+		t.Fatal("ok = true, want false (strict verify must reject self-signed cert)")
+	}
+}

--- a/runner/cmd/agent/probe_test.go
+++ b/runner/cmd/agent/probe_test.go
@@ -41,59 +41,36 @@ func TestProbeLogsProvider_ESDisabledFallsThroughToLoki(t *testing.T) {
 	}
 }
 
-// The ES probe must send the configured credentials and honour
-// ELASTICSEARCH_SSL_VERIFY=false, so the badge reflects query reachability
-// against a secured, self-signed OpenSearch/ES endpoint.
-func TestProbeLogsProvider_ESAuthAndInsecureTLS(t *testing.T) {
+// The ES probe must send the configured credentials so the badge reflects
+// query reachability against a secured OpenSearch/ES endpoint (which 401s an
+// unauthenticated probe).
+func TestProbeLogsProvider_ESProbeSendsAuth(t *testing.T) {
 	var gotAuth string
-	es := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	es := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotAuth = r.Header.Get("Authorization")
-		if r.URL.Path == "/_cluster/health" {
+		if r.URL.Path == "/_cluster/health" && gotAuth != "" {
 			w.WriteHeader(http.StatusOK)
 			return
 		}
-		w.WriteHeader(http.StatusNotFound)
+		w.WriteHeader(http.StatusUnauthorized)
 	}))
 	defer es.Close()
 
 	cfg := &config.Config{
-		ElasticsearchEnabled:   true,
-		ElasticsearchURL:       es.URL, // https with a self-signed cert
-		ElasticsearchUser:      "admin",
-		ElasticsearchPassword:  "pw",
-		ElasticsearchSSLVerify: false,
+		ElasticsearchEnabled:  true,
+		ElasticsearchURL:      es.URL,
+		ElasticsearchUser:     "admin",
+		ElasticsearchPassword: "pw",
 	}
 	provider, _, ok, _ := probeLogsProvider(context.Background(), cfg)
 	if provider != "ES" {
 		t.Fatalf("provider = %q, want ES", provider)
 	}
 	if !ok {
-		t.Fatal("ok = false, want true (insecure TLS + basic auth should succeed)")
+		t.Fatal("ok = false, want true (authenticated probe should succeed)")
 	}
 	want := "Basic " + base64.StdEncoding.EncodeToString([]byte("admin:pw"))
 	if gotAuth != want {
 		t.Fatalf("Authorization = %q, want %q", gotAuth, want)
-	}
-}
-
-// With strict TLS verification (the default) the probe cannot complete the
-// handshake against a self-signed endpoint, so the badge reports unhealthy.
-func TestProbeLogsProvider_ESStrictTLSFailsOnSelfSigned(t *testing.T) {
-	es := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer es.Close()
-
-	cfg := &config.Config{
-		ElasticsearchEnabled:   true,
-		ElasticsearchURL:       es.URL,
-		ElasticsearchSSLVerify: true,
-	}
-	provider, _, ok, _ := probeLogsProvider(context.Background(), cfg)
-	if provider != "ES" {
-		t.Fatalf("provider = %q, want ES", provider)
-	}
-	if ok {
-		t.Fatal("ok = true, want false (strict verify must reject self-signed cert)")
 	}
 }

--- a/runner/pkg/config/config.go
+++ b/runner/pkg/config/config.go
@@ -32,10 +32,12 @@ type Config struct {
 	LokiHeaders       string
 
 	// Elasticsearch
-	ElasticsearchURL      string
-	ElasticsearchUser     string
-	ElasticsearchPassword string
-	ElasticsearchAPIKey   string
+	ElasticsearchURL       string
+	ElasticsearchUser      string
+	ElasticsearchPassword  string
+	ElasticsearchAPIKey    string
+	ElasticsearchEnabled   bool // ELASTICSEARCH_ENABLED; default true when URL is set
+	ElasticsearchSSLVerify bool // ELASTICSEARCH_SSL_VERIFY; default true
 
 	// Signoz
 	SignozURL    string
@@ -169,19 +171,25 @@ func FromEnv() (*Config, error) {
 		ElasticsearchUser:     os.Getenv("ELASTICSEARCH_USERNAME"),
 		ElasticsearchPassword: os.Getenv("ELASTICSEARCH_PASSWORD"),
 		ElasticsearchAPIKey:   os.Getenv("ELASTICSEARCH_APIKEY"),
-		SignozURL:             os.Getenv("SIGNOZ_URL"),
-		SignozAPIKey:          os.Getenv("SIGNOZ_API_KEY"),
-		JaegerURL:             os.Getenv("JAEGER_URL"),
-		ChronosphereURL:       os.Getenv("CHRONOSPHERE_URL"),
-		ChronosphereAPIKey:    os.Getenv("CHRONOSPHERE_API_KEY"),
-		PinotURL:              os.Getenv("PINOT_URL"),
-		PinotAuthToken:        os.Getenv("PINOT_AUTH_TOKEN"),
-		PinotUsername:         os.Getenv("PINOT_USERNAME"),
-		PinotPassword:         os.Getenv("PINOT_PASSWORD"),
-		HTTPProxyTargets:      os.Getenv("HTTP_PROXY_TARGETS"),
-		LokiRulesURL:          os.Getenv("LOKI_RULES_URL"),
-		HTTPListenAddr:        cmp(os.Getenv("HTTP_LISTEN_ADDR"), ":5000"),
-		PprofEnabled:          envBool("PPROF_ENABLED", false),
+		// ELASTICSEARCH_ENABLED gates ES as a logs provider independent of the
+		// URL: operators set it false to keep a stray ELASTICSEARCH_URL from
+		// overriding a working provider (e.g. Loki). Unset → enabled when a URL
+		// is present, preserving legacy URL-presence behaviour.
+		ElasticsearchEnabled:   envBool("ELASTICSEARCH_ENABLED", true),
+		ElasticsearchSSLVerify: envBool("ELASTICSEARCH_SSL_VERIFY", true),
+		SignozURL:              os.Getenv("SIGNOZ_URL"),
+		SignozAPIKey:           os.Getenv("SIGNOZ_API_KEY"),
+		JaegerURL:              os.Getenv("JAEGER_URL"),
+		ChronosphereURL:        os.Getenv("CHRONOSPHERE_URL"),
+		ChronosphereAPIKey:     os.Getenv("CHRONOSPHERE_API_KEY"),
+		PinotURL:               os.Getenv("PINOT_URL"),
+		PinotAuthToken:         os.Getenv("PINOT_AUTH_TOKEN"),
+		PinotUsername:          os.Getenv("PINOT_USERNAME"),
+		PinotPassword:          os.Getenv("PINOT_PASSWORD"),
+		HTTPProxyTargets:       os.Getenv("HTTP_PROXY_TARGETS"),
+		LokiRulesURL:           os.Getenv("LOKI_RULES_URL"),
+		HTTPListenAddr:         cmp(os.Getenv("HTTP_LISTEN_ADDR"), ":5000"),
+		PprofEnabled:           envBool("PPROF_ENABLED", false),
 		// K8s subsystems default-on so the agent is drop-in compatible with
 		// the legacy runner Deployment — no env additions needed for cutover.
 		// Operators can opt out per-subsystem via DISCOVERY_ENABLED=false etc.

--- a/runner/pkg/config/config.go
+++ b/runner/pkg/config/config.go
@@ -32,12 +32,11 @@ type Config struct {
 	LokiHeaders       string
 
 	// Elasticsearch
-	ElasticsearchURL       string
-	ElasticsearchUser      string
-	ElasticsearchPassword  string
-	ElasticsearchAPIKey    string
-	ElasticsearchEnabled   bool // ELASTICSEARCH_ENABLED; default true when URL is set
-	ElasticsearchSSLVerify bool // ELASTICSEARCH_SSL_VERIFY; default true
+	ElasticsearchURL      string
+	ElasticsearchUser     string
+	ElasticsearchPassword string
+	ElasticsearchAPIKey   string
+	ElasticsearchEnabled  bool // ELASTICSEARCH_ENABLED; default true when URL is set
 
 	// Signoz
 	SignozURL    string
@@ -175,21 +174,20 @@ func FromEnv() (*Config, error) {
 		// URL: operators set it false to keep a stray ELASTICSEARCH_URL from
 		// overriding a working provider (e.g. Loki). Unset → enabled when a URL
 		// is present, preserving legacy URL-presence behaviour.
-		ElasticsearchEnabled:   envBool("ELASTICSEARCH_ENABLED", true),
-		ElasticsearchSSLVerify: envBool("ELASTICSEARCH_SSL_VERIFY", true),
-		SignozURL:              os.Getenv("SIGNOZ_URL"),
-		SignozAPIKey:           os.Getenv("SIGNOZ_API_KEY"),
-		JaegerURL:              os.Getenv("JAEGER_URL"),
-		ChronosphereURL:        os.Getenv("CHRONOSPHERE_URL"),
-		ChronosphereAPIKey:     os.Getenv("CHRONOSPHERE_API_KEY"),
-		PinotURL:               os.Getenv("PINOT_URL"),
-		PinotAuthToken:         os.Getenv("PINOT_AUTH_TOKEN"),
-		PinotUsername:          os.Getenv("PINOT_USERNAME"),
-		PinotPassword:          os.Getenv("PINOT_PASSWORD"),
-		HTTPProxyTargets:       os.Getenv("HTTP_PROXY_TARGETS"),
-		LokiRulesURL:           os.Getenv("LOKI_RULES_URL"),
-		HTTPListenAddr:         cmp(os.Getenv("HTTP_LISTEN_ADDR"), ":5000"),
-		PprofEnabled:           envBool("PPROF_ENABLED", false),
+		ElasticsearchEnabled: envBool("ELASTICSEARCH_ENABLED", true),
+		SignozURL:            os.Getenv("SIGNOZ_URL"),
+		SignozAPIKey:         os.Getenv("SIGNOZ_API_KEY"),
+		JaegerURL:            os.Getenv("JAEGER_URL"),
+		ChronosphereURL:      os.Getenv("CHRONOSPHERE_URL"),
+		ChronosphereAPIKey:   os.Getenv("CHRONOSPHERE_API_KEY"),
+		PinotURL:             os.Getenv("PINOT_URL"),
+		PinotAuthToken:       os.Getenv("PINOT_AUTH_TOKEN"),
+		PinotUsername:        os.Getenv("PINOT_USERNAME"),
+		PinotPassword:        os.Getenv("PINOT_PASSWORD"),
+		HTTPProxyTargets:     os.Getenv("HTTP_PROXY_TARGETS"),
+		LokiRulesURL:         os.Getenv("LOKI_RULES_URL"),
+		HTTPListenAddr:       cmp(os.Getenv("HTTP_LISTEN_ADDR"), ":5000"),
+		PprofEnabled:         envBool("PPROF_ENABLED", false),
 		// K8s subsystems default-on so the agent is drop-in compatible with
 		// the legacy runner Deployment — no env additions needed for cutover.
 		// Operators can opt out per-subsystem via DISCOVERY_ENABLED=false etc.

--- a/runner/pkg/config/config_test.go
+++ b/runner/pkg/config/config_test.go
@@ -50,9 +50,8 @@ func TestFromEnv_ReadsAllFields(t *testing.T) {
 		LokiURL:           "http://loki:3100",
 		LokiHeaders:       "X-Scope-OrgID: t1",
 		HTTPListenAddr:    ":7000",
-		// ES enable/SSL-verify default on when their env vars are unset.
-		ElasticsearchEnabled:   true,
-		ElasticsearchSSLVerify: true,
+		// ES enable defaults on when ELASTICSEARCH_ENABLED is unset.
+		ElasticsearchEnabled: true,
 		// K8s subsystems default-on (drop-in compatible with the legacy runner);
 		// operators opt out per-subsystem via DISCOVERY_ENABLED=false etc.
 		DiscoveryEnabled:   true,

--- a/runner/pkg/config/config_test.go
+++ b/runner/pkg/config/config_test.go
@@ -50,6 +50,9 @@ func TestFromEnv_ReadsAllFields(t *testing.T) {
 		LokiURL:           "http://loki:3100",
 		LokiHeaders:       "X-Scope-OrgID: t1",
 		HTTPListenAddr:    ":7000",
+		// ES enable/SSL-verify default on when their env vars are unset.
+		ElasticsearchEnabled:   true,
+		ElasticsearchSSLVerify: true,
 		// K8s subsystems default-on (drop-in compatible with the legacy runner);
 		// operators opt out per-subsystem via DISCOVERY_ENABLED=false etc.
 		DiscoveryEnabled:   true,


### PR DESCRIPTION
## Context

Surfaced while debugging an `iteration-prod` agent that showed **Logs: Disconnected / Provider: ES / URL: https://opensearch-cluster-master.opensearch.svc.cluster.local:9200** even though logs were configured for Loki. Root cause was three distinct bugs in the agent's logs-provider handling.

## Bugs fixed

1. **ES selected on URL-presence alone.** `probeLogsProvider` gated only on `ELASTICSEARCH_URL != ""` and never read `ELASTICSEARCH_ENABLED`. A stray `ELASTICSEARCH_URL` (here injected via `runner.additional_env_vars`) silently overrode a working Loki provider — and setting `ELASTICSEARCH_ENABLED=false` did nothing. Now gated on `ElasticsearchEnabled`, which defaults to `true` when the env is unset (legacy URL-presence behaviour preserved).

2. **ES health probe ignored its own config.** The probe hit `/_cluster/health` with strict TLS verification and **no auth**, so a secured / self-signed OpenSearch always reported "disconnected" even when the configured credentials worked. The probe now sends the configured API key / basic auth and honours `ELASTICSEARCH_SSL_VERIFY`, matching the query client.

3. **Loki probe path mismatch.** The probe hit `{LOKI_URL}/ready`, which the loki gateway returns **404** for (it only proxies `/loki/...` API paths). This produced a false-negative "disconnected" while queries worked. Verified in-cluster: `/ready` → 404, `/loki/api/v1/status/buildinfo` → 200. Switched the probe to the buildinfo endpoint.

## Changes

- `pkg/config`: new `ElasticsearchEnabled` / `ElasticsearchSSLVerify` (env `ELASTICSEARCH_ENABLED` / `ELASTICSEARCH_SSL_VERIFY`, both default true).
- `cmd/agent`: gate ES selection + client on `enabled`; ES probe uses auth + TLS posture (`esHTTPClient` / `esAuthHeader`); Loki probe path → `/loki/api/v1/status/buildinfo`.
- chart: `runner.es.enabled` / `runner.es.sslVerify` values surface the new env (omitted when defaults hold).
- tests: disabled-fallthrough-to-Loki, ES auth + insecure-TLS success, strict-TLS reject of self-signed.

## Test

`go build ./... && go test ./...` green; `golangci-lint` clean; `helm template` renders the new env only when non-default.