### PR TITLE
fix(agent): stop light-action 401s for unconfigured proxy datasources

### DIFF
--- a/charts/nudgebee-agent/templates/runner.yaml
+++ b/charts/nudgebee-agent/templates/runner.yaml
@@ -140,25 +140,25 @@ stringData:
   SIGNOZ_URL: {{ .Values.runner.signoz.url }}
   {{- end }}
   {{- if .Values.runner.jaeger.queryUrl }}
-  JAEGER_QUERY_URL: {{ .Values.runner.jaeger.queryUrl }}
+  JAEGER_QUERY_URL: {{ .Values.runner.jaeger.queryUrl | quote }}
   {{- end }}
   {{- if .Values.runner.chronosphere.url }}
-  CHRONOSPHERE_URL: {{ .Values.runner.chronosphere.url }}
+  CHRONOSPHERE_URL: {{ .Values.runner.chronosphere.url | quote }}
   {{- end }}
   {{- if .Values.runner.chronosphere.apiKey }}
-  CHRONOSPHERE_API_KEY: {{ .Values.runner.chronosphere.apiKey }}
+  CHRONOSPHERE_API_KEY: {{ .Values.runner.chronosphere.apiKey | quote }}
   {{- end }}
   {{- if .Values.runner.pinot.url }}
-  PINOT_URL: {{ .Values.runner.pinot.url }}
+  PINOT_URL: {{ .Values.runner.pinot.url | quote }}
   {{- end }}
   {{- if .Values.runner.pinot.authToken }}
-  PINOT_AUTH_TOKEN: {{ .Values.runner.pinot.authToken }}
+  PINOT_AUTH_TOKEN: {{ .Values.runner.pinot.authToken | quote }}
   {{- end }}
   {{- if .Values.runner.pinot.username }}
-  PINOT_USERNAME: {{ .Values.runner.pinot.username }}
+  PINOT_USERNAME: {{ .Values.runner.pinot.username | quote }}
   {{- end }}
   {{- if .Values.runner.pinot.password }}
-  PINOT_PASSWORD: {{ .Values.runner.pinot.password }}
+  PINOT_PASSWORD: {{ .Values.runner.pinot.password | quote }}
   {{- end }}
   {{- if and (or (index (default (dict) (index .Values "opentelemetry-collector")) "enabled") .Values.runner.clickhouse_enabled) (hasKey .Values.runner "clickhouse_password") }}
   CLICKHOUSE_PASSWORD: {{ .Values.runner.clickhouse_password }}

--- a/charts/nudgebee-agent/templates/runner.yaml
+++ b/charts/nudgebee-agent/templates/runner.yaml
@@ -139,6 +139,27 @@ stringData:
   {{- if .Values.runner.signoz.url }}
   SIGNOZ_URL: {{ .Values.runner.signoz.url }}
   {{- end }}
+  {{- if .Values.runner.jaeger.queryUrl }}
+  JAEGER_QUERY_URL: {{ .Values.runner.jaeger.queryUrl }}
+  {{- end }}
+  {{- if .Values.runner.chronosphere.url }}
+  CHRONOSPHERE_URL: {{ .Values.runner.chronosphere.url }}
+  {{- end }}
+  {{- if .Values.runner.chronosphere.apiKey }}
+  CHRONOSPHERE_API_KEY: {{ .Values.runner.chronosphere.apiKey }}
+  {{- end }}
+  {{- if .Values.runner.pinot.url }}
+  PINOT_URL: {{ .Values.runner.pinot.url }}
+  {{- end }}
+  {{- if .Values.runner.pinot.authToken }}
+  PINOT_AUTH_TOKEN: {{ .Values.runner.pinot.authToken }}
+  {{- end }}
+  {{- if .Values.runner.pinot.username }}
+  PINOT_USERNAME: {{ .Values.runner.pinot.username }}
+  {{- end }}
+  {{- if .Values.runner.pinot.password }}
+  PINOT_PASSWORD: {{ .Values.runner.pinot.password }}
+  {{- end }}
   {{- if and (or (index (default (dict) (index .Values "opentelemetry-collector")) "enabled") .Values.runner.clickhouse_enabled) (hasKey .Values.runner "clickhouse_password") }}
   CLICKHOUSE_PASSWORD: {{ .Values.runner.clickhouse_password }}
   {{- end }}

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -145,6 +145,25 @@ runner:
     # Set to enable SigNoz actions. Surfaces as SIGNOZ_URL.
     url: ""
     apiKey: ""
+  jaeger:
+    # In-cluster Jaeger query endpoint. Set when the account uses
+    # traces=jaeger-via-agent so the agent can serve jaeger_query_* actions the
+    # backend dispatches. Surfaces as JAEGER_QUERY_URL (the agent falls back to
+    # it for JAEGER_URL). When empty, jaeger_query_* return a clear
+    # "not configured" error instead of failing auth.
+    queryUrl: ""
+  chronosphere:
+    # Chronosphere trace API endpoint. Surfaces as CHRONOSPHERE_URL. Empty →
+    # chronosphere_query_traces returns "not configured".
+    url: ""
+    apiKey: ""
+  pinot:
+    # Apache Pinot broker endpoint. Surfaces as PINOT_URL. Empty →
+    # pinot_* actions return "not configured".
+    url: ""
+    authToken: ""
+    username: ""
+    password: ""
   grafana:
     url: ""
     username: ""

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -61,7 +61,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-06-11T03-52-06_de087656560d1ffe7e1ba51bbf5a3b0fe2da1f9f
+    tag: 2026-06-11T05-00-18_d0e21617879bd1623413f463aad4d975f6964e6d
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/runner/cmd/agent/main.go
+++ b/runner/cmd/agent/main.go
@@ -140,6 +140,39 @@ func run(ctx context.Context, logger *slog.Logger, cfg *config.Config) error {
 		"health": {},
 	}
 
+	// registerProxy wires a read-only proxy datasource so the backend never
+	// gets a 401 "not in light-action allowlist" or 404 "action not
+	// registered" for it — even when the datasource isn't configured on THIS
+	// agent. The backend selects these actions from per-account integration
+	// config (e.g. traces=jaeger-via-agent), independent of the agent's env,
+	// so the action names must always be in the allowlist. When the datasource
+	// is enabled the real handlers are wired; when it's not, a stub returns a
+	// clear "not configured" error instead of failing auth. Same precedent as
+	// query_data / api_traces_enricher_v2 below, which register unconditionally
+	// so callers see a handled response rather than an auth rejection.
+	//
+	// `real` is the datasource's own Handlers() map — constructed even when
+	// disabled (the constructors are cheap and make no network calls), so the
+	// action NAMES always come straight from the package and can't drift.
+	// Only read-only proxies go through here; mutations / pod-exec stay out of
+	// lightActions and require HMAC or RSA partial-keys.
+	registerProxy := func(datasource string, enabled bool, real map[string]dispatch.Handler) {
+		for action, h := range real {
+			lightActions[action] = struct{}{}
+			if enabled {
+				handlers[action] = h
+				continue
+			}
+			// Don't clobber a real handler another subsystem already wired.
+			if _, exists := handlers[action]; !exists {
+				name := action
+				handlers[action] = func(context.Context, map[string]any) (any, error) {
+					return nil, fmt.Errorf("%s datasource not configured on this agent (action %q)", datasource, name)
+				}
+			}
+		}
+	}
+
 	// Build the K8s client up-front so service-discovery can run before any
 	// observability subsystem is wired. If construction fails, we fall back
 	// to env-only configuration — the agent still serves whatever URLs are
@@ -297,89 +330,72 @@ func run(ctx context.Context, logger *slog.Logger, cfg *config.Config) error {
 		logger.Info("loki enabled", "url", cfg.LokiURL, "actions", len(lh)+len(ch))
 	}
 
-	if cfg.ElasticsearchEnabled && cfg.ElasticsearchURL != "" {
-		ec := elasticsearch.New(cfg.ElasticsearchURL, nil)
-		ec.Username = cfg.ElasticsearchUser
-		ec.Password = cfg.ElasticsearchPassword
-		ec.APIKey = cfg.ElasticsearchAPIKey
-		eh := elasticsearch.Handlers(ec)
-		maps.Copy(handlers, eh)
-		for name := range eh {
-			lightActions[name] = struct{}{}
-		}
-		logger.Info("elasticsearch enabled", "url", cfg.ElasticsearchURL, "actions", len(eh))
+	esEnabled := cfg.ElasticsearchEnabled && cfg.ElasticsearchURL != ""
+	ec := elasticsearch.New(cfg.ElasticsearchURL, nil)
+	ec.Username = cfg.ElasticsearchUser
+	ec.Password = cfg.ElasticsearchPassword
+	ec.APIKey = cfg.ElasticsearchAPIKey
+	registerProxy("elasticsearch", esEnabled, elasticsearch.Handlers(ec))
+	if esEnabled {
+		logger.Info("elasticsearch enabled", "url", cfg.ElasticsearchURL)
 	}
 
+	sc := signoz.New(cfg.SignozURL, nil)
+	sc.APIKey = cfg.SignozAPIKey
+	registerProxy("signoz", cfg.SignozURL != "", signoz.Handlers(sc))
 	if cfg.SignozURL != "" {
-		sc := signoz.New(cfg.SignozURL, nil)
-		sc.APIKey = cfg.SignozAPIKey
-		sh := signoz.Handlers(sc)
-		maps.Copy(handlers, sh)
-		for name := range sh {
-			lightActions[name] = struct{}{}
-		}
-		logger.Info("signoz enabled", "url", cfg.SignozURL, "actions", len(sh))
+		logger.Info("signoz enabled", "url", cfg.SignozURL)
 	}
 
+	jc := jaeger.New(cfg.JaegerURL, nil)
+	registerProxy("jaeger", cfg.JaegerURL != "", jaeger.Handlers(jc))
 	if cfg.JaegerURL != "" {
-		jc := jaeger.New(cfg.JaegerURL, nil)
-		jh := jaeger.Handlers(jc)
-		maps.Copy(handlers, jh)
-		for name := range jh {
-			lightActions[name] = struct{}{}
-		}
-		logger.Info("jaeger enabled", "url", cfg.JaegerURL, "actions", len(jh))
+		logger.Info("jaeger enabled", "url", cfg.JaegerURL)
 	}
 
+	cc := chronosphere.New(cfg.ChronosphereURL, nil)
+	cc.APIKey = cfg.ChronosphereAPIKey
+	registerProxy("chronosphere", cfg.ChronosphereURL != "", chronosphere.Handlers(cc))
 	if cfg.ChronosphereURL != "" {
-		cc := chronosphere.New(cfg.ChronosphereURL, nil)
-		cc.APIKey = cfg.ChronosphereAPIKey
-		ch := chronosphere.Handlers(cc)
-		maps.Copy(handlers, ch)
-		for name := range ch {
-			lightActions[name] = struct{}{}
-		}
-		logger.Info("chronosphere enabled", "url", cfg.ChronosphereURL, "actions", len(ch))
+		logger.Info("chronosphere enabled", "url", cfg.ChronosphereURL)
 	}
 
+	pc := pinot.New(cfg.PinotURL, nil)
+	pc.AuthToken = cfg.PinotAuthToken
+	pc.Username = cfg.PinotUsername
+	pc.Password = cfg.PinotPassword
+	registerProxy("pinot", cfg.PinotURL != "", pinot.Handlers(pc))
 	if cfg.PinotURL != "" {
-		pc := pinot.New(cfg.PinotURL, nil)
-		pc.AuthToken = cfg.PinotAuthToken
-		pc.Username = cfg.PinotUsername
-		pc.Password = cfg.PinotPassword
-		ph := pinot.Handlers(pc)
-		maps.Copy(handlers, ph)
-		for name := range ph {
-			lightActions[name] = struct{}{}
-		}
-		logger.Info("pinot enabled", "url", cfg.PinotURL, "actions", len(ph))
+		logger.Info("pinot enabled", "url", cfg.PinotURL)
 	}
 
-	if targets := config.ParseTargets(cfg.HTTPProxyTargets); len(targets) > 0 {
-		hp := httpproxy.New(targets, nil)
-		ph := httpproxy.Handlers(hp)
-		maps.Copy(handlers, ph)
-		for name := range ph {
-			lightActions[name] = struct{}{}
-		}
-		logger.Info("http proxy enabled", "targets", len(targets), "actions", len(ph))
+	targets := config.ParseTargets(cfg.HTTPProxyTargets)
+	registerProxy("http_proxy", len(targets) > 0, httpproxy.Handlers(httpproxy.New(targets, nil)))
+	if len(targets) > 0 {
+		logger.Info("http proxy enabled", "targets", len(targets))
 	}
 
+	// GCP needs ADC, so we can't build a live client when disabled; a throwaway
+	// HTTP client gives registerProxy the action names (gke_logs / gke_traces)
+	// for the stub path without touching credentials.
+	gcpEnabled := false
+	var gcpClient *gcp.Client
 	if cfg.GCPEnabled {
-		gcpClient, err := gcp.New(ctx)
+		c, err := gcp.New(ctx)
 		if err != nil {
 			// Don't fail the whole agent — GCP creds might be missing on this
-			// cluster. Log and continue; gke_logs / gke_traces just won't be
-			// registered.
+			// cluster. Log and fall through to the not-configured stubs.
 			logger.Warn("gcp disabled: ADC unavailable", "err", err)
 		} else {
-			gh := gcp.Handlers(gcpClient, cfg.GCPProjectID)
-			maps.Copy(handlers, gh)
-			for name := range gh {
-				lightActions[name] = struct{}{}
-			}
-			logger.Info("gcp enabled", "default_project", cfg.GCPProjectID, "actions", len(gh))
+			gcpClient, gcpEnabled = c, true
 		}
+	}
+	if gcpClient == nil {
+		gcpClient = gcp.NewWithHTTP(nil)
+	}
+	registerProxy("gcp", gcpEnabled, gcp.Handlers(gcpClient, cfg.GCPProjectID))
+	if gcpEnabled {
+		logger.Info("gcp enabled", "default_project", cfg.GCPProjectID)
 	}
 
 	// logs_enricher (Finding-shape) reads pod logs through

--- a/runner/pkg/config/config.go
+++ b/runner/pkg/config/config.go
@@ -177,17 +177,23 @@ func FromEnv() (*Config, error) {
 		ElasticsearchEnabled: envBool("ELASTICSEARCH_ENABLED", true),
 		SignozURL:            os.Getenv("SIGNOZ_URL"),
 		SignozAPIKey:         os.Getenv("SIGNOZ_API_KEY"),
-		JaegerURL:            os.Getenv("JAEGER_URL"),
-		ChronosphereURL:      os.Getenv("CHRONOSPHERE_URL"),
-		ChronosphereAPIKey:   os.Getenv("CHRONOSPHERE_API_KEY"),
-		PinotURL:             os.Getenv("PINOT_URL"),
-		PinotAuthToken:       os.Getenv("PINOT_AUTH_TOKEN"),
-		PinotUsername:        os.Getenv("PINOT_USERNAME"),
-		PinotPassword:        os.Getenv("PINOT_PASSWORD"),
-		HTTPProxyTargets:     os.Getenv("HTTP_PROXY_TARGETS"),
-		LokiRulesURL:         os.Getenv("LOKI_RULES_URL"),
-		HTTPListenAddr:       cmp(os.Getenv("HTTP_LISTEN_ADDR"), ":5000"),
-		PprofEnabled:         envBool("PPROF_ENABLED", false),
+		// JAEGER_URL drives the jaeger read-proxy handlers + light-action
+		// allowlist. Fall back to JAEGER_QUERY_URL (the var the telemetry
+		// heartbeat uses to tell the backend jaeger is enabled) so a
+		// deployment that only sets JAEGER_QUERY_URL doesn't end up with the
+		// backend dispatching jaeger_query_* while the agent rejects them as
+		// "not in light-action allowlist".
+		JaegerURL:          cmp(os.Getenv("JAEGER_URL"), os.Getenv("JAEGER_QUERY_URL")),
+		ChronosphereURL:    os.Getenv("CHRONOSPHERE_URL"),
+		ChronosphereAPIKey: os.Getenv("CHRONOSPHERE_API_KEY"),
+		PinotURL:           os.Getenv("PINOT_URL"),
+		PinotAuthToken:     os.Getenv("PINOT_AUTH_TOKEN"),
+		PinotUsername:      os.Getenv("PINOT_USERNAME"),
+		PinotPassword:      os.Getenv("PINOT_PASSWORD"),
+		HTTPProxyTargets:   os.Getenv("HTTP_PROXY_TARGETS"),
+		LokiRulesURL:       os.Getenv("LOKI_RULES_URL"),
+		HTTPListenAddr:     cmp(os.Getenv("HTTP_LISTEN_ADDR"), ":5000"),
+		PprofEnabled:       envBool("PPROF_ENABLED", false),
 		// K8s subsystems default-on so the agent is drop-in compatible with
 		// the legacy runner Deployment — no env additions needed for cutover.
 		// Operators can opt out per-subsystem via DISCOVERY_ENABLED=false etc.


### PR DESCRIPTION
## Problem

Loki showed ~all light-action failures over the last 3 days were jaeger:
`jaeger_query_traces` (368) and `jaeger_query_services` (190), rejected with:

```
auth: action "jaeger_query_traces" not in light-action allowlist
```

Root cause is a class of bug, not just jaeger. The agent only registers a
datasource's actions — **both** the handler and the light-action allowlist
entry — when that datasource's URL is set at startup (`main.go`). But the
backend decides what to dispatch from each **account's integration config**
(e.g. `traces=jaeger-via-agent`), independent of the agent's env. So any
datasource the backend can select but the chart doesn't wire gets a 401.

The `nudgebee-agent` chart wires no jaeger URL at all, yet accounts configured
for jaeger-via-agent still dispatch `jaeger_query_*` → every one rejected.

Same latent risk for chronosphere, pinot, gke — they just aren't in use yet.

## Fix (whole class, not just jaeger)

- **`registerProxy()`** always adds a read-only proxy datasource's action names
  to the allowlist (sourced from the package's own `Handlers()` map, so names
  can't drift). URL set → real handler; URL unset → a stub returning a clear
  `"<datasource> not configured"` error instead of an auth rejection. Applied to
  jaeger, chronosphere, pinot, signoz, elasticsearch, gcp, http-proxy. Mirrors
  the existing `query_data` / `api_traces_enricher_v2` unconditional-register
  precedent. Prometheus/Loki left as-is (wired by default + auto-discovered).
- **config:** `JAEGER_URL` falls back to `JAEGER_QUERY_URL`, aligning handler
  registration with the var the telemetry heartbeat already reports.
- **chart:** first-class values for the optional trace datasources
  (`runner.jaeger.queryUrl`, `runner.chronosphere.{url,apiKey}`,
  `runner.pinot.{url,authToken,username,password}`), surfaced as env in the
  runner ConfigMap. This is what makes jaeger actually **return traces** — the
  stub only stops the auth failure.

## Behavior change

Dispatcher path for a dispatched-but-unconfigured datasource action goes from
**401** "not in light-action allowlist" (auth reject) to **200** when
configured, or **500** with an actionable "not configured" message when not.

## To resolve the affected tenant

Set `runner.jaeger.queryUrl` to the in-cluster jaeger-query endpoint and
restart the pod. Without it, jaeger goes 401 → "not configured" 500 — better,
but no traces until the URL is provided.

## Validation

- `gofmt` / `go vet` clean, `go build ./...` OK, agent test suites pass.
- `helm lint` passes; `helm template` renders the new env when set and omits it by default.