### PR TITLE
fix(triggers): gate node_not_ready on sustained NotReady, not transition

### DIFF
--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -61,7 +61,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-06-11T09-07-11_fc587257e673a32c92bc74a2bfbe0b6ac69b9303
+    tag: 2026-06-12T05-58-19_c641a9b173542834b0c8ba72be83b565a5adda80
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/runner/pkg/triggers/predicates.go
+++ b/runner/pkg/triggers/predicates.go
@@ -397,11 +397,22 @@ func jobFailureMatcher() MatcherSpec {
 	}
 }
 
-// ------- Node NotReady (transition) -------
+// ------- Node NotReady (sustained) -------
 
-// nodeNotReadyMatcher fires when a Node's Ready condition transitions
-// from True to False. Without the transition gate, a permanently-broken
-// Node would re-fire every kubelet heartbeat.
+// nodeNotReadyMinDuration is how long a Node must continuously report
+// Ready=False before it's worth a Finding. Short-lived NotReady is
+// expected churn — spot/preemptible reclaim, autoscaler scale-down, and
+// graceful-shutdown drains all flip a Node NotReady for well under a
+// minute right before it's deleted. Only a Node that stays NotReady past
+// this window is a real, still-present problem.
+const nodeNotReadyMinDuration = 15 * time.Minute
+
+// nodeNotReadyMatcher fires when a Node has been Ready=False for at least
+// nodeNotReadyMinDuration. This is level-triggered, not edge-triggered:
+// the predicate re-evaluates true on every heartbeat once the window is
+// crossed, so the RateLimit window (keyed on the per-episode fingerprint)
+// keeps a long outage from re-firing on each kubelet update. A Node that's
+// reclaimed quickly is deleted before the window elapses and never fires.
 func nodeNotReadyMatcher() MatcherSpec {
 	return MatcherSpec{
 		Name:           "node_not_ready",
@@ -410,14 +421,25 @@ func nodeNotReadyMatcher() MatcherSpec {
 		AggregationKey: "node_not_ready",
 		Priority:       "HIGH",
 		FindingType:    "issue",
-		RateLimit:      0, // transition-gated, no need
-		Predicate: func(obj, oldObj map[string]any) bool {
-			return nodeReadyStatus(obj) == "False" && nodeReadyStatus(oldObj) != "False"
+		// One fire per outage episode; re-fire only if it's still NotReady
+		// 6h later (the fingerprint pins the episode via lastTransitionTime).
+		RateLimit: 6 * time.Hour,
+		Predicate: func(obj, _ map[string]any) bool {
+			if nodeReadyStatus(obj) != "False" {
+				return false
+			}
+			ts := nodeReadyLastTransition(obj)
+			since, ok := durationSinceRFC3339(ts)
+			if !ok {
+				return false
+			}
+			return since >= nodeNotReadyMinDuration
 		},
 		FingerprintFn: func(obj map[string]any) string {
 			name := metaName(obj)
-			// Include lastTransitionTime so a flapping Node produces
-			// distinct Findings per transition rather than one forever.
+			// lastTransitionTime pins the NotReady episode: a Node that
+			// recovers and fails again gets a distinct fingerprint (and
+			// thus a distinct Finding) rather than reusing this one.
 			ts := nodeReadyLastTransition(obj)
 			return fp("node_not_ready", name, ts)
 		},
@@ -576,6 +598,19 @@ func nodeReadyLastTransition(obj map[string]any) string {
 		}
 	}
 	return ""
+}
+
+// durationSinceRFC3339 parses an RFC3339 timestamp and returns how long
+// ago it was, or ok=false if the string is empty/unparseable.
+func durationSinceRFC3339(ts string) (time.Duration, bool) {
+	if ts == "" {
+		return 0, false
+	}
+	t, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		return 0, false
+	}
+	return time.Since(t), true
 }
 
 func metaName(obj map[string]any) string {

--- a/runner/pkg/triggers/predicates.go
+++ b/runner/pkg/triggers/predicates.go
@@ -601,12 +601,14 @@ func nodeReadyLastTransition(obj map[string]any) string {
 }
 
 // durationSinceRFC3339 parses an RFC3339 timestamp and returns how long
-// ago it was, or ok=false if the string is empty/unparseable.
+// ago it was, or ok=false if the string is empty/unparseable. RFC3339Nano
+// is used so timestamps with fractional seconds parse too (the layout
+// makes the fractional part optional, so plain-seconds values still work).
 func durationSinceRFC3339(ts string) (time.Duration, bool) {
 	if ts == "" {
 		return 0, false
 	}
-	t, err := time.Parse(time.RFC3339, ts)
+	t, err := time.Parse(time.RFC3339Nano, ts)
 	if err != nil {
 		return 0, false
 	}

--- a/runner/pkg/triggers/predicates_test.go
+++ b/runner/pkg/triggers/predicates_test.go
@@ -694,27 +694,40 @@ func TestJobFailure_DoesNotRefireWhilePersistentlyFailed(t *testing.T) {
 
 // ---------- node_not_ready ----------
 
-func TestNodeNotReady_FiresOnTransitionTrueToFalse(t *testing.T) {
-	oldNode := asObj(t, `{
+// notReadyNode builds a Node fixture whose Ready condition has been False
+// since `ago` before now, so the duration gate can be exercised
+// deterministically relative to the test's wall clock.
+func notReadyNode(t *testing.T, ago time.Duration) map[string]any {
+	t.Helper()
+	ts := time.Now().Add(-ago).UTC().Format(time.RFC3339)
+	return asObj(t, `{
 		"metadata":{"name":"n1"},
-		"status":{"conditions":[{"type":"Ready","status":"True"}]}
+		"status":{"conditions":[{"type":"Ready","status":"False","lastTransitionTime":"`+ts+`"}]}
 	}`)
-	newNode := asObj(t, `{
-		"metadata":{"name":"n1"},
-		"status":{"conditions":[{"type":"Ready","status":"False","lastTransitionTime":"2026-05-07T13:00:00Z"}]}
-	}`)
-	if !nodeNotReadyMatcher().Predicate(newNode, oldNode) {
-		t.Error("predicate should fire on Ready True→False")
+}
+
+func TestNodeNotReady_FiresWhenNotReadyBeyondThreshold(t *testing.T) {
+	node := notReadyNode(t, nodeNotReadyMinDuration+5*time.Minute)
+	if !nodeNotReadyMatcher().Predicate(node, nil) {
+		t.Error("predicate should fire once a Node has been NotReady past the threshold")
 	}
 }
 
-func TestNodeNotReady_DoesNotRefireWhilePersistentlyNotReady(t *testing.T) {
-	notReady := asObj(t, `{
+func TestNodeNotReady_DoesNotFireBeforeThreshold(t *testing.T) {
+	// Short-lived NotReady (spot reclaim / drain) — under the window.
+	node := notReadyNode(t, 1*time.Minute)
+	if nodeNotReadyMatcher().Predicate(node, nil) {
+		t.Error("predicate must not fire while NotReady is still within the threshold window")
+	}
+}
+
+func TestNodeNotReady_DoesNotFireWhenReady(t *testing.T) {
+	ready := asObj(t, `{
 		"metadata":{"name":"n1"},
-		"status":{"conditions":[{"type":"Ready","status":"False"}]}
+		"status":{"conditions":[{"type":"Ready","status":"True"}]}
 	}`)
-	if nodeNotReadyMatcher().Predicate(notReady, notReady) {
-		t.Error("predicate must not refire when oldObj was already NotReady")
+	if nodeNotReadyMatcher().Predicate(ready, nil) {
+		t.Error("predicate must not fire for a Ready node")
 	}
 }
 

--- a/runner/pkg/triggers/predicates_test.go
+++ b/runner/pkg/triggers/predicates_test.go
@@ -721,6 +721,19 @@ func TestNodeNotReady_DoesNotFireBeforeThreshold(t *testing.T) {
 	}
 }
 
+func TestNodeNotReady_ParsesFractionalSecondTimestamp(t *testing.T) {
+	// Some sources emit lastTransitionTime with fractional seconds; it must
+	// still parse (RFC3339Nano), not silently fail and suppress the fire.
+	ts := time.Now().Add(-(nodeNotReadyMinDuration + 5*time.Minute)).UTC().Format("2006-01-02T15:04:05.000Z07:00")
+	node := asObj(t, `{
+		"metadata":{"name":"n1"},
+		"status":{"conditions":[{"type":"Ready","status":"False","lastTransitionTime":"`+ts+`"}]}
+	}`)
+	if !nodeNotReadyMatcher().Predicate(node, nil) {
+		t.Error("predicate should fire for a fractional-second lastTransitionTime past the threshold")
+	}
+}
+
 func TestNodeNotReady_DoesNotFireWhenReady(t *testing.T) {
 	ready := asObj(t, `{
 		"metadata":{"name":"n1"},


### PR DESCRIPTION
## Problem

The `node_not_ready` matcher fired on every `Ready: True→False` transition. On clusters with spot/preemptible or autoscaled node pools, every node reclaim, scale-down, and graceful-shutdown drain flipped a node NotReady for ~30–60s right before it was deleted — each raising a **HIGH** issue for a node that no longer exists.

Confirmed in the dev DB: **3,347** `node_not_ready` events, **346 distinct nodes in 7 days**, each firing once and never recovering under that name — the signature of lifecycle churn, not incidents. All on the all-spot `k8s-dev` runner pools.

## Change

Make the matcher **level-triggered on duration** instead of edge-triggered on transition:

- Fires only once a node has continuously reported `Ready=False` for **≥15m** (`nodeNotReadyMinDuration`). Reclaimed nodes are deleted before the window elapses → never fire. A genuinely stuck node still surfaces.
- Added `RateLimit: 6h` keyed on the per-episode fingerprint (`name + lastTransitionTime`), so the now level-triggered predicate doesn't re-fire on every kubelet heartbeat during a long outage. Recover-then-fail-again gets a new `lastTransitionTime` → new fingerprint → fires again.

## Performance

Neutral-to-cheaper. The rate limiter sits *before* the expensive evidence-fetch path in the engine, so churn events stop at the predicate (cheaper than before, which proceeded to fingerprint + 3 K8s events-table API calls per transition). Rate-limiter entries are only created for nodes that pass the 15m gate — the churny ones never reach `Allow`, so no memory growth.

## Notes

- Matches `Ready=False` only (unchanged). Unreachable nodes report `Ready=Unknown` and still won't fire — sustained-unreachable detection would be a follow-up.
- This stops new noise only; the existing OPEN `node_not_ready` backlog on `k8s-dev` is unaffected and can be cleared separately.

## Test

Rewrote the matcher tests for the duration gate (fires past threshold, silent within threshold, silent when Ready). `go build`, `go test ./pkg/triggers ./pkg/alerts`, `go vet` all pass.