### PR TITLE
feat(rightsize): port rightsizing_resource apply action from the legacy agent

### DIFF
--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -61,7 +61,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-06-09T06-20-22_0a83b93f21e8aed2b300de8a6618a7e15e436fa3
+    tag: 2026-06-09T11-54-39_e79a2ba05fffea44c0af9b00fa46b7938ad3ee2d
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/runner/cmd/agent/main.go
+++ b/runner/cmd/agent/main.go
@@ -574,6 +574,20 @@ func run(ctx context.Context, logger *slog.Logger, cfg *config.Config) error {
 			"prometheus", promClient != nil, "dynamic_client", dynamicKube != nil)
 	}
 
+	// rightsizing_resource: applies a backend-computed recommendation (explicit
+	// per-container cpu/mem request+limit + correlation annotations) to a
+	// workload. Needs only the dynamic client (read + Update across
+	// Deployment/StatefulSet/DaemonSet/Rollout/Pod). Delivered via the
+	// agent_task poller (pkg/tasks) — a trusted path — so it is a plain handler
+	// and is NOT a lightAction (an unsigned WS delivery of a mutation is
+	// correctly rejected). Skipped when the dynamic client is unavailable.
+	if dynamicKube != nil {
+		handlers["rightsizing_resource"] = rightsize.NewApplier(dynamicKube).Handle
+		logger.Info("rightsizing_resource enabled")
+	} else {
+		logger.Warn("rightsizing_resource disabled — needs a dynamic K8s client")
+	}
+
 	// Read primitives are light-action (no signature). Mutations and pod-exec
 	// actions are NOT in lightActions, so the dispatcher rejects them unless
 	// the request carries a valid HMAC signature OR RSA partial-keys.

--- a/runner/pkg/rightsize/apply.go
+++ b/runner/pkg/rightsize/apply.go
@@ -1,0 +1,275 @@
+package rightsize
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+// rightsizing_resource — apply a backend-computed recommendation (explicit
+// per-container CPU/memory request+limit, plus correlation annotations) to a
+// workload. A faithful port of the legacy Python playbook action
+// playbooks/nudgebee_playbooks/rightsizing.py:rightsizing_resource.
+//
+// Distinct from continuous_rightsizing (rightsize.go): that action samples
+// Prometheus and *computes* the recommendation; this one *applies* values the
+// backend already decided. Driven by api-server's ApplyRecommendation
+// (account/adapter/kuberntes.go) over the agent_task poller (pkg/tasks) — a
+// trusted GET/POST path — so it carries no signature and is registered as a
+// plain handler, NOT a lightAction (an unsigned WS delivery of a mutation is
+// correctly rejected).
+
+// applyKind describes how to read + patch one workload kind on the apply path.
+type applyKind struct {
+	gvr           schema.GroupVersionResource
+	containerPath []string // nested path to the []container slice
+	noop          bool     // Job: accepted but intentionally not applied (legacy parity)
+}
+
+// workloadContainerPath is where every controller kind exposes its pod template
+// containers. Pods expose them one level up (spec.containers).
+var workloadContainerPath = []string{"spec", "template", "spec", "containers"}
+
+// applyKinds mirrors the legacy RIGHTSIZING_HANDLERS map exactly: Deployment,
+// Pod, Job (no-op), DaemonSet, StatefulSet, Rollout. ReplicaSet is deliberately
+// absent — the Python handler map had no ReplicaSet entry, so the backend got
+// RESOURCE_NOT_SUPPORTED for it; we preserve that rather than silently start
+// patching a Deployment-owned ReplicaSet (which the controller would revert).
+var applyKinds = map[string]applyKind{
+	"Deployment":  {gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}, containerPath: workloadContainerPath},
+	"StatefulSet": {gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "statefulsets"}, containerPath: workloadContainerPath},
+	"DaemonSet":   {gvr: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "daemonsets"}, containerPath: workloadContainerPath},
+	"Rollout":     {gvr: schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "rollouts"}, containerPath: workloadContainerPath},
+	"Pod":         {gvr: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}, containerPath: []string{"spec", "containers"}},
+	"Job":         {noop: true},
+}
+
+// Applier applies explicit rightsizing recommendations. It needs only a dynamic
+// client (no Prometheus) — main registers it whenever the dynamic client is up.
+type Applier struct {
+	dyn dynamic.Interface
+}
+
+// NewApplier builds an Applier. dyn is required.
+func NewApplier(dyn dynamic.Interface) *Applier { return &Applier{dyn: dyn} }
+
+// containerChange is one container's target resources from the backend. An
+// empty string means "clear that key" — the backend sends JSON null for a
+// resource it doesn't want set, which decodes to "" here, and we delete it,
+// matching the legacy update_container_resources (None → del, value → set).
+type containerChange struct {
+	name   string
+	reqCPU string
+	limCPU string
+	reqMem string
+	limMem string
+}
+
+// Handle is the dispatch entry point for action_name "rightsizing_resource".
+// On success it returns {success:true, response:"Succeeded"}; the task poller
+// stores the map as the task response and the collector keys task status off
+// data["success"] (k8s-collector task_handler.save_task_status).
+func (a *Applier) Handle(ctx context.Context, params map[string]any) (any, error) {
+	kind := strField(params, "kind")
+	name := strField(params, "name")
+	namespace := strField(params, "namespace")
+	if kind == "" || name == "" || namespace == "" {
+		return nil, fmt.Errorf("rightsizing_resource: kind, name and namespace are required (got kind=%q name=%q namespace=%q)", kind, name, namespace)
+	}
+
+	spec, ok := applyKinds[kind]
+	if !ok {
+		return nil, fmt.Errorf("rightsizing_resource: %s rightsizing is not supported", kind)
+	}
+	if spec.noop {
+		// Legacy rightsize_job was a logged no-op. Report success so the
+		// recommendation resolves instead of the task retrying forever.
+		return map[string]any{"success": true, "response": "Succeeded", "msg": fmt.Sprintf("%s rightsizing not supported yet", kind)}, nil
+	}
+
+	changes, err := parseContainerChanges(params["containers"])
+	if err != nil {
+		return nil, fmt.Errorf("rightsizing_resource: %w", err)
+	}
+	annotations := parseAnnotations(params["annotations"])
+
+	ri := a.dyn.Resource(spec.gvr).Namespace(namespace)
+	obj, err := ri.Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("rightsizing_resource: get %s %s/%s: %w", kind, namespace, name, err)
+	}
+
+	if err := applyContainerChanges(obj, spec.containerPath, changes); err != nil {
+		return nil, fmt.Errorf("rightsizing_resource: %s %s/%s: %w", kind, namespace, name, err)
+	}
+	mergeAnnotations(obj, annotations)
+
+	// Dry-run first (the legacy handlers did a dry_run=All replace before the
+	// real apply) so an invalid spec fails the task cleanly instead of
+	// half-applying across containers.
+	if _, err := ri.Update(ctx, obj, metav1.UpdateOptions{DryRun: []string{metav1.DryRunAll}}); err != nil {
+		return nil, fmt.Errorf("rightsizing_resource: dry-run apply %s %s/%s: %w", kind, namespace, name, err)
+	}
+	if _, err := ri.Update(ctx, obj, metav1.UpdateOptions{}); err != nil {
+		return nil, fmt.Errorf("rightsizing_resource: apply %s %s/%s: %w", kind, namespace, name, err)
+	}
+
+	return map[string]any{"success": true, "response": "Succeeded"}, nil
+}
+
+// parseContainerChanges decodes the action_params.containers list. It rejects a
+// missing/empty list and an all-empty container entry, mirroring the legacy
+// RightsizingParams.validate_containers + Container.__init__ guards.
+func parseContainerChanges(raw any) ([]containerChange, error) {
+	list, _ := raw.([]any)
+	if len(list) == 0 {
+		return nil, fmt.Errorf("containers can not be empty")
+	}
+	out := make([]containerChange, 0, len(list))
+	for _, item := range list {
+		m, _ := item.(map[string]any)
+		if m == nil {
+			continue
+		}
+		c := containerChange{
+			name:   strField(m, "container_name"),
+			reqCPU: asString(m["cpu_request"]),
+			limCPU: asString(m["cpu_limit"]),
+			reqMem: asString(m["memory_request"]),
+			limMem: asString(m["memory_limit"]),
+		}
+		if c.name == "" {
+			return nil, fmt.Errorf("container entry missing container_name")
+		}
+		if c.reqCPU == "" && c.limCPU == "" && c.reqMem == "" && c.limMem == "" {
+			return nil, fmt.Errorf("container %q: all resource values can not be empty", c.name)
+		}
+		if err := validateChange(c); err != nil {
+			return nil, err
+		}
+		out = append(out, c)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("containers can not be empty")
+	}
+	return out, nil
+}
+
+// validateChange enforces request <= limit per resource when both are set,
+// mirroring the legacy validate_changes.
+func validateChange(c containerChange) error {
+	if err := requestNotAboveLimit(c.reqCPU, c.limCPU); err != nil {
+		return fmt.Errorf("container %q cpu: %w", c.name, err)
+	}
+	if err := requestNotAboveLimit(c.reqMem, c.limMem); err != nil {
+		return fmt.Errorf("container %q memory: %w", c.name, err)
+	}
+	return nil
+}
+
+// requestNotAboveLimit errors when both request and limit are set and the
+// request exceeds the limit. Either side empty (not being changed) passes.
+func requestNotAboveLimit(req, lim string) error {
+	if req == "" || lim == "" {
+		return nil
+	}
+	rq, err := resource.ParseQuantity(req)
+	if err != nil {
+		return fmt.Errorf("invalid request quantity %q: %w", req, err)
+	}
+	lq, err := resource.ParseQuantity(lim)
+	if err != nil {
+		return fmt.Errorf("invalid limit quantity %q: %w", lim, err)
+	}
+	if rq.Cmp(lq) > 0 {
+		return fmt.Errorf("request %s must be <= limit %s", req, lim)
+	}
+	return nil
+}
+
+// applyContainerChanges sets the request/limit values on each named container
+// found at path. Reuses setContainerResources (rightsize.go) for the set-or-
+// delete semantics. Errors if the workload has no containers, or none of the
+// requested containers exist.
+func applyContainerChanges(obj *unstructured.Unstructured, path []string, changes []containerChange) error {
+	containers, found, err := unstructured.NestedSlice(obj.Object, path...)
+	if err != nil {
+		return fmt.Errorf("read containers: %w", err)
+	}
+	if !found || len(containers) == 0 {
+		return fmt.Errorf("no containers at %s", strings.Join(path, "."))
+	}
+
+	byName := make(map[string]containerChange, len(changes))
+	for _, c := range changes {
+		byName[c.name] = c
+	}
+
+	matched := 0
+	for i := range containers {
+		c, _ := containers[i].(map[string]any)
+		if c == nil {
+			continue
+		}
+		cname, _ := c["name"].(string)
+		ch, ok := byName[cname]
+		if !ok {
+			continue
+		}
+		matched++
+		setContainerResources(c, ch.reqCPU, ch.reqMem, ch.limCPU, ch.limMem)
+		containers[i] = c
+	}
+	if matched == 0 {
+		return fmt.Errorf("none of the requested containers were found in the workload")
+	}
+
+	if err := unstructured.SetNestedSlice(obj.Object, containers, path...); err != nil {
+		return fmt.Errorf("rebuild containers: %w", err)
+	}
+	return nil
+}
+
+// parseAnnotations coerces action_params.annotations into a string map,
+// dropping nil / "None" / empty values exactly like the legacy
+// nb_annotations_cleaned filter.
+func parseAnnotations(raw any) map[string]string {
+	m, _ := raw.(map[string]any)
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		if v == nil {
+			continue
+		}
+		s := asString(v)
+		if s == "" || s == "None" {
+			continue
+		}
+		out[k] = s
+	}
+	return out
+}
+
+// mergeAnnotations merges the cleaned annotations onto the workload metadata,
+// preserving any existing annotations (legacy: metadata.annotations.update()).
+func mergeAnnotations(obj *unstructured.Unstructured, annotations map[string]string) {
+	if len(annotations) == 0 {
+		return
+	}
+	ann := obj.GetAnnotations()
+	if ann == nil {
+		ann = map[string]string{}
+	}
+	for k, v := range annotations {
+		ann[k] = v
+	}
+	obj.SetAnnotations(ann)
+}

--- a/runner/pkg/rightsize/apply_test.go
+++ b/runner/pkg/rightsize/apply_test.go
@@ -1,0 +1,227 @@
+package rightsize
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+// applyScheme registers the GVRs the apply path understands so the dynamic fake
+// recognises them (the fake 404s a Get for an unregistered GVR). Skips the
+// no-op Job entry, which has no GVR.
+func applyScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	for kind, entry := range applyKinds {
+		if entry.noop {
+			continue
+		}
+		gvr := entry.gvr
+		s.AddKnownTypeWithName(
+			schema.GroupVersionKind{Group: gvr.Group, Version: gvr.Version, Kind: kind},
+			&unstructured.Unstructured{},
+		)
+		s.AddKnownTypeWithName(
+			schema.GroupVersionKind{Group: gvr.Group, Version: gvr.Version, Kind: kind + "List"},
+			&unstructured.UnstructuredList{},
+		)
+	}
+	return s
+}
+
+// deploymentWith builds a Deployment with one container carrying the given
+// resources (nil resources → no resources block).
+func deploymentWith(name, ns, container string, resources map[string]any) *unstructured.Unstructured {
+	c := map[string]any{"name": container, "image": "nginx"}
+	if resources != nil {
+		c["resources"] = resources
+	}
+	u := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata":   map[string]any{"name": name, "namespace": ns},
+		"spec": map[string]any{
+			"template": map[string]any{
+				"spec": map[string]any{"containers": []any{c}},
+			},
+		},
+	}}
+	return u
+}
+
+func getContainer0(t *testing.T, obj *unstructured.Unstructured) map[string]any {
+	t.Helper()
+	containers, _, err := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "containers")
+	if err != nil || len(containers) == 0 {
+		t.Fatalf("no containers: %v", err)
+	}
+	c, _ := containers[0].(map[string]any)
+	return c
+}
+
+func TestApply_Deployment_SetsRequestsLimitsAndAnnotations(t *testing.T) {
+	existing := deploymentWith("web", "shop", "app", map[string]any{
+		"requests": map[string]any{"cpu": "100m", "memory": "128Mi"},
+	})
+	dyn := dynamicfake.NewSimpleDynamicClient(applyScheme(), existing)
+	a := NewApplier(dyn)
+
+	params := map[string]any{
+		"kind":      "Deployment",
+		"name":      "web",
+		"namespace": "shop",
+		"containers": []any{
+			map[string]any{
+				"container_name": "app",
+				"cpu_request":    "250m",
+				"cpu_limit":      "500m",
+				"memory_request": "256Mi",
+				"memory_limit":   "512Mi",
+			},
+		},
+		"annotations": map[string]any{
+			"recommendation_apply.vertical-scaler": `{"id":"r1"}`,
+			"skip_me":                              "None", // filtered out
+			"skip_nil":                             nil,    // filtered out
+		},
+	}
+
+	res, err := a.Handle(context.Background(), params)
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if m, _ := res.(map[string]any); m["success"] != true {
+		t.Fatalf("want success=true, got %v", res)
+	}
+
+	// Read back the persisted object.
+	got, err := dyn.Resource(applyKinds["Deployment"].gvr).Namespace("shop").
+		Get(context.Background(), "web", metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := getContainer0(t, got)
+	r := c["resources"].(map[string]any)
+	req := r["requests"].(map[string]any)
+	lim := r["limits"].(map[string]any)
+	if req["cpu"] != "250m" || req["memory"] != "256Mi" {
+		t.Errorf("requests = %v; want cpu=250m memory=256Mi", req)
+	}
+	if lim["cpu"] != "500m" || lim["memory"] != "512Mi" {
+		t.Errorf("limits = %v; want cpu=500m memory=512Mi", lim)
+	}
+	ann := got.GetAnnotations()
+	if ann["recommendation_apply.vertical-scaler"] != `{"id":"r1"}` {
+		t.Errorf("annotation not applied: %v", ann)
+	}
+	if _, ok := ann["skip_me"]; ok {
+		t.Errorf(`"None"-valued annotation should be filtered: %v`, ann)
+	}
+	if _, ok := ann["skip_nil"]; ok {
+		t.Errorf("nil-valued annotation should be filtered: %v", ann)
+	}
+}
+
+func TestApply_ClearsResourceWhenValueEmpty(t *testing.T) {
+	existing := deploymentWith("web", "shop", "app", map[string]any{
+		"requests": map[string]any{"cpu": "100m", "memory": "128Mi"},
+		"limits":   map[string]any{"cpu": "200m", "memory": "256Mi"},
+	})
+	dyn := dynamicfake.NewSimpleDynamicClient(applyScheme(), existing)
+	a := NewApplier(dyn)
+
+	// Only memory_request set; cpu_* and memory_limit are null → cleared.
+	params := map[string]any{
+		"kind": "Deployment", "name": "web", "namespace": "shop",
+		"containers": []any{map[string]any{
+			"container_name": "app",
+			"memory_request": "200Mi",
+		}},
+	}
+	if _, err := a.Handle(context.Background(), params); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+
+	got, _ := dyn.Resource(applyKinds["Deployment"].gvr).Namespace("shop").
+		Get(context.Background(), "web", metav1.GetOptions{})
+	r := getContainer0(t, got)["resources"].(map[string]any)
+	req := r["requests"].(map[string]any)
+	if req["memory"] != "200Mi" {
+		t.Errorf("memory request = %v; want 200Mi", req["memory"])
+	}
+	if _, ok := req["cpu"]; ok {
+		t.Errorf("cpu request should have been cleared: %v", req)
+	}
+	// memory limit cleared; cpu limit also cleared → limits map removed.
+	if _, ok := r["limits"]; ok {
+		t.Errorf("limits should have been removed once empty: %v", r)
+	}
+}
+
+func TestApply_RequestAboveLimitRejected(t *testing.T) {
+	a := NewApplier(dynamicfake.NewSimpleDynamicClient(applyScheme()))
+	params := map[string]any{
+		"kind": "Deployment", "name": "web", "namespace": "shop",
+		"containers": []any{map[string]any{
+			"container_name": "app",
+			"cpu_request":    "500m",
+			"cpu_limit":      "250m", // request > limit
+		}},
+	}
+	if _, err := a.Handle(context.Background(), params); err == nil {
+		t.Fatal("expected error for request > limit, got nil")
+	}
+}
+
+func TestApply_UnsupportedKind(t *testing.T) {
+	a := NewApplier(dynamicfake.NewSimpleDynamicClient(applyScheme()))
+	// ReplicaSet is intentionally unsupported (legacy parity).
+	params := map[string]any{
+		"kind": "ReplicaSet", "name": "web", "namespace": "shop",
+		"containers": []any{map[string]any{"container_name": "app", "cpu_request": "100m"}},
+	}
+	if _, err := a.Handle(context.Background(), params); err == nil {
+		t.Fatal("expected unsupported-kind error, got nil")
+	}
+}
+
+func TestApply_JobIsNoOpSuccess(t *testing.T) {
+	a := NewApplier(dynamicfake.NewSimpleDynamicClient(applyScheme()))
+	params := map[string]any{
+		"kind": "Job", "name": "batch", "namespace": "shop",
+		"containers": []any{map[string]any{"container_name": "app", "cpu_request": "100m"}},
+	}
+	res, err := a.Handle(context.Background(), params)
+	if err != nil {
+		t.Fatalf("Job should be a no-op success, got err: %v", err)
+	}
+	if m, _ := res.(map[string]any); m["success"] != true {
+		t.Fatalf("Job no-op should report success, got %v", res)
+	}
+}
+
+func TestApply_EmptyContainersRejected(t *testing.T) {
+	a := NewApplier(dynamicfake.NewSimpleDynamicClient(applyScheme()))
+	params := map[string]any{
+		"kind": "Deployment", "name": "web", "namespace": "shop",
+		"containers": []any{},
+	}
+	if _, err := a.Handle(context.Background(), params); err == nil {
+		t.Fatal("expected error for empty containers, got nil")
+	}
+}
+
+func TestApply_WorkloadNotFound(t *testing.T) {
+	a := NewApplier(dynamicfake.NewSimpleDynamicClient(applyScheme()))
+	params := map[string]any{
+		"kind": "Deployment", "name": "ghost", "namespace": "shop",
+		"containers": []any{map[string]any{"container_name": "app", "cpu_request": "100m"}},
+	}
+	if _, err := a.Handle(context.Background(), params); err == nil {
+		t.Fatal("expected not-found error, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

api-server's `ApplyRecommendation` drives a `rightsizing_resource` agent task (`account/adapter/kuberntes.go`) to apply a backend-computed vertical-scaling recommendation, but the new Go agent had no handler for it — so applying a RightSizing recommendation 404'd at the agent and the task never completed. This ports the action from the legacy Python agent (`playbooks/nudgebee_playbooks/rightsizing.py`), as the **apply-side sibling** of the `continuous_rightsizing` port in #457.

`pkg/rightsize/apply.go` adds `Applier.Handle`:
- parses `{kind, name, namespace, containers[], annotations}`
- sets each named container's cpu/mem request+limit via the dynamic client
- merges correlation annotations (filtering null/`"None"`/empty)
- dry-run `Update` then real `Update` (mirrors the legacy `dry_run=All` replace-then-apply)
- returns `{success:true, response:"Succeeded"}` (collector keys task status off `data["success"]`)

Delivered via the trusted `agent_task` poller (`pkg/tasks`) — no signature — so it is a plain handler and **not** a light-action; an unsigned WS delivery of this mutation stays rejected.

Kind set mirrors the legacy `RIGHTSIZING_HANDLERS` exactly: Deployment / StatefulSet / DaemonSet / Rollout / Pod, with **Job a no-op success** and **ReplicaSet intentionally unsupported** (legacy parity → `RESOURCE_NOT_SUPPORTED`). `request <= limit` is validated per resource.

## Type of change

- [x] New feature (non-breaking)

## Chart version

- [x] No version bump needed — runner code only. The runner image tag in `charts/nudgebee-agent/values.yaml` is bumped automatically by `update-image-tags.yml` after merge (same as #457); no chart templates/values are touched here.

## Test plan

Runner-only change, so the helm-lint items aren't applicable:

- `go build ./...` — passes
- `go vet ./...` — clean
- `gofmt -l` — clean
- `go test ./pkg/rightsize/` — passes (7 new tests: apply sets requests/limits/annotations, clear-on-empty, request>limit rejected, unsupported kind, Job no-op, empty containers, workload-not-found)
- golangci-lint runs in CI (local run blocked by a go1.25 vs 1.26.3 toolchain mismatch)

## Related issues

Sibling of #457 (the `continuous_rightsizing` port).

🤖 Generated with [Claude Code](https://claude.com/claude-code)