### PR TITLE
fix(kube): accept kind in read family, resolve to GVR

### DIFF
--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -61,7 +61,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-06-09T11-54-39_e79a2ba05fffea44c0af9b00fa46b7938ad3ee2d
+    tag: 2026-06-11T03-52-06_de087656560d1ffe7e1ba51bbf5a3b0fe2da1f9f
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/runner/docs/actions.md
+++ b/runner/docs/actions.md
@@ -112,6 +112,8 @@ Use `target: "*"` only if the operator opts into wildcard mode (ON only when `*=
 | `list_resource_names` | Just names + namespaces | (same as get_resource) |
 | `kubectl_command_executor` | Run kubectl with read verbs only | `command` (full kubectl line) |
 
+The read family also accepts the legacy/UI shape `kind` ("Deployment") in place of `group`/`version`/`resource_type` — it's resolved to the canonical GVR for common built-in kinds and the workload CRDs (see `pkg/kube/kind_resolver.go`). An explicit `resource_type` always wins over `kind`; arbitrary/CRD kinds not in the table must pass an explicit GVR.
+
 `kubectl_command_executor` enforces a **read-only verb allowlist**: `get`, `describe`, `logs`, `top`, `explain`, `api-resources`, `api-versions`, `version`, `cluster-info`, `config`, `auth`. Mutating verbs (`apply`, `delete`, `patch`, etc.) are rejected — they go through Group D actions instead, which require RSA partial-keys.
 
 ## Group C — Pod-exec  🔐

--- a/runner/pkg/kube/dynamic.go
+++ b/runner/pkg/kube/dynamic.go
@@ -53,7 +53,7 @@ type GetParams struct {
 }
 
 func ParseGetParams(p map[string]any) GetParams {
-	return GetParams{
+	gp := GetParams{
 		Group:         strParam(p, "group"),
 		Version:       strParam(p, "version"),
 		ResourceType:  strParam(p, "resource_type"),
@@ -61,6 +61,26 @@ func ParseGetParams(p map[string]any) GetParams {
 		Name:          strParam(p, "name"),
 		AllNamespaces: boolParam(p, "all_namespaces"),
 	}
+	// Backward-compat with the legacy `kind`-based contract (and the UI built
+	// on it): callers that address a resource by `kind` ("Deployment") instead
+	// of an explicit GVR used to work, but requiring resource_type made
+	// {name, namespace, kind} fail with "version and resource_type are
+	// required". When resource_type is absent, resolve the kind to its
+	// canonical GVR (see kind_resolver.go). An explicit GVR always wins:
+	// resource_type set ⇒ kind ignored; an explicitly-provided group/version
+	// is preserved over the table's canonical one.
+	if gp.ResourceType == "" {
+		if gvr, ok := resolveKind(strParam(p, "kind")); ok {
+			gp.ResourceType = gvr.Resource
+			if gp.Group == "" {
+				gp.Group = gvr.Group
+			}
+			if gp.Version == "" {
+				gp.Version = gvr.Version
+			}
+		}
+	}
+	return gp
 }
 
 // GetResource fetches resources matching p and returns them as a FLAT array

--- a/runner/pkg/kube/kind_resolver.go
+++ b/runner/pkg/kube/kind_resolver.go
@@ -1,0 +1,95 @@
+package kube
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// kindToGVR maps a user-facing resource Kind (lowercased) to its canonical
+// GroupVersionResource.
+//
+// Why this exists: the read family (get_resource / get_resource_yaml /
+// list_resource_names) addresses resources by an explicit GVR
+// (group/version/resource_type). But the legacy `kind`-based contract these
+// actions replaced — and every existing caller built against it (the UI's
+// KubernetesPodYaml.tsx / KubernetesWorkloads.jsx, api-server enrichers) —
+// addresses resources by `kind` ("Deployment"), not GVR. Requiring GVR was a
+// silent contract regression: a {name, namespace, kind} call fails with
+// "version and resource_type are required". This table restores kind-based
+// addressing without forcing every caller to learn GVRs.
+//
+// The agent's MUTATING handlers already accept `kind` via
+// mutate.supportedWorkloadKinds; this is the read-side counterpart. The two
+// maps are intentionally separate (mutate's carries namespaced/expectedKind
+// fields for write semantics and is workload-only). If a third kind→GVR table
+// shows up, consolidate then — see CLAUDE.md on not re-encoding the same fact.
+//
+// Scope: the common built-in kinds (a superset of the legacy enumerated set
+// node/deployment/statefulset/daemonset/job/persistentvolume/
+// persistentvolumeclaim/service/configmap/networkpolicy) plus the workload
+// CRDs the mutate side understands. Generic / arbitrary-CRD reads still use an
+// explicit GVR — which always wins over `kind` (see ParseGetParams).
+var kindToGVR = map[string]schema.GroupVersionResource{
+	// core/v1
+	"pod":                   {Group: "", Version: "v1", Resource: "pods"},
+	"service":               {Group: "", Version: "v1", Resource: "services"},
+	"configmap":             {Group: "", Version: "v1", Resource: "configmaps"},
+	"secret":                {Group: "", Version: "v1", Resource: "secrets"},
+	"persistentvolumeclaim": {Group: "", Version: "v1", Resource: "persistentvolumeclaims"},
+	"persistentvolume":      {Group: "", Version: "v1", Resource: "persistentvolumes"},
+	"node":                  {Group: "", Version: "v1", Resource: "nodes"},
+	"namespace":             {Group: "", Version: "v1", Resource: "namespaces"},
+	"serviceaccount":        {Group: "", Version: "v1", Resource: "serviceaccounts"},
+	"endpoints":             {Group: "", Version: "v1", Resource: "endpoints"},
+	"event":                 {Group: "", Version: "v1", Resource: "events"},
+	"replicationcontroller": {Group: "", Version: "v1", Resource: "replicationcontrollers"},
+	"limitrange":            {Group: "", Version: "v1", Resource: "limitranges"},
+	"resourcequota":         {Group: "", Version: "v1", Resource: "resourcequotas"},
+
+	// apps/v1
+	"deployment":  {Group: "apps", Version: "v1", Resource: "deployments"},
+	"daemonset":   {Group: "apps", Version: "v1", Resource: "daemonsets"},
+	"statefulset": {Group: "apps", Version: "v1", Resource: "statefulsets"},
+	"replicaset":  {Group: "apps", Version: "v1", Resource: "replicasets"},
+
+	// batch/v1
+	"job":     {Group: "batch", Version: "v1", Resource: "jobs"},
+	"cronjob": {Group: "batch", Version: "v1", Resource: "cronjobs"},
+
+	// networking.k8s.io/v1
+	"ingress":       {Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"},
+	"ingressclass":  {Group: "networking.k8s.io", Version: "v1", Resource: "ingressclasses"},
+	"networkpolicy": {Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicies"},
+
+	// autoscaling
+	"horizontalpodautoscaler": {Group: "autoscaling", Version: "v2", Resource: "horizontalpodautoscalers"},
+
+	// policy/v1
+	"poddisruptionbudget": {Group: "policy", Version: "v1", Resource: "poddisruptionbudgets"},
+
+	// rbac.authorization.k8s.io/v1
+	"role":               {Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"},
+	"rolebinding":        {Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"},
+	"clusterrole":        {Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"},
+	"clusterrolebinding": {Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterrolebindings"},
+
+	// storage.k8s.io/v1
+	"storageclass": {Group: "storage.k8s.io", Version: "v1", Resource: "storageclasses"},
+
+	// Workload CRDs — kept in sync with mutate.supportedWorkloadKinds so a
+	// resource the agent can mutate by kind is also readable by kind.
+	"rollout":      {Group: "argoproj.io", Version: "v1alpha1", Resource: "rollouts"},
+	"nodepool":     {Group: "karpenter.sh", Version: "v1", Resource: "nodepools"},
+	"ec2nodeclass": {Group: "karpenter.k8s.aws", Version: "v1", Resource: "ec2nodeclasses"},
+}
+
+// resolveKind maps a Kind string to its canonical GVR. Matching is
+// case-insensitive ("Deployment" and "deployment" both resolve) because the
+// UI sends the apiserver's CamelCase Kind while the legacy list_resource_names
+// contract used lowercase. Returns ok=false for kinds not in the table —
+// callers needing an arbitrary/CRD kind must pass an explicit GVR.
+func resolveKind(kind string) (schema.GroupVersionResource, bool) {
+	gvr, ok := kindToGVR[strings.ToLower(strings.TrimSpace(kind))]
+	return gvr, ok
+}

--- a/runner/pkg/kube/kind_resolver_test.go
+++ b/runner/pkg/kube/kind_resolver_test.go
@@ -1,0 +1,96 @@
+package kube
+
+import "testing"
+
+func TestResolveKind(t *testing.T) {
+	cases := []struct {
+		in       string
+		ok       bool
+		group    string
+		version  string
+		resource string
+	}{
+		{"Deployment", true, "apps", "v1", "deployments"},
+		{"deployment", true, "apps", "v1", "deployments"}, // case-insensitive
+		{" Deployment ", true, "apps", "v1", "deployments"},
+		{"Pod", true, "", "v1", "pods"},
+		{"ConfigMap", true, "", "v1", "configmaps"},
+		{"NetworkPolicy", true, "networking.k8s.io", "v1", "networkpolicies"},
+		{"Rollout", true, "argoproj.io", "v1alpha1", "rollouts"},
+		{"", false, "", "", ""},
+		{"NoSuchKind", false, "", "", ""},
+	}
+	for _, c := range cases {
+		gvr, ok := resolveKind(c.in)
+		if ok != c.ok {
+			t.Errorf("resolveKind(%q) ok = %v; want %v", c.in, ok, c.ok)
+			continue
+		}
+		if !ok {
+			continue
+		}
+		if gvr.Group != c.group || gvr.Version != c.version || gvr.Resource != c.resource {
+			t.Errorf("resolveKind(%q) = %s/%s/%s; want %s/%s/%s",
+				c.in, gvr.Group, gvr.Version, gvr.Resource, c.group, c.version, c.resource)
+		}
+	}
+}
+
+// The exact failing call from the field: {name, namespace, kind:"Deployment"}
+// must resolve to the apps/v1/deployments GVR instead of erroring.
+func TestParseGetParams_KindResolvesToGVR(t *testing.T) {
+	got := ParseGetParams(map[string]any{
+		"name":      "services-server",
+		"namespace": "nudgebee",
+		"kind":      "Deployment",
+	})
+	want := GetParams{
+		Group: "apps", Version: "v1", ResourceType: "deployments",
+		Namespace: "nudgebee", Name: "services-server",
+	}
+	if got != want {
+		t.Errorf("ParseGetParams kind path\n got:  %+v\n want: %+v", got, want)
+	}
+}
+
+// An explicit resource_type must win — kind is ignored when GVR is given.
+func TestParseGetParams_ExplicitResourceTypeWins(t *testing.T) {
+	got := ParseGetParams(map[string]any{
+		"group":         "apps",
+		"version":       "v1",
+		"resource_type": "statefulsets",
+		"kind":          "Deployment", // should be ignored
+		"name":          "db",
+	})
+	if got.ResourceType != "statefulsets" {
+		t.Errorf("explicit resource_type should win, got %q", got.ResourceType)
+	}
+}
+
+// A caller-provided version is preserved over the table's canonical one when
+// resolving by kind (only resource_type is unconditionally filled).
+func TestParseGetParams_KindPreservesExplicitVersion(t *testing.T) {
+	got := ParseGetParams(map[string]any{
+		"kind":    "HorizontalPodAutoscaler",
+		"version": "v1", // table canonical is v2; caller override must stick
+		"name":    "hpa",
+	})
+	if got.Version != "v1" {
+		t.Errorf("explicit version should be preserved, got %q", got.Version)
+	}
+	if got.ResourceType != "horizontalpodautoscalers" {
+		t.Errorf("resource_type should be filled from kind, got %q", got.ResourceType)
+	}
+}
+
+// An unknown kind with no explicit GVR leaves resource_type empty so the
+// downstream "version and resource_type are required" error still fires.
+func TestParseGetParams_UnknownKindLeavesEmpty(t *testing.T) {
+	got := ParseGetParams(map[string]any{
+		"kind": "SomeRandomCRD",
+		"name": "x",
+	})
+	if got.ResourceType != "" {
+		t.Errorf("unknown kind should not resolve, got resource_type %q", got.ResourceType)
+	}
+}


### PR DESCRIPTION
# Description

The agent's Kube **read family** (`get_resource`, `get_resource_yaml`, `list_resource_names`) requires an explicit `group`/`version`/`resource_type` GVR. But every existing caller — the UI (`KubernetesPodYaml.tsx`, `KubernetesWorkloads.jsx`) and the legacy `kind`-based contract these actions replaced — addresses resources by **`kind`** (e.g. `"Deployment"`), not GVR. So a `{name, namespace, kind}` call fails:

```
relay_forward_request → get_resource_yaml
  action_params: {name: "services-server", namespace: "nudgebee", kind: "Deployment"}
→ {"error": "kube: version and resource_type are required"}
```

This was a silent **contract regression** in the rewrite: the legacy `get_resource_yaml` expected the kind of the resource, its name and namespace, and the agent's own **mutating** handlers already accept `kind` (`mutate.supportedWorkloadKinds`). The read family was the lone outlier.

### Fix
`ParseGetParams` now resolves `kind` → canonical GVR via a new `kind_resolver.go` table **when `resource_type` is absent**:
- **Explicit GVR always wins** — `resource_type` set ⇒ `kind` ignored.
- A caller-provided `group`/`version` is **preserved** over the table's canonical one (only `resource_type` is unconditionally filled).
- Case-insensitive (`"Deployment"` and `"deployment"` both resolve).
- The table is a superset of the legacy enumerated kinds (node/deployment/statefulset/daemonset/job/pv/pvc/service/configmap/networkpolicy) + common built-ins + the workload CRDs the mutate side understands (Rollout, NodePool, EC2NodeClass).
- **Unknown / arbitrary CRD kinds** not in the table still require an explicit GVR — the existing required-fields error is unchanged for them (no silent wrong-resource).

No frontend change needed — the existing UI payload works once this ships.

Fixes the `get_resource_yaml` failure reported from the field (account `a2a30b02-…`).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] `go build ./...` — passes
- [x] `go test ./pkg/kube/` — passes (incl. new `kind_resolver_test.go`)
- [x] `gofmt`/`go vet` clean
- [x] New tests: field-exact failing call resolves to `apps/v1/deployments`; explicit-`resource_type`-wins; explicit-`version` preserved; unknown-kind leaves `resource_type` empty (downstream error preserved)

# Review Notes → Risks & Counterarguments

- **Second kind→GVR table.** `pkg/mutate` already has `supportedWorkloadKinds`. Kept separate intentionally — mutate's carries `namespaced`/`expectedKind` for write semantics and is workload-only; `pkg/kube` can't cleanly depend on `pkg/mutate`. Both are documented as needing consolidation if a third appears.
- **Static map is incomplete for arbitrary CRDs.** By design: generic/CRD reads keep using explicit GVR (the read family's primary path). A discovery-backed RESTMapper would be drift-free but is a larger change and the mutate side already accepts the static-map tradeoff. Reconsider if CRD-by-kind reads become common.
- **kind→GVR isn't 1:1** (e.g. `Ingress` across groups). The explicit-GVR override resolves ambiguity; the table returns the canonical modern GVR, matching the mutate-side assumptions.

> Note on base branch: this Go fix targets `main` because the read-family code (`runner/pkg/kube/`) exists **only on `main`** — `test`/`prod` are chart/release branches with no Go source. It reaches prod via the normal image-build + chart-promotion path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)