### PR TITLE
feat: implement replica_rightsizing, rightsize_pvc, volume_delete agent_task remediations

### DIFF
--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -61,7 +61,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-06-15T07-37-24_c32d436823190c10409d9382076601c3bce0e930
+    tag: 2026-06-15T10-47-06_f694c523c6ce9a8c5d2fc3c923866e6bbed0b0c8
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/runner/cmd/actionctl/main.go
+++ b/runner/cmd/actionctl/main.go
@@ -72,7 +72,7 @@ func main() {
 		fatal("unknown action", fmt.Errorf("%q not registered (have it spelled right?)", *action))
 	}
 
-	params := map[string]any{}
+	var params map[string]any
 	switch *action {
 	case "replica_rightsizing":
 		if *replicas < 0 {
@@ -89,10 +89,10 @@ func main() {
 
 	fmt.Printf("→ %s %s\n", *action, mustJSON(params))
 	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
-	defer cancel()
 
 	start := time.Now()
 	data, err := h(ctx, params)
+	cancel() // done with ctx; explicit so the os.Exit paths below don't skip a defer
 	elapsed := time.Since(start).Round(time.Millisecond)
 	if err != nil {
 		fmt.Printf("✗ FAILED in %s: %v\n", elapsed, err)

--- a/runner/cmd/actionctl/main.go
+++ b/runner/cmd/actionctl/main.go
@@ -1,0 +1,112 @@
+// Command actionctl is a local dev harness for invoking the agent's
+// agent_task remediation handlers against a real cluster, without standing up
+// the relay / backend / poller. It builds the same mutate.Handlers map the
+// agent registers and calls one handler by action_name with a params map —
+// exactly what the task poller does via HandleTrusted.
+//
+// Cluster creds come from in-cluster config or, locally, $KUBECONFIG /
+// ~/.kube/config (k8sclient.New). Use it to exercise replica_rightsizing,
+// rightsize_pvc (expand + downsize migration), and volume_delete.
+//
+// Examples:
+//
+//	go run ./cmd/actionctl -action replica_rightsizing -kind Deployment -namespace demo -name web -replicas 0
+//	go run ./cmd/actionctl -action rightsize_pvc -namespace demo -name data -size 3Gi     # expand
+//	go run ./cmd/actionctl -action rightsize_pvc -namespace demo -name data -size 1Gi     # downsize migration
+//	go run ./cmd/actionctl -action volume_delete -pv pvc-abc123                            # PV name
+//
+// This is a mutation tool. It acts on whatever cluster your kubeconfig points
+// at — double-check the context first.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"k8s.io/client-go/dynamic"
+
+	"github.com/nudgebee/nudgebee-agent/internal/k8sclient"
+	"github.com/nudgebee/nudgebee-agent/pkg/mutate"
+	"github.com/nudgebee/nudgebee-agent/pkg/podexec"
+)
+
+func main() {
+	var (
+		action     = flag.String("action", "", "replica_rightsizing | rightsize_pvc | volume_delete")
+		kubeconfig = flag.String("kubeconfig", "", "kubeconfig path (default: $KUBECONFIG or ~/.kube/config)")
+		namespace  = flag.String("namespace", "", "namespace (rightsize_pvc, replica_rightsizing)")
+		name       = flag.String("name", "", "PVC name (rightsize_pvc) or workload name (replica_rightsizing)")
+		size       = flag.String("size", "", "target size for rightsize_pvc, e.g. 3Gi")
+		kind       = flag.String("kind", "", "Deployment | StatefulSet | Rollout (replica_rightsizing)")
+		replicas   = flag.Int("replicas", -1, "target replica count (replica_rightsizing)")
+		pv         = flag.String("pv", "", "PersistentVolume name (volume_delete)")
+		timeout    = flag.Duration("timeout", 55*time.Minute, "overall deadline (downsize copies can be slow)")
+	)
+	flag.Parse()
+	if *action == "" {
+		fmt.Fprintln(os.Stderr, "missing -action")
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	cs, restCfg, err := k8sclient.New(*kubeconfig)
+	if err != nil {
+		fatal("build kube client", err)
+	}
+	dyn, err := dynamic.NewForConfig(restCfg)
+	if err != nil {
+		fatal("build dynamic client", err)
+	}
+
+	mut := mutate.New(cs, "", nil)
+	mut.SetDynamic(dyn)
+	mut.SetExec(podexec.New(cs, restCfg))
+
+	handlers := mutate.Handlers(mut)
+	h, ok := handlers[*action]
+	if !ok {
+		fatal("unknown action", fmt.Errorf("%q not registered (have it spelled right?)", *action))
+	}
+
+	params := map[string]any{}
+	switch *action {
+	case "replica_rightsizing":
+		if *replicas < 0 {
+			fatal("params", fmt.Errorf("replica_rightsizing needs -replicas >= 0"))
+		}
+		params = map[string]any{"kind": *kind, "namespace": *namespace, "name": *name, "replica_count": *replicas}
+	case "rightsize_pvc":
+		params = map[string]any{"namespace": *namespace, "name": *name, "size": *size}
+	case "volume_delete":
+		params = map[string]any{"name": *pv}
+	default:
+		fatal("params", fmt.Errorf("no param mapping for action %q", *action))
+	}
+
+	fmt.Printf("→ %s %s\n", *action, mustJSON(params))
+	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
+	defer cancel()
+
+	start := time.Now()
+	data, err := h(ctx, params)
+	elapsed := time.Since(start).Round(time.Millisecond)
+	if err != nil {
+		fmt.Printf("✗ FAILED in %s: %v\n", elapsed, err)
+		os.Exit(1)
+	}
+	fmt.Printf("✓ OK in %s: %s\n", elapsed, mustJSON(data))
+}
+
+func fatal(ctx string, err error) {
+	fmt.Fprintf(os.Stderr, "%s: %v\n", ctx, err)
+	os.Exit(1)
+}
+
+func mustJSON(v any) string {
+	b, _ := json.Marshal(v)
+	return string(b)
+}

--- a/runner/cmd/agent/main.go
+++ b/runner/cmd/agent/main.go
@@ -538,6 +538,12 @@ func run(ctx context.Context, logger *slog.Logger, cfg *config.Config) error {
 		}
 		mut := mutate.New(typedKube, cfg.AlertManagerURL, amHeaders)
 		mut.SetDynamic(dynamicKube) // unlocks PrometheusRule CRUD actions
+		// SPDY exec capability for the rightsize_pvc downsize migration's
+		// data-mover pod. Without a REST config the downsize path errors at
+		// request time; expansion / replica / volume_delete still work.
+		if kubeRestCfg != nil {
+			mut.SetExec(podexec.New(typedKube, kubeRestCfg))
+		}
 		// INSTALLATION_NAMESPACE is set by the chart via the downward API.
 		// Required by the legacy alert-rule path; falls back to the scanner
 		// namespace (also chart-set) so a hand-rolled deployment without
@@ -638,8 +644,27 @@ func run(ctx context.Context, logger *slog.Logger, cfg *config.Config) error {
 	lightActions["refresh_playbook"] = struct{}{}
 	validator.SetLightActions(lightActions)
 
+	// longActions run far past the 180s default when invoked through the
+	// trusted agent_task poller — currently only the rightsize_pvc downsize
+	// migration (copies volume data via a mover pod). The ceiling stays under
+	// the server's 60-min PROCESSING→TIMEOUT reap so a task isn't force-failed
+	// mid-flight. Override with LONG_TASK_TIMEOUT_SECONDS.
+	longActions := map[string]struct{}{"rightsize_pvc": {}}
+	longTaskTimeout := 50 * time.Minute
+	if v := os.Getenv("LONG_TASK_TIMEOUT_SECONDS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			longTaskTimeout = time.Duration(n) * time.Second
+		} else {
+			logger.Warn("invalid LONG_TASK_TIMEOUT_SECONDS, using default", "value", v)
+		}
+	}
+
 	mreg := metrics.New()
-	disp := dispatch.New(dispatch.Config{Logger: logger}, validator, handlers)
+	disp := dispatch.New(dispatch.Config{
+		Logger:          logger,
+		LongTaskTimeout: longTaskTimeout,
+		LongActions:     longActions,
+	}, validator, handlers)
 	disp.SetMetrics(mreg)
 
 	// Pod-shell session manager (TerminalRequest WS shape, output_type=Terminal).
@@ -948,11 +973,12 @@ func run(ctx context.Context, logger *slog.Logger, cfg *config.Config) error {
 	// the tenant. Period defaults to 120s (matches TASK_RUNNER_WINDOW).
 	if cfg.BackendEndpoint != "" {
 		ts := &tasks.Service{
-			Endpoint:   cfg.BackendEndpoint,
-			AuthSecret: cfg.AuthSecretKey,
-			Period:     tasks.ParseTaskWindow(os.Getenv("TASK_RUNNER_WINDOW")),
-			Logger:     logger,
-			Dispatch:   disp,
+			Endpoint:    cfg.BackendEndpoint,
+			AuthSecret:  cfg.AuthSecretKey,
+			Period:      tasks.ParseTaskWindow(os.Getenv("TASK_RUNNER_WINDOW")),
+			Logger:      logger,
+			Dispatch:    disp,
+			LongActions: longActions,
 		}
 		g.Go(func() error {
 			logger.Info("starting task poller", "endpoint", cfg.BackendEndpoint, "period", ts.Period)

--- a/runner/pkg/dispatch/dispatch.go
+++ b/runner/pkg/dispatch/dispatch.go
@@ -35,6 +35,16 @@ type Config struct {
 	HighPriorityPoolSize int           // default 3  (WEBSOCKET_HIGH_PRIORITY_THREADPOOL_SIZE)
 	TaskTimeout          time.Duration // default 180s
 	Logger               *slog.Logger
+
+	// LongTaskTimeout is the deadline applied to actions in LongActions when
+	// invoked through HandleTrusted (the agent_task poller). It exists for
+	// long-running remediations — notably the rightsize_pvc downsize
+	// migration, which copies volume data via a mover pod and routinely
+	// exceeds the 180s default. 0 disables the override (LongActions then run
+	// under TaskTimeout). Only the trusted poller path honours this; the WS
+	// Handle path always uses TaskTimeout (no long action reaches it).
+	LongTaskTimeout time.Duration
+	LongActions     map[string]struct{}
 }
 
 // Metrics is the optional metrics sink. Pass *metrics.Registry from main, or
@@ -131,7 +141,13 @@ func (d *Dispatcher) HandleTrusted(ctx context.Context, actionName string, param
 	}
 	defer pool.Release(1)
 
-	taskCtx, cancel := context.WithTimeout(ctx, d.cfg.TaskTimeout)
+	timeout := d.cfg.TaskTimeout
+	if d.cfg.LongTaskTimeout > 0 {
+		if _, long := d.cfg.LongActions[actionName]; long {
+			timeout = d.cfg.LongTaskTimeout
+		}
+	}
+	taskCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	start := time.Now()

--- a/runner/pkg/dispatch/dispatch_test.go
+++ b/runner/pkg/dispatch/dispatch_test.go
@@ -439,3 +439,42 @@ func TestDispatch_RegularActionUnchanged(t *testing.T) {
 
 // silence unused-imports warning for auth (kept for future tests)
 var _ = auth.Validator{}
+
+// TestHandleTrusted_LongActionTimeout verifies the per-action timeout: a long
+// action runs under LongTaskTimeout while everything else uses the (short)
+// TaskTimeout and times out.
+func TestHandleTrusted_LongActionTimeout(t *testing.T) {
+	d := New(Config{
+		TaskTimeout:     20 * time.Millisecond,
+		LongTaskTimeout: 2 * time.Second,
+		LongActions:     map[string]struct{}{"migrate": {}},
+	}, nil, map[string]Handler{
+		"migrate": Handler(func(ctx context.Context, _ map[string]any) (any, error) {
+			select {
+			case <-time.After(80 * time.Millisecond):
+				return "ok", nil
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}),
+		"quick": Handler(func(ctx context.Context, _ map[string]any) (any, error) {
+			select {
+			case <-time.After(80 * time.Millisecond):
+				return "ok", nil
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}),
+	})
+
+	// long action: survives past the short TaskTimeout.
+	data, ok, err := d.HandleTrusted(context.Background(), "migrate", nil, false)
+	if !ok || err != nil || data != "ok" {
+		t.Errorf("long action: data=%v ok=%v err=%v; want ok", data, ok, err)
+	}
+	// non-long action: reaped at TaskTimeout.
+	_, ok, err = d.HandleTrusted(context.Background(), "quick", nil, false)
+	if !ok || err == nil {
+		t.Errorf("short action should hit deadline; ok=%v err=%v", ok, err)
+	}
+}

--- a/runner/pkg/mutate/handlers.go
+++ b/runner/pkg/mutate/handlers.go
@@ -30,7 +30,16 @@ func Handlers(m *Mutator) map[string]dispatch.Handler {
 		hs["create_or_replace_alert_rule"] = wrap(m, handleCreateOrReplacePromRule)
 		hs["delete_alert_rule"] = wrapErr(m, handleDeletePromRule)
 		hs["replace_workload"] = wrap(m, handleReplaceWorkload)
+		// replica_rightsizing scales Deployment/StatefulSet/Rollout via the
+		// dynamic client. Delivered through the agent_task poller (trusted),
+		// so — like rightsizing_resource — it is deliberately NOT a lightAction.
+		hs["replica_rightsizing"] = wrap(m, handleReplicaRightsizing)
 	}
+	// PVC remediation needs only the typed client. Same trusted-poller
+	// posture: kept out of lightActions (callers reach these via agent_task,
+	// never unsigned WS).
+	hs["rightsize_pvc"] = wrap(m, handleRightsizePVC)
+	hs["volume_delete"] = wrap(m, handleVolumeDelete)
 	if m.LokiRulesURL != "" {
 		hs["create_loki_alert_rule"] = wrap(m, handleCreateLokiRule)
 		hs["update_loki_alert_rule"] = wrap(m, handleCreateLokiRule) // upsert; same handler
@@ -268,6 +277,25 @@ func perKindBodyField(kind string) string {
 		return "ec2nodeclass"
 	}
 	return ""
+}
+
+// handleReplicaRightsizing scales a workload. replica_count arrives as a JSON
+// number (scale-to-zero path) or a numeric string (event-resolution path);
+// toInt64 coerces both. kind is one of Deployment/StatefulSet/Rollout.
+func handleReplicaRightsizing(ctx context.Context, m *Mutator, p map[string]any) (any, error) {
+	replicas, ok := toInt64(p["replica_count"])
+	if !ok {
+		return nil, errors.New("replica_rightsizing: replica_count required (integer or numeric string)")
+	}
+	return m.ScaleWorkload(ctx, str(p, "kind"), str(p, "namespace"), str(p, "name"), replicas)
+}
+
+func handleRightsizePVC(ctx context.Context, m *Mutator, p map[string]any) (any, error) {
+	return m.RightsizePVC(ctx, str(p, "namespace"), str(p, "name"), str(p, "size"))
+}
+
+func handleVolumeDelete(ctx context.Context, m *Mutator, p map[string]any) (any, error) {
+	return m.DeleteVolume(ctx, str(p, "name"))
 }
 
 func handleCreateLokiRule(ctx context.Context, m *Mutator, p map[string]any) (any, error) {

--- a/runner/pkg/mutate/live_test.go
+++ b/runner/pkg/mutate/live_test.go
@@ -1,0 +1,329 @@
+//go:build live
+
+// Live integration tests for the agent_task remediation actions, run against a
+// REAL cluster (kubeconfig). They are excluded from the normal build by the
+// `live` tag — the fake-client unit tests cover the logic; these prove the
+// actions work end-to-end where pods actually run and PVCs bind to real disks
+// (which envtest can't do).
+//
+// Run (defaults suit a pd-balanced cluster):
+//
+//	go test -tags live ./pkg/mutate -run TestLive -v -timeout 25m
+//
+// On a C4/hyperdisk node pool, pd-balanced won't attach — use the hyperdisk
+// class and its >=4Gi sizes:
+//
+//	LIVE_SC=hyperdisk-balanced-rwo LIVE_BASE_SIZE=6Gi LIVE_EXPAND_SIZE=8Gi LIVE_DOWNSIZE_SIZE=4Gi \
+//	  go test -tags live ./pkg/mutate -run TestLive -v -timeout 25m
+//
+// Each test creates a throwaway namespace and deletes it on cleanup.
+package mutate
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/nudgebee/nudgebee-agent/internal/k8sclient"
+	"github.com/nudgebee/nudgebee-agent/pkg/podexec"
+)
+
+func liveSC() string { return envOr("LIVE_SC", "standard-rwo") }
+
+// Sizes are env-tunable because the floor depends on the disk type: pd-balanced
+// allows 1Gi, hyperdisk-balanced requires >=4Gi. base > downsize so the
+// downsize test actually shrinks. On a C4 node pool, run with:
+//
+//	LIVE_SC=hyperdisk-balanced-rwo LIVE_BASE_SIZE=6Gi LIVE_EXPAND_SIZE=8Gi LIVE_DOWNSIZE_SIZE=4Gi
+func baseSize() string     { return envOr("LIVE_BASE_SIZE", "2Gi") }
+func expandSize() string   { return envOr("LIVE_EXPAND_SIZE", "3Gi") }
+func downsizeSize() string { return envOr("LIVE_DOWNSIZE_SIZE", "1Gi") }
+
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+// liveSetup builds real clients and a fully-wired Mutator, skipping the test if
+// no cluster is reachable.
+func liveSetup(t *testing.T) (kubernetes.Interface, *rest.Config, *Mutator) {
+	t.Helper()
+	cs, restCfg, err := k8sclient.New("")
+	if err != nil {
+		t.Skipf("no cluster: %v", err)
+	}
+	if _, err := cs.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{Limit: 1}); err != nil {
+		t.Skipf("cluster unreachable: %v", err)
+	}
+	dyn, err := dynamic.NewForConfig(restCfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := New(cs, "", nil)
+	m.SetDynamic(dyn)
+	m.SetExec(podexec.New(cs, restCfg))
+	return cs, restCfg, m
+}
+
+func newNamespace(t *testing.T, cs kubernetes.Interface) string {
+	t.Helper()
+	ns := fmt.Sprintf("rs-live-%d", time.Now().UnixNano()%1_000_000)
+	if _, err := cs.CoreV1().Namespaces().Create(context.Background(),
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create namespace: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cs.CoreV1().Namespaces().Delete(context.Background(), ns, metav1.DeleteOptions{})
+		t.Logf("namespace %s deleted", ns)
+	})
+	return ns
+}
+
+func waitFor(t *testing.T, what string, timeout time.Duration, fn func() (bool, error)) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		ok, err := fn()
+		if err != nil {
+			t.Fatalf("waiting for %s: %v", what, err)
+		}
+		if ok {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out after %s waiting for %s", timeout, what)
+		}
+		time.Sleep(3 * time.Second)
+	}
+}
+
+// makePVCAndDeploy creates a PVC and a busybox Deployment that mounts it at
+// /data and just sleeps (it does NOT write the volume — data is written by the
+// test via exec so we can prove the migration preserved it). Waits until the
+// pod is Running and the PVC is Bound.
+func makePVCAndDeploy(t *testing.T, cs kubernetes.Interface, ns, pvcName, deploy, size string) {
+	t.Helper()
+	sc := liveSC()
+	if _, err := cs.CoreV1().PersistentVolumeClaims(ns).Create(context.Background(), &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: pvcName},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			StorageClassName: &sc,
+			Resources:        corev1.VolumeResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse(size)}},
+		},
+	}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create pvc: %v", err)
+	}
+	reps := int32(1)
+	if _, err := cs.AppsV1().Deployments(ns).Create(context.Background(), &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: deploy},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &reps,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": deploy}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": deploy}},
+				Spec: corev1.PodSpec{
+					TerminationGracePeriodSeconds: ptr64(1),
+					Containers: []corev1.Container{{
+						Name:         "app",
+						Image:        "busybox",
+						Command:      []string{"sh", "-c", "sleep 100000"},
+						VolumeMounts: []corev1.VolumeMount{{Name: "v", MountPath: "/data"}},
+					}},
+					Volumes: []corev1.Volume{{Name: "v", VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: pvcName},
+					}}},
+				},
+			},
+		},
+	}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create deploy: %v", err)
+	}
+	waitFor(t, "pod Running", 4*time.Minute, func() (bool, error) {
+		return podRunning(cs, ns, "app="+deploy)
+	})
+	waitFor(t, "pvc Bound", 2*time.Minute, func() (bool, error) {
+		p, err := cs.CoreV1().PersistentVolumeClaims(ns).Get(context.Background(), pvcName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		return p.Status.Phase == corev1.ClaimBound, nil
+	})
+}
+
+func podRunning(cs kubernetes.Interface, ns, selector string) (bool, error) {
+	pods, err := cs.CoreV1().Pods(ns).List(context.Background(), metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return false, err
+	}
+	for _, p := range pods.Items {
+		if p.Status.Phase == corev1.PodRunning {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func podName(t *testing.T, cs kubernetes.Interface, ns, selector string) string {
+	t.Helper()
+	pods, err := cs.CoreV1().Pods(ns).List(context.Background(), metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range pods.Items {
+		if p.Status.Phase == corev1.PodRunning {
+			return p.Name
+		}
+	}
+	t.Fatalf("no running pod for %s", selector)
+	return ""
+}
+
+func execSh(t *testing.T, restCfg *rest.Config, cs kubernetes.Interface, ns, pod, cmd string) string {
+	t.Helper()
+	res, err := podexec.New(cs, restCfg).Exec(context.Background(), &podexec.Request{
+		Namespace: ns, Pod: pod, Command: []string{"sh", "-c", cmd}, Timeout: 30 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("exec %q: %v", cmd, err)
+	}
+	return strings.TrimSpace(res.Stdout)
+}
+
+func ptr64(i int64) *int64 { return &i }
+
+// --- tests ---
+
+func TestLiveExpandPVC(t *testing.T) {
+	cs, _, m := liveSetup(t)
+	ns := newNamespace(t, cs)
+	makePVCAndDeploy(t, cs, ns, "data", "web", baseSize())
+
+	if _, err := m.RightsizePVC(context.Background(), ns, "data", expandSize()); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, "pvc request 3Gi", time.Minute, func() (bool, error) {
+		p, err := cs.CoreV1().PersistentVolumeClaims(ns).Get(context.Background(), "data", metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		q := p.Spec.Resources.Requests[corev1.ResourceStorage]
+		return q.Cmp(resource.MustParse(expandSize())) == 0, nil
+	})
+}
+
+func TestLiveReplicaScale(t *testing.T) {
+	cs, _, m := liveSetup(t)
+	ns := newNamespace(t, cs)
+	makePVCAndDeploy(t, cs, ns, "data", "web", baseSize())
+
+	if _, err := m.ScaleWorkload(context.Background(), "Deployment", ns, "web", 0); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, "scaled to 0", time.Minute, func() (bool, error) {
+		d, err := cs.AppsV1().Deployments(ns).Get(context.Background(), "web", metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		return d.Status.Replicas == 0, nil
+	})
+	if _, err := m.ScaleWorkload(context.Background(), "Deployment", ns, "web", 1); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLiveDownsizeDeployment(t *testing.T) {
+	cs, restCfg, m := liveSetup(t)
+	ns := newNamespace(t, cs)
+	makePVCAndDeploy(t, cs, ns, "data", "web", baseSize())
+
+	// Write a token the container never touches, so it survives only if the
+	// migration copied the data.
+	const token = "nudgebee-downsize-ok"
+	pod := podName(t, cs, ns, "app=web")
+	execSh(t, restCfg, cs, ns, pod, "echo "+token+" > /data/marker.txt && sync")
+
+	// Downsize 2Gi -> 1Gi (GKE PD minimum).
+	if _, err := m.RightsizePVC(context.Background(), ns, "data", downsizeSize()); err != nil {
+		t.Fatalf("downsize: %v", err)
+	}
+
+	// Original PVC gone; a downsized PVC exists at 1Gi.
+	pvcs, _ := cs.CoreV1().PersistentVolumeClaims(ns).List(context.Background(), metav1.ListOptions{})
+	var newName string
+	for _, p := range pvcs.Items {
+		if p.Name == "data" {
+			t.Error("original PVC should be deleted")
+		}
+		if strings.HasPrefix(p.Name, "data-downsized-") {
+			newName = p.Name
+			if q := p.Spec.Resources.Requests[corev1.ResourceStorage]; q.Cmp(resource.MustParse(downsizeSize())) != 0 {
+				t.Errorf("new pvc size = %s; want %s", q.String(), downsizeSize())
+			}
+		}
+	}
+	if newName == "" {
+		t.Fatal("downsized PVC not found")
+	}
+
+	// Workload back up on the new PVC, data intact.
+	waitFor(t, "pod Running on new PVC", 4*time.Minute, func() (bool, error) {
+		return podRunning(cs, ns, "app=web")
+	})
+	got := execSh(t, restCfg, cs, ns, podName(t, cs, ns, "app=web"), "cat /data/marker.txt")
+	if got != token {
+		t.Fatalf("data not preserved: marker=%q want %q", got, token)
+	}
+	t.Logf("downsize OK: data survived on %s", newName)
+}
+
+func TestLiveVolumeDelete(t *testing.T) {
+	cs, _, m := liveSetup(t)
+	ns := newNamespace(t, cs)
+	makePVCAndDeploy(t, cs, ns, "data", "web", baseSize())
+
+	// Resolve the bound PV, then release the consumer so the PVC delete won't hang.
+	pvc, err := cs.CoreV1().PersistentVolumeClaims(ns).Get(context.Background(), "data", metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pvName := pvc.Spec.VolumeName
+	if err := cs.AppsV1().Deployments(ns).Delete(context.Background(), "web", metav1.DeleteOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, "consumer pod gone", 2*time.Minute, func() (bool, error) {
+		pods, err := cs.CoreV1().Pods(ns).List(context.Background(), metav1.ListOptions{LabelSelector: "app=web"})
+		if err != nil {
+			return false, err
+		}
+		return len(pods.Items) == 0, nil
+	})
+
+	if _, err := m.DeleteVolume(context.Background(), pvName); err != nil {
+		t.Fatalf("volume_delete: %v", err)
+	}
+	// Bound PVC gone.
+	waitFor(t, "pvc deleted", 2*time.Minute, func() (bool, error) {
+		_, err := cs.CoreV1().PersistentVolumeClaims(ns).Get(context.Background(), "data", metav1.GetOptions{})
+		return apierrors.IsNotFound(err), nil
+	})
+	// PV gone (explicit delete, or auto-removed for reclaim=Delete).
+	waitFor(t, "pv deleted", 2*time.Minute, func() (bool, error) {
+		_, err := cs.CoreV1().PersistentVolumes().Get(context.Background(), pvName, metav1.GetOptions{})
+		return apierrors.IsNotFound(err), nil
+	})
+}

--- a/runner/pkg/mutate/mutate.go
+++ b/runner/pkg/mutate/mutate.go
@@ -3,11 +3,14 @@
 // CRUD. Each one mutates customer cluster state; all of them MUST be served
 // behind RSA partial-keys auth in production (NOT light-action).
 //
+// Remediation/apply actions delivered via the agent_task poller (trusted, not
+// lightActions): replica_rightsizing (scale), rightsize_pvc (expand;
+// downsize-via-migration is Phase 2), volume_delete (PV + bound PVC).
+//
 // Out-of-scope for v1 — bring in follow-up commits as they're needed:
-//   - drain                 : evict-pods + wait, ~150 LoC orchestration
-//   - replace_workload, create_workload   : dynamic client + manifest validation
-//   - create_pvc_snapshot, rightsize_pvc  : PVC-resize subresource
-//   - PrometheusRule/LokiRule CRUD        : CRD manipulation, prometheus-operator
+//   - create_workload      : dynamic client + manifest validation
+//   - create_pvc_snapshot  : PVC snapshot subresource
+//   - rightsize_pvc downsize : data-migration (scale→copy→swap), Phase 2
 package mutate
 
 import (
@@ -22,6 +25,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/nudgebee/nudgebee-agent/pkg/podexec"
 )
 
 // Mutator wraps the typed client + an optional AlertManager URL for silences.
@@ -44,7 +49,21 @@ type Mutator struct {
 	// dynamic is the dynamic client used for CRD operations like
 	// PrometheusRule. Set via SetDynamic.
 	dynamic dynamic.Interface
+
+	// exec runs commands inside pods (SPDY). Required only by the
+	// rightsize_pvc downsize migration's data-mover pod. Set via SetExec;
+	// nil disables the downsize path (expansion still works).
+	exec podexec.Executor
+
+	// Migration timeout overrides (0 = use the package defaults). Set by
+	// tests to keep the downsize unit tests fast.
+	opTimeoutOverride      time.Duration
+	podTermTimeoutOverride time.Duration
+	pollIntervalOverride   time.Duration
 }
+
+// SetExec wires the pod-exec capability used by the downsize migration.
+func (m *Mutator) SetExec(e podexec.Executor) { m.exec = e }
 
 func New(cs kubernetes.Interface, alertManagerURL string, headers map[string]string) *Mutator {
 	return &Mutator{

--- a/runner/pkg/mutate/mutate.go
+++ b/runner/pkg/mutate/mutate.go
@@ -60,6 +60,11 @@ type Mutator struct {
 	opTimeoutOverride      time.Duration
 	podTermTimeoutOverride time.Duration
 	pollIntervalOverride   time.Duration
+	copyTimeoutOverride    time.Duration
+
+	// moverImageOverride forces the data-mover image (tests); empty falls back
+	// to MOVER_IMAGE / "ubuntu".
+	moverImageOverride string
 }
 
 // SetExec wires the pod-exec capability used by the downsize migration.

--- a/runner/pkg/mutate/pvc.go
+++ b/runner/pkg/mutate/pvc.go
@@ -1,0 +1,129 @@
+// Package mutate — rightsize_pvc (expand) and volume_delete.
+//
+// Both arrive only via the agent_task poller (trusted path).
+//
+// rightsize_pvc resizes a PVC. Expansion is in-place (verify the StorageClass
+// allows expansion, patch spec.resources.requests.storage). Downsize cannot
+// shrink a PV in place, so it routes to the copy-migration in pvcdownsize.go.
+//
+// volume_delete removes an unused PersistentVolume. The payload carries only
+// `name` (no namespace) because the api-server's unused_pvc recommendation is a
+// serialized PV manifest — `name` is the cluster-scoped PV name. Mirroring the
+// legacy robusta action, we delete the bound PVC (resolved via the PV's
+// spec.claimRef) first, then the PV itself; both deletes are 404-tolerant.
+package mutate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// RightsizePVC is the rightsize_pvc dispatcher: it compares the PVC's current
+// provisioned size against the target and routes to in-place expansion or the
+// downsize migration. size accepts the api-server's two wire forms
+// "20.000000Gi" (%f) and "20Gi". No-op when already at the target.
+func (m *Mutator) RightsizePVC(ctx context.Context, namespace, name, size string) (any, error) {
+	if m.Client == nil {
+		return nil, errors.New("mutate: client not configured")
+	}
+	if namespace == "" || name == "" || size == "" {
+		return nil, errors.New("mutate: namespace, name and size required")
+	}
+	target, err := resource.ParseQuantity(size)
+	if err != nil {
+		return nil, fmt.Errorf("rightsize_pvc: invalid size %q: %w", size, err)
+	}
+
+	pvcs := m.Client.CoreV1().PersistentVolumeClaims(namespace)
+	pvc, err := pvcs.Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("rightsize_pvc: get pvc %s/%s: %w", namespace, name, err)
+	}
+
+	// Direction is decided on the provisioned capacity (what exists), matching
+	// the legacy action; fall back to the request before the PVC is bound.
+	current := pvc.Status.Capacity[corev1.ResourceStorage]
+	if current.IsZero() {
+		current = pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+	}
+	switch target.Cmp(current) {
+	case 0:
+		return map[string]any{
+			"success": true,
+			"message": fmt.Sprintf("pvc %s/%s already at %s", namespace, name, current.String()),
+		}, nil
+	case -1:
+		// PVs can't shrink in place — copy data onto a smaller volume.
+		return m.DownsizePVC(ctx, namespace, name, target)
+	}
+
+	// Expansion requires the StorageClass to allow it. An unset
+	// StorageClassName means the default class / a statically-provisioned PV;
+	// we can't resolve allowVolumeExpansion, so attempt the patch and let the
+	// apiserver reject it if unsupported.
+	if scName := pvc.Spec.StorageClassName; scName != nil && *scName != "" {
+		sc, scErr := m.Client.StorageV1().StorageClasses().Get(ctx, *scName, metav1.GetOptions{})
+		if scErr != nil {
+			return nil, fmt.Errorf("rightsize_pvc: get storageclass %q: %w", *scName, scErr)
+		}
+		if sc.AllowVolumeExpansion == nil || !*sc.AllowVolumeExpansion {
+			return nil, fmt.Errorf("rightsize_pvc: storageclass %q does not allow volume expansion", *scName)
+		}
+	}
+
+	patch := fmt.Appendf(nil, `{"spec":{"resources":{"requests":{"storage":%q}}}}`, target.String())
+	if _, err := pvcs.Patch(ctx, name, types.StrategicMergePatchType, patch, metav1.PatchOptions{}); err != nil {
+		return nil, fmt.Errorf("rightsize_pvc: patch pvc %s/%s to %s: %w", namespace, name, target.String(), err)
+	}
+	return map[string]any{
+		"success": true,
+		"message": fmt.Sprintf("pvc %s/%s expansion to %s requested", namespace, name, target.String()),
+	}, nil
+}
+
+// DeleteVolume deletes a PersistentVolume by (cluster-scoped) name, deleting
+// the bound PVC first via the PV's spec.claimRef. Both deletes tolerate a
+// missing object (already gone == success), matching the legacy action.
+func (m *Mutator) DeleteVolume(ctx context.Context, pvName string) (any, error) {
+	if m.Client == nil {
+		return nil, errors.New("mutate: client not configured")
+	}
+	if pvName == "" {
+		return nil, errors.New("mutate: pv name required")
+	}
+
+	pvs := m.Client.CoreV1().PersistentVolumes()
+	pv, err := pvs.Get(ctx, pvName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return map[string]any{"success": true, "message": fmt.Sprintf("pv %s already deleted", pvName)}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("volume_delete: get pv %s: %w", pvName, err)
+	}
+
+	deletedPVC := ""
+	if ref := pv.Spec.ClaimRef; ref != nil && ref.Name != "" {
+		err := m.Client.CoreV1().PersistentVolumeClaims(ref.Namespace).Delete(ctx, ref.Name, metav1.DeleteOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("volume_delete: delete bound pvc %s/%s: %w", ref.Namespace, ref.Name, err)
+		}
+		deletedPVC = ref.Namespace + "/" + ref.Name
+	}
+
+	if err := pvs.Delete(ctx, pvName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		return nil, fmt.Errorf("volume_delete: delete pv %s: %w", pvName, err)
+	}
+
+	msg := fmt.Sprintf("pv %s deleted", pvName)
+	if deletedPVC != "" {
+		msg = fmt.Sprintf("pv %s and bound pvc %s deleted", pvName, deletedPVC)
+	}
+	return map[string]any{"success": true, "message": msg}, nil
+}

--- a/runner/pkg/mutate/pvc_test.go
+++ b/runner/pkg/mutate/pvc_test.go
@@ -1,0 +1,140 @@
+package mutate
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func boolPtr(b bool) *bool    { return &b }
+func strPtr(s string) *string { return &s }
+
+func newPVC(ns, name, sc, size string) *corev1.PersistentVolumeClaim {
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: strPtr(sc),
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse(size)},
+			},
+		},
+	}
+}
+
+func expandableSC(name string) *storagev1.StorageClass {
+	return &storagev1.StorageClass{
+		ObjectMeta:           metav1.ObjectMeta{Name: name},
+		AllowVolumeExpansion: boolPtr(true),
+	}
+}
+
+func TestExpandPVC_HappyPath(t *testing.T) {
+	cs := fake.NewClientset(newPVC("data", "db", "fast", "10Gi"), expandableSC("fast"))
+	m := New(cs, "", nil)
+
+	// "20.000000Gi" is the %f wire form the api-server sends.
+	got, err := m.RightsizePVC(context.Background(), "data", "db", "20.000000Gi")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.(map[string]any)["success"] != true {
+		t.Fatalf("success = %v", got)
+	}
+	pvc, _ := cs.CoreV1().PersistentVolumeClaims("data").Get(context.Background(), "db", metav1.GetOptions{})
+	if q := pvc.Spec.Resources.Requests[corev1.ResourceStorage]; q.String() != "20Gi" {
+		t.Errorf("requested storage = %s; want 20Gi", q.String())
+	}
+}
+
+func TestExpandPVC_DownsizeRejected(t *testing.T) {
+	cs := fake.NewClientset(newPVC("data", "db", "fast", "20Gi"), expandableSC("fast"))
+	m := New(cs, "", nil)
+	if _, err := m.RightsizePVC(context.Background(), "data", "db", "10Gi"); err == nil {
+		t.Fatal("expected downsize to be rejected")
+	}
+}
+
+func TestExpandPVC_AlreadyAtSize(t *testing.T) {
+	cs := fake.NewClientset(newPVC("data", "db", "fast", "20Gi"), expandableSC("fast"))
+	m := New(cs, "", nil)
+	got, err := m.RightsizePVC(context.Background(), "data", "db", "20Gi")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.(map[string]any)["success"] != true {
+		t.Errorf("expected no-op success, got %v", got)
+	}
+}
+
+func TestExpandPVC_ExpansionNotAllowed(t *testing.T) {
+	sc := &storagev1.StorageClass{
+		ObjectMeta:           metav1.ObjectMeta{Name: "slow"},
+		AllowVolumeExpansion: boolPtr(false),
+	}
+	cs := fake.NewClientset(newPVC("data", "db", "slow", "10Gi"), sc)
+	m := New(cs, "", nil)
+	if _, err := m.RightsizePVC(context.Background(), "data", "db", "20Gi"); err == nil {
+		t.Fatal("expected error when StorageClass forbids expansion")
+	}
+}
+
+func TestDeleteVolume_WithClaimRef(t *testing.T) {
+	pv := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "pv-1"},
+		Spec: corev1.PersistentVolumeSpec{
+			ClaimRef: &corev1.ObjectReference{Namespace: "data", Name: "db"},
+		},
+	}
+	pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "db", Namespace: "data"}}
+	cs := fake.NewClientset(pv, pvc)
+	m := New(cs, "", nil)
+
+	if _, err := m.DeleteVolume(context.Background(), "pv-1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cs.CoreV1().PersistentVolumes().Get(context.Background(), "pv-1", metav1.GetOptions{}); err == nil {
+		t.Error("pv should be deleted")
+	}
+	if _, err := cs.CoreV1().PersistentVolumeClaims("data").Get(context.Background(), "db", metav1.GetOptions{}); err == nil {
+		t.Error("bound pvc should be deleted")
+	}
+}
+
+func TestDeleteVolume_NoClaimRef(t *testing.T) {
+	pv := &corev1.PersistentVolume{ObjectMeta: metav1.ObjectMeta{Name: "pv-2"}}
+	cs := fake.NewClientset(pv)
+	m := New(cs, "", nil)
+	if _, err := m.DeleteVolume(context.Background(), "pv-2"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cs.CoreV1().PersistentVolumes().Get(context.Background(), "pv-2", metav1.GetOptions{}); err == nil {
+		t.Error("pv should be deleted")
+	}
+}
+
+func TestDeleteVolume_NotFoundIsSuccess(t *testing.T) {
+	cs := fake.NewClientset()
+	m := New(cs, "", nil)
+	got, err := m.DeleteVolume(context.Background(), "ghost")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.(map[string]any)["success"] != true {
+		t.Errorf("missing pv should be success, got %v", got)
+	}
+}
+
+func TestHandlers_RegistersPVCRemediation(t *testing.T) {
+	m := New(fake.NewClientset(), "", nil)
+	hs := Handlers(m)
+	for _, want := range []string{"rightsize_pvc", "volume_delete"} {
+		if _, ok := hs[want]; !ok {
+			t.Errorf("missing %q (should register with just a typed client)", want)
+		}
+	}
+}

--- a/runner/pkg/mutate/pvcdownsize.go
+++ b/runner/pkg/mutate/pvcdownsize.go
@@ -1,0 +1,338 @@
+// Package mutate — rightsize_pvc downsize migration.
+//
+// PVs cannot shrink in place, so downsizing a PVC means copying its data onto a
+// smaller volume and repointing the workload. This is a faithful port of the
+// legacy robusta volume_rightsize_analyzer downsize path. It is data-
+// destructive; the ordering and the explicit point-of-no-return below are
+// load-bearing — do not reorder.
+//
+// Strategy differs by workload kind:
+//
+//	Deployment  — single copy + rename. Create a new PVC ({pvc}-downsized-xxxx),
+//	              copy data, repoint the Deployment's volume to it, then delete
+//	              the original. The original PVC is the safety net until the
+//	              workload runs on the new one (point of no return = repoint).
+//
+//	StatefulSet — name-preserving double copy. volumeClaimTemplate PVC names are
+//	              fixed ({tpl}-{sts}-{ordinal}), so we copy original→temp, delete
+//	              the original, recreate it at the new size, copy temp→original.
+//	              Point of no return = deleting the original PVC; before that we
+//	              flip the PV reclaim policy to Retain so a second copy survives.
+//
+// The data copy runs in a transient "ubuntu" mover pod (cp -a) in the
+// workload's namespace, exec'd over SPDY. The agent ServiceAccount therefore
+// needs: pods create/get/delete + pods/exec; pvc get/create/delete; pv
+// get/patch/delete; deployments/statefulsets get/update/list; storageclasses
+// get.
+package mutate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+)
+
+const (
+	moverImage            = "ubuntu"
+	pvcScalerAnnotation   = "NudgebeeDiskScaler" // key == value, marks PVCs we create
+	defaultOpTimeout      = 300 * time.Second    // per-stage ceiling (copy, pvc-delete, pod-running)
+	defaultPodTermTimeout = 300 * time.Second
+	defaultPollInterval   = 5 * time.Second
+)
+
+// Timeout accessors fall back to the defaults above; tests set the unexported
+// Mutator fields to keep migration unit tests fast.
+func (m *Mutator) opTimeout() time.Duration {
+	if m.opTimeoutOverride > 0 {
+		return m.opTimeoutOverride
+	}
+	return defaultOpTimeout
+}
+
+func (m *Mutator) podTermTimeout() time.Duration {
+	if m.podTermTimeoutOverride > 0 {
+		return m.podTermTimeoutOverride
+	}
+	return defaultPodTermTimeout
+}
+
+func (m *Mutator) pollInterval() time.Duration {
+	if m.pollIntervalOverride > 0 {
+		return m.pollIntervalOverride
+	}
+	return defaultPollInterval
+}
+
+// k8sInternalAnnotation matches keys we must not carry across (provisioner /
+// binding bookkeeping). Mirrors the legacy regex set.
+var k8sInternalAnnotation = regexp.MustCompile(`\.(beta\.)?kubernetes\.io(/.*)?$`)
+
+// DownsizePVC migrates pvcName in namespace down to target. Returns a
+// {success, message} map on success; an error (→ task FAILED) otherwise.
+func (m *Mutator) DownsizePVC(ctx context.Context, namespace, pvcName string, target resource.Quantity) (any, error) {
+	if m.Client == nil {
+		return nil, errors.New("mutate: client not configured")
+	}
+	if m.exec == nil {
+		return nil, errors.New("rightsize_pvc: downsize requires pod-exec capability (not configured on this agent)")
+	}
+
+	pvc, pv, err := m.validateDownsizePrereqs(ctx, namespace, pvcName)
+	if err != nil {
+		return nil, err
+	}
+	snap := newPVCSnapshot(pvc)
+
+	_, kind, err := m.getWorkloadByPVC(ctx, namespace, pvcName)
+	if err != nil {
+		return nil, err
+	}
+	switch kind {
+	case "Deployment":
+		if err := m.downsizeDeployment(ctx, namespace, pvcName, pvc, pv, target, snap); err != nil {
+			return nil, err
+		}
+	case "StatefulSet":
+		if err := m.downsizeStatefulSet(ctx, namespace, pvcName, pvc, pv, target, snap); err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("rightsize_pvc: no Deployment or StatefulSet found using PVC %q", pvcName)
+	}
+	return map[string]any{
+		"success": true,
+		"message": fmt.Sprintf("pvc %s/%s downsized to %s", namespace, pvcName, target.String()),
+	}, nil
+}
+
+// validateDownsizePrereqs hard-fails unless the PVC is Bound, its PV exists and
+// is not hostPath, and its StorageClass exists.
+func (m *Mutator) validateDownsizePrereqs(ctx context.Context, namespace, pvcName string) (*corev1.PersistentVolumeClaim, *corev1.PersistentVolume, error) {
+	pvc, err := m.Client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvcName, metav1.GetOptions{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("rightsize_pvc: get pvc %s/%s: %w", namespace, pvcName, err)
+	}
+	if pvc.Status.Phase != corev1.ClaimBound {
+		return nil, nil, fmt.Errorf("rightsize_pvc: pvc %s/%s is %q, must be Bound to downsize", namespace, pvcName, pvc.Status.Phase)
+	}
+	if pvc.Spec.VolumeName == "" {
+		return nil, nil, fmt.Errorf("rightsize_pvc: pvc %s/%s has no volumeName", namespace, pvcName)
+	}
+	pv, err := m.Client.CoreV1().PersistentVolumes().Get(ctx, pvc.Spec.VolumeName, metav1.GetOptions{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("rightsize_pvc: get pv %s: %w", pvc.Spec.VolumeName, err)
+	}
+	if pv.Spec.HostPath != nil {
+		return nil, nil, fmt.Errorf("rightsize_pvc: pv %s is hostPath — downsize unsupported", pv.Name)
+	}
+	scName := ""
+	if pvc.Spec.StorageClassName != nil {
+		scName = *pvc.Spec.StorageClassName
+	}
+	if scName == "" {
+		return nil, nil, fmt.Errorf("rightsize_pvc: pvc %s/%s has no storageClassName", namespace, pvcName)
+	}
+	if _, err := m.Client.StorageV1().StorageClasses().Get(ctx, scName, metav1.GetOptions{}); err != nil {
+		return nil, nil, fmt.Errorf("rightsize_pvc: get storageclass %q: %w", scName, err)
+	}
+	return pvc, pv, nil
+}
+
+// downsizeDeployment: copy → repoint → delete original. Point of no return is
+// the volume repoint at repointDeploymentPVC.
+func (m *Mutator) downsizeDeployment(ctx context.Context, namespace, pvcName string, pvc *corev1.PersistentVolumeClaim, pv *corev1.PersistentVolume, target resource.Quantity, snap pvcSnapshot) (retErr error) {
+	dep, kind, err := m.getWorkloadByPVC(ctx, namespace, pvcName)
+	if err != nil || kind != "Deployment" {
+		return fmt.Errorf("rightsize_pvc: no Deployment found using PVC %q", pvcName)
+	}
+	deployment := dep.(*appsv1.Deployment)
+	name := deployment.Name
+	selector := labelSelectorString(deployment.Spec.Selector)
+	newPVCName := fmt.Sprintf("%s-downsized-%s", pvcName, rand.String(8))
+
+	var oldReplicas *int32
+	newPVCCreated := false
+	deploymentUpdated := false
+
+	defer func() {
+		if retErr == nil {
+			return
+		}
+		if deploymentUpdated {
+			// Past the point of no return: leave both PVCs in place; the
+			// Deployment already runs on the new one. Manual cleanup only.
+			m.logger().Error("rightsize_pvc: failure after Deployment repoint; original PVC retained for recovery",
+				"deployment", name, "namespace", namespace, "new_pvc", newPVCName, "err", retErr)
+			return
+		}
+		if newPVCCreated {
+			_ = m.deletePVC(ctx, namespace, newPVCName)
+		}
+		if oldReplicas != nil {
+			if _, err := m.scaleWorkloadTyped(ctx, "Deployment", namespace, name, *oldReplicas); err != nil {
+				m.logger().Error("rightsize_pvc: CRITICAL: failed to restore replicas after rollback", "deployment", name, "err", err)
+			}
+		}
+	}()
+
+	// Phase A — non-destructive (original PVC untouched).
+	r, err := m.scaleWorkloadTyped(ctx, "Deployment", namespace, name, 0)
+	if err != nil {
+		return err
+	}
+	oldReplicas = &r
+	if err := m.waitForPodsTerminated(ctx, namespace, selector); err != nil {
+		return err
+	}
+	if err := m.createPVCFromSpec(ctx, namespace, newPVCName, pvc, target); err != nil {
+		return err
+	}
+	newPVCCreated = true
+	if err := m.copyData(ctx, namespace, pvcName, newPVCName, "copier"); err != nil {
+		return err
+	}
+	newPVCObj, err := m.Client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, newPVCName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("rightsize_pvc: re-read new pvc %s: %w", newPVCName, err)
+	}
+	if mm := snap.verifyParity(newPVCObj, target); len(mm) > 0 {
+		return fmt.Errorf("rightsize_pvc: config parity check failed for new pvc %s: %v", newPVCName, mm)
+	}
+
+	// Phase B — repoint (point of no return).
+	if err := m.repointDeploymentPVC(ctx, namespace, name, pvcName, newPVCName); err != nil {
+		return err
+	}
+	deploymentUpdated = true
+	if _, err := m.scaleWorkloadTyped(ctx, "Deployment", namespace, name, *oldReplicas); err != nil {
+		return err
+	}
+	oldReplicas = nil // replicas restored; don't re-scale in rollback
+
+	// Phase C — cleanup (workload is on the new PVC).
+	if err := m.deletePVC(ctx, namespace, pvcName); err != nil {
+		return err
+	}
+	if err := m.waitForPVCDeletion(ctx, namespace, pvcName); err != nil {
+		return err
+	}
+	if pv.Spec.PersistentVolumeReclaimPolicy == corev1.PersistentVolumeReclaimRetain {
+		m.deletePVBestEffort(ctx, pv.Name)
+	}
+	return nil
+}
+
+// downsizeStatefulSet: copy original→temp, delete original, recreate at new
+// size, copy temp→original. Point of no return is deleting the original PVC;
+// the PV reclaim policy is flipped to Retain beforehand so its data survives.
+func (m *Mutator) downsizeStatefulSet(ctx context.Context, namespace, pvcName string, pvc *corev1.PersistentVolumeClaim, pv *corev1.PersistentVolume, target resource.Quantity, snap pvcSnapshot) (retErr error) {
+	sts, kind, err := m.getWorkloadByPVC(ctx, namespace, pvcName)
+	if err != nil || kind != "StatefulSet" {
+		return fmt.Errorf("rightsize_pvc: no StatefulSet found using PVC %q", pvcName)
+	}
+	statefulSet := sts.(*appsv1.StatefulSet)
+	name := statefulSet.Name
+	selector := labelSelectorString(statefulSet.Spec.Selector)
+	tempPVCName := fmt.Sprintf("%s-tmp-%s", pvcName, rand.String(8))
+	origReclaim := pv.Spec.PersistentVolumeReclaimPolicy
+
+	var oldReplicas *int32
+	reclaimPatched := false
+	tempPVCCreated := false
+	originalPVCDeleted := false
+
+	defer func() {
+		if retErr == nil {
+			return
+		}
+		if originalPVCDeleted {
+			// Past the point of no return. Two safe copies remain: the temp
+			// PVC and the retained (Released) PV. Do NOT delete them, do NOT
+			// restore reclaim, do NOT scale up — the workload must stay down.
+			m.logger().Error("rightsize_pvc: CRITICAL: original PVC deleted but downsize incomplete; data safe on temp PVC and retained PV — manual recovery required",
+				"statefulset", name, "namespace", namespace, "pvc", pvcName, "temp_pvc", tempPVCName, "pv", pv.Name, "err", retErr)
+			return
+		}
+		if tempPVCCreated {
+			_ = m.deletePVC(ctx, namespace, tempPVCName)
+		}
+		if reclaimPatched {
+			if err := m.patchPVReclaim(ctx, pv.Name, origReclaim); err != nil {
+				m.logger().Error("rightsize_pvc: failed to restore PV reclaim policy on rollback", "pv", pv.Name, "err", err)
+			}
+		}
+		if oldReplicas != nil {
+			if _, err := m.scaleWorkloadTyped(ctx, "StatefulSet", namespace, name, *oldReplicas); err != nil {
+				m.logger().Error("rightsize_pvc: CRITICAL: failed to restore replicas after rollback", "statefulset", name, "err", err)
+			}
+		}
+	}()
+
+	// Phase A — non-destructive.
+	r, err := m.scaleWorkloadTyped(ctx, "StatefulSet", namespace, name, 0)
+	if err != nil {
+		return err
+	}
+	oldReplicas = &r
+	if err := m.waitForPodsTerminated(ctx, namespace, selector); err != nil {
+		return err
+	}
+	if origReclaim != corev1.PersistentVolumeReclaimRetain {
+		if err := m.patchPVReclaim(ctx, pv.Name, corev1.PersistentVolumeReclaimRetain); err != nil {
+			return err
+		}
+		reclaimPatched = true
+	}
+	if err := m.createPVCFromSpec(ctx, namespace, tempPVCName, pvc, target); err != nil {
+		return err
+	}
+	tempPVCCreated = true
+	if err := m.copyData(ctx, namespace, pvcName, tempPVCName, "cp1"); err != nil {
+		return err
+	}
+
+	// Phase B — destructive (point of no return).
+	if err := m.deletePVC(ctx, namespace, pvcName); err != nil {
+		return err
+	}
+	if err := m.waitForPVCDeletion(ctx, namespace, pvcName); err != nil {
+		return err
+	}
+	originalPVCDeleted = true
+	if err := m.createPVCFromSpec(ctx, namespace, pvcName, pvc, target); err != nil {
+		return err
+	}
+	if err := m.copyData(ctx, namespace, tempPVCName, pvcName, "cp2"); err != nil {
+		return err
+	}
+	finalPVC, err := m.Client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, pvcName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("rightsize_pvc: re-read pvc %s: %w", pvcName, err)
+	}
+	if mm := snap.verifyParity(finalPVC, target); len(mm) > 0 {
+		return fmt.Errorf("rightsize_pvc: config parity check failed for pvc %s: %v", pvcName, mm)
+	}
+	if _, err := m.scaleWorkloadTyped(ctx, "StatefulSet", namespace, name, *oldReplicas); err != nil {
+		return err
+	}
+	oldReplicas = nil
+
+	// Phase C — cleanup.
+	if err := m.deletePVC(ctx, namespace, tempPVCName); err != nil {
+		return err
+	}
+	if err := m.waitForPVCDeletion(ctx, namespace, tempPVCName); err != nil {
+		return err
+	}
+	tempPVCCreated = false
+	m.deletePVBestEffort(ctx, pv.Name) // orphaned Released PV
+	return nil
+}

--- a/runner/pkg/mutate/pvcdownsize.go
+++ b/runner/pkg/mutate/pvcdownsize.go
@@ -30,6 +30,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"regexp"
 	"time"
 
@@ -41,12 +42,40 @@ import (
 )
 
 const (
-	moverImage            = "ubuntu"
+	defaultMoverImage     = "ubuntu"
 	pvcScalerAnnotation   = "NudgebeeDiskScaler" // key == value, marks PVCs we create
-	defaultOpTimeout      = 300 * time.Second    // per-stage ceiling (copy, pvc-delete, pod-running)
+	defaultOpTimeout      = 300 * time.Second    // per-stage ceiling (pvc-delete, pod-running)
 	defaultPodTermTimeout = 300 * time.Second
 	defaultPollInterval   = 5 * time.Second
+	defaultCopyTimeout    = 30 * time.Minute // used only when ctx carries no deadline
 )
+
+// moverImageName resolves the data-mover image: explicit override (tests) >
+// MOVER_IMAGE env (air-gapped clusters that mirror images) > "ubuntu".
+func (m *Mutator) moverImageName() string {
+	if m.moverImageOverride != "" {
+		return m.moverImageOverride
+	}
+	if v := os.Getenv("MOVER_IMAGE"); v != "" {
+		return v
+	}
+	return defaultMoverImage
+}
+
+// copyTimeout bounds a single data copy. It uses the remaining ctx budget (the
+// LongTaskTimeout the poller applies), minus headroom for the surrounding
+// scale/cleanup, so a large volume isn't cut off at a fixed 5m.
+func (m *Mutator) copyTimeout(ctx context.Context) time.Duration {
+	if m.copyTimeoutOverride > 0 {
+		return m.copyTimeoutOverride
+	}
+	if dl, ok := ctx.Deadline(); ok {
+		if d := time.Until(dl) - time.Minute; d > 0 {
+			return d
+		}
+	}
+	return defaultCopyTimeout
+}
 
 // Timeout accessors fall back to the defaults above; tests set the unexported
 // Mutator fields to keep migration unit tests fast.

--- a/runner/pkg/mutate/pvcdownsize_helpers.go
+++ b/runner/pkg/mutate/pvcdownsize_helpers.go
@@ -95,6 +95,10 @@ func labelSelectorString(sel *metav1.LabelSelector) string {
 // read-modify-update with conflict retries. Returns the prior replica count.
 func (m *Mutator) scaleWorkloadTyped(ctx context.Context, kind, namespace, name string, replicas int32) (int32, error) {
 	var old int32
+	// Capture the prior count only on the first read: a conflict-retry re-Gets
+	// the (possibly already-scaled) object, and recapturing would clobber `old`
+	// with the new value — leaving the caller to "restore" to the wrong count.
+	var oldCaptured bool
 	for attempt := 0; attempt < 3; attempt++ {
 		var err error
 		switch kind {
@@ -102,7 +106,9 @@ func (m *Mutator) scaleWorkloadTyped(ctx context.Context, kind, namespace, name 
 			var d *appsv1.Deployment
 			d, err = m.Client.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
 			if err == nil {
-				old = derefReplicas(d.Spec.Replicas)
+				if !oldCaptured {
+					old, oldCaptured = derefReplicas(d.Spec.Replicas), true
+				}
 				d.Spec.Replicas = &replicas
 				_, err = m.Client.AppsV1().Deployments(namespace).Update(ctx, d, metav1.UpdateOptions{})
 			}
@@ -110,7 +116,9 @@ func (m *Mutator) scaleWorkloadTyped(ctx context.Context, kind, namespace, name 
 			var s *appsv1.StatefulSet
 			s, err = m.Client.AppsV1().StatefulSets(namespace).Get(ctx, name, metav1.GetOptions{})
 			if err == nil {
-				old = derefReplicas(s.Spec.Replicas)
+				if !oldCaptured {
+					old, oldCaptured = derefReplicas(s.Spec.Replicas), true
+				}
 				s.Spec.Replicas = &replicas
 				_, err = m.Client.AppsV1().StatefulSets(namespace).Update(ctx, s, metav1.UpdateOptions{})
 			}
@@ -204,7 +212,7 @@ func (m *Mutator) createPVCFromSpec(ctx context.Context, namespace, pvcName stri
 // runs `cp -a`, verifies the COPY_SUCCESS marker + exit 0, then deletes the pod.
 func (m *Mutator) copyData(ctx context.Context, namespace, srcPVC, dstPVC, role string) error {
 	podName := fmt.Sprintf("%s-%s-%s", srcPVC, role, rand.String(8))
-	pod := moverPod(podName, srcPVC, dstPVC)
+	pod := moverPod(podName, srcPVC, dstPVC, m.moverImageName())
 	if _, err := m.Client.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{}); err != nil {
 		return fmt.Errorf("rightsize_pvc: create mover pod %s: %w", podName, err)
 	}
@@ -214,13 +222,17 @@ func (m *Mutator) copyData(ctx context.Context, namespace, srcPVC, dstPVC, role 
 		return err
 	}
 
-	const cpCommand = `set -e; if [ -z "$(ls -A /srcData 2>/dev/null)" ]; then echo "COPY_SUCCESS: source is empty"; else timeout 300 cp -a /srcData/. /dstData/ && echo "COPY_SUCCESS: data copied"; fi`
+	// The copy can take far longer than the per-stage opTimeout; bound it by the
+	// remaining LongTaskTimeout budget (copyTimeout) instead of a fixed 5m, both
+	// in the shell `timeout` and the exec deadline so they agree.
+	ct := m.copyTimeout(ctx)
+	cpCommand := fmt.Sprintf(`set -e; if [ -z "$(ls -A /srcData 2>/dev/null)" ]; then echo "COPY_SUCCESS: source is empty"; else timeout %d cp -a /srcData/. /dstData/ && echo "COPY_SUCCESS: data copied"; fi`, int(ct.Seconds()))
 	res, err := m.exec.Exec(ctx, &podexec.Request{
 		Namespace: namespace,
 		Pod:       podName,
 		Container: "data-copier",
 		Command:   []string{"/bin/sh", "-c", cpCommand},
-		Timeout:   m.opTimeout(),
+		Timeout:   ct,
 	})
 	if err != nil {
 		return fmt.Errorf("rightsize_pvc: exec cp in %s: %w", podName, err)
@@ -234,14 +246,14 @@ func (m *Mutator) copyData(ctx context.Context, namespace, srcPVC, dstPVC, role 
 	return nil
 }
 
-func moverPod(name, srcPVC, dstPVC string) *corev1.Pod {
+func moverPod(name, srcPVC, dstPVC, image string) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: name},
 		Spec: corev1.PodSpec{
 			RestartPolicy: corev1.RestartPolicyNever,
 			Containers: []corev1.Container{{
 				Name:            "data-copier",
-				Image:           moverImage,
+				Image:           image,
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command:         []string{"/bin/bash", "-c", "sleep infinity"},
 				VolumeMounts: []corev1.VolumeMount{
@@ -286,14 +298,27 @@ func (m *Mutator) repointDeploymentPVC(ctx context.Context, namespace, name, old
 			return fmt.Errorf("rightsize_pvc: get deployment %s: %w", name, err)
 		}
 		found := false
+		alreadyRepointed := false
 		for i := range d.Spec.Template.Spec.Volumes {
 			v := &d.Spec.Template.Spec.Volumes[i]
-			if v.PersistentVolumeClaim != nil && v.PersistentVolumeClaim.ClaimName == oldPVC {
+			if v.PersistentVolumeClaim == nil {
+				continue
+			}
+			switch v.PersistentVolumeClaim.ClaimName {
+			case oldPVC:
 				v.PersistentVolumeClaim.ClaimName = newPVC
 				found = true
+			case newPVC:
+				alreadyRepointed = true
 			}
 		}
 		if !found {
+			// A prior attempt's Update may have applied server-side before the
+			// client saw a conflict; the re-Get then shows newPVC already set.
+			// Treat that as done rather than failing the migration.
+			if alreadyRepointed {
+				return nil
+			}
 			return fmt.Errorf("rightsize_pvc: deployment %s has no volume referencing pvc %s", name, oldPVC)
 		}
 		_, err = m.Client.AppsV1().Deployments(namespace).Update(ctx, d, metav1.UpdateOptions{})

--- a/runner/pkg/mutate/pvcdownsize_helpers.go
+++ b/runner/pkg/mutate/pvcdownsize_helpers.go
@@ -1,0 +1,455 @@
+package mutate
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	"github.com/nudgebee/nudgebee-agent/pkg/podexec"
+)
+
+func (m *Mutator) logger() *slog.Logger { return slog.Default() }
+
+// getWorkloadByPVC finds the Deployment or StatefulSet that mounts pvcName,
+// matching both pod-template volumes and StatefulSet volumeClaimTemplates
+// (PVC name pattern {tpl}-{sts}-{ordinal}). Deployments are checked first.
+// Returns (workload, kind, nil); a not-found is (nil, "", nil).
+func (m *Mutator) getWorkloadByPVC(ctx context.Context, namespace, pvcName string) (any, string, error) {
+	deps, err := m.Client.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, "", fmt.Errorf("rightsize_pvc: list deployments: %w", err)
+	}
+	for i := range deps.Items {
+		if podSpecMountsPVC(&deps.Items[i].Spec.Template.Spec, pvcName) {
+			return &deps.Items[i], "Deployment", nil
+		}
+	}
+	stss, err := m.Client.AppsV1().StatefulSets(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, "", fmt.Errorf("rightsize_pvc: list statefulsets: %w", err)
+	}
+	for i := range stss.Items {
+		sts := &stss.Items[i]
+		if podSpecMountsPVC(&sts.Spec.Template.Spec, pvcName) {
+			return sts, "StatefulSet", nil
+		}
+		for _, tpl := range sts.Spec.VolumeClaimTemplates {
+			prefix := fmt.Sprintf("%s-%s-", tpl.Name, sts.Name)
+			if suffix, ok := strings.CutPrefix(pvcName, prefix); ok && isAllDigits(suffix) {
+				return sts, "StatefulSet", nil
+			}
+		}
+	}
+	return nil, "", nil
+}
+
+func podSpecMountsPVC(spec *corev1.PodSpec, pvcName string) bool {
+	for _, v := range spec.Volumes {
+		if v.PersistentVolumeClaim != nil && v.PersistentVolumeClaim.ClaimName == pvcName {
+			return true
+		}
+	}
+	return false
+}
+
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func labelSelectorString(sel *metav1.LabelSelector) string {
+	if sel == nil {
+		return ""
+	}
+	keys := make([]string, 0, len(sel.MatchLabels))
+	for k := range sel.MatchLabels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, k+"="+sel.MatchLabels[k])
+	}
+	return strings.Join(parts, ",")
+}
+
+// scaleWorkloadTyped sets spec.replicas on a Deployment/StatefulSet via
+// read-modify-update with conflict retries. Returns the prior replica count.
+func (m *Mutator) scaleWorkloadTyped(ctx context.Context, kind, namespace, name string, replicas int32) (int32, error) {
+	var old int32
+	for attempt := 0; attempt < 3; attempt++ {
+		var err error
+		switch kind {
+		case "Deployment":
+			var d *appsv1.Deployment
+			d, err = m.Client.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+			if err == nil {
+				old = derefReplicas(d.Spec.Replicas)
+				d.Spec.Replicas = &replicas
+				_, err = m.Client.AppsV1().Deployments(namespace).Update(ctx, d, metav1.UpdateOptions{})
+			}
+		case "StatefulSet":
+			var s *appsv1.StatefulSet
+			s, err = m.Client.AppsV1().StatefulSets(namespace).Get(ctx, name, metav1.GetOptions{})
+			if err == nil {
+				old = derefReplicas(s.Spec.Replicas)
+				s.Spec.Replicas = &replicas
+				_, err = m.Client.AppsV1().StatefulSets(namespace).Update(ctx, s, metav1.UpdateOptions{})
+			}
+		default:
+			return 0, fmt.Errorf("rightsize_pvc: unsupported kind %q for scale", kind)
+		}
+		if err == nil {
+			return old, nil
+		}
+		if apierrors.IsConflict(err) && attempt < 2 {
+			select {
+			case <-ctx.Done():
+				return 0, ctx.Err()
+			case <-time.After(time.Duration(1<<attempt) * time.Second):
+			}
+			continue
+		}
+		return 0, fmt.Errorf("rightsize_pvc: scale %s %s/%s to %d: %w", kind, namespace, name, replicas, err)
+	}
+	return 0, fmt.Errorf("rightsize_pvc: scale %s %s/%s: exhausted retries", kind, namespace, name)
+}
+
+func derefReplicas(r *int32) int32 {
+	if r == nil {
+		return 1
+	}
+	return *r
+}
+
+// waitForPodsTerminated blocks until no pods match selector, polling every
+// m.pollInterval() up to m.podTermTimeout().
+func (m *Mutator) waitForPodsTerminated(ctx context.Context, namespace, selector string) error {
+	deadline := time.Now().Add(m.podTermTimeout())
+	for {
+		pods, err := m.Client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
+		if err != nil {
+			return fmt.Errorf("rightsize_pvc: list pods %q: %w", selector, err)
+		}
+		if len(pods.Items) == 0 {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("rightsize_pvc: timeout waiting for pods %q to terminate", selector)
+		}
+		if err := sleepCtx(ctx, m.pollInterval()); err != nil {
+			return err
+		}
+	}
+}
+
+// createPVCFromSpec creates a PVC named pvcName cloning src's spec at the new
+// size, clearing fields that bind it to the old PV. Preserves original labels
+// and user annotations, adds the scaler marker annotation.
+func (m *Mutator) createPVCFromSpec(ctx context.Context, namespace, pvcName string, src *corev1.PersistentVolumeClaim, size resource.Quantity) error {
+	spec := *src.Spec.DeepCopy()
+	if spec.Resources.Requests == nil {
+		spec.Resources.Requests = corev1.ResourceList{}
+	}
+	spec.Resources.Requests[corev1.ResourceStorage] = size
+	spec.VolumeName = ""
+	spec.Selector = nil
+	spec.DataSource = nil
+	spec.DataSourceRef = nil
+
+	annotations := filterUserAnnotations(src.Annotations)
+	annotations[pvcScalerAnnotation] = pvcScalerAnnotation
+	var labels map[string]string
+	if len(src.Labels) > 0 {
+		labels = make(map[string]string, len(src.Labels))
+		for k, v := range src.Labels {
+			labels[k] = v
+		}
+	}
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        pvcName,
+			Namespace:   namespace,
+			Labels:      labels,
+			Annotations: annotations,
+		},
+		Spec: spec,
+	}
+	if _, err := m.Client.CoreV1().PersistentVolumeClaims(namespace).Create(ctx, pvc, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("rightsize_pvc: create pvc %s/%s: %w", namespace, pvcName, err)
+	}
+	return nil
+}
+
+// copyData spins up a transient mover pod mounting src→/srcData and dst→/dstData,
+// runs `cp -a`, verifies the COPY_SUCCESS marker + exit 0, then deletes the pod.
+func (m *Mutator) copyData(ctx context.Context, namespace, srcPVC, dstPVC, role string) error {
+	podName := fmt.Sprintf("%s-%s-%s", srcPVC, role, rand.String(8))
+	pod := moverPod(podName, srcPVC, dstPVC)
+	if _, err := m.Client.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("rightsize_pvc: create mover pod %s: %w", podName, err)
+	}
+	defer m.deletePodBestEffort(context.WithoutCancel(ctx), namespace, podName)
+
+	if err := m.waitForPodRunning(ctx, namespace, podName); err != nil {
+		return err
+	}
+
+	const cpCommand = `set -e; if [ -z "$(ls -A /srcData 2>/dev/null)" ]; then echo "COPY_SUCCESS: source is empty"; else timeout 300 cp -a /srcData/. /dstData/ && echo "COPY_SUCCESS: data copied"; fi`
+	res, err := m.exec.Exec(ctx, &podexec.Request{
+		Namespace: namespace,
+		Pod:       podName,
+		Container: "data-copier",
+		Command:   []string{"/bin/sh", "-c", cpCommand},
+		Timeout:   m.opTimeout(),
+	})
+	if err != nil {
+		return fmt.Errorf("rightsize_pvc: exec cp in %s: %w", podName, err)
+	}
+	if res.ExitCode != 0 {
+		return fmt.Errorf("rightsize_pvc: data copy %s→%s exit %d (stderr: %s)", srcPVC, dstPVC, res.ExitCode, strings.TrimSpace(res.Stderr))
+	}
+	if !strings.Contains(res.Stdout, "COPY_SUCCESS") {
+		return fmt.Errorf("rightsize_pvc: data copy %s→%s produced no COPY_SUCCESS marker (stdout: %s)", srcPVC, dstPVC, strings.TrimSpace(res.Stdout))
+	}
+	return nil
+}
+
+func moverPod(name, srcPVC, dstPVC string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{{
+				Name:            "data-copier",
+				Image:           moverImage,
+				ImagePullPolicy: corev1.PullIfNotPresent,
+				Command:         []string{"/bin/bash", "-c", "sleep infinity"},
+				VolumeMounts: []corev1.VolumeMount{
+					{Name: "src-vol", MountPath: "/srcData"},
+					{Name: "dst-vol", MountPath: "/dstData"},
+				},
+			}},
+			Volumes: []corev1.Volume{
+				{Name: "src-vol", VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: srcPVC}}},
+				{Name: "dst-vol", VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: dstPVC}}},
+			},
+		},
+	}
+}
+
+func (m *Mutator) waitForPodRunning(ctx context.Context, namespace, podName string) error {
+	deadline := time.Now().Add(m.opTimeout())
+	for {
+		pod, err := m.Client.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("rightsize_pvc: get mover pod %s: %w", podName, err)
+		}
+		switch pod.Status.Phase {
+		case corev1.PodRunning:
+			return nil
+		case corev1.PodFailed:
+			return fmt.Errorf("rightsize_pvc: mover pod %s entered Failed", podName)
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("rightsize_pvc: mover pod %s not Running within %s (last phase %s)", podName, m.opTimeout(), pod.Status.Phase)
+		}
+		if err := sleepCtx(ctx, m.pollInterval()); err != nil {
+			return err
+		}
+	}
+}
+
+func (m *Mutator) repointDeploymentPVC(ctx context.Context, namespace, name, oldPVC, newPVC string) error {
+	for attempt := 0; attempt < 5; attempt++ {
+		d, err := m.Client.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("rightsize_pvc: get deployment %s: %w", name, err)
+		}
+		found := false
+		for i := range d.Spec.Template.Spec.Volumes {
+			v := &d.Spec.Template.Spec.Volumes[i]
+			if v.PersistentVolumeClaim != nil && v.PersistentVolumeClaim.ClaimName == oldPVC {
+				v.PersistentVolumeClaim.ClaimName = newPVC
+				found = true
+			}
+		}
+		if !found {
+			return fmt.Errorf("rightsize_pvc: deployment %s has no volume referencing pvc %s", name, oldPVC)
+		}
+		_, err = m.Client.AppsV1().Deployments(namespace).Update(ctx, d, metav1.UpdateOptions{})
+		if err == nil {
+			return nil
+		}
+		if apierrors.IsConflict(err) && attempt < 4 {
+			if err := sleepCtx(ctx, time.Duration(1<<attempt)*time.Second); err != nil {
+				return err
+			}
+			continue
+		}
+		return fmt.Errorf("rightsize_pvc: repoint deployment %s pvc: %w", name, err)
+	}
+	return fmt.Errorf("rightsize_pvc: repoint deployment %s: exhausted retries", name)
+}
+
+func (m *Mutator) patchPVReclaim(ctx context.Context, pvName string, policy corev1.PersistentVolumeReclaimPolicy) error {
+	patch := fmt.Appendf(nil, `{"spec":{"persistentVolumeReclaimPolicy":%q}}`, string(policy))
+	if _, err := m.Client.CoreV1().PersistentVolumes().Patch(ctx, pvName, types.StrategicMergePatchType, patch, metav1.PatchOptions{}); err != nil {
+		return fmt.Errorf("rightsize_pvc: patch pv %s reclaim to %s: %w", pvName, policy, err)
+	}
+	return nil
+}
+
+func (m *Mutator) deletePVC(ctx context.Context, namespace, name string) error {
+	if err := m.Client.CoreV1().PersistentVolumeClaims(namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("rightsize_pvc: delete pvc %s/%s: %w", namespace, name, err)
+	}
+	return nil
+}
+
+func (m *Mutator) waitForPVCDeletion(ctx context.Context, namespace, name string) error {
+	deadline := time.Now().Add(m.opTimeout())
+	for {
+		_, err := m.Client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("rightsize_pvc: poll pvc %s/%s deletion: %w", namespace, name, err)
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("rightsize_pvc: timeout waiting for pvc %s/%s deletion", namespace, name)
+		}
+		if err := sleepCtx(ctx, m.pollInterval()); err != nil {
+			return err
+		}
+	}
+}
+
+// deletePVBestEffort logs but never fails — an orphaned Released PV is left for
+// manual cleanup rather than aborting an otherwise-complete migration.
+func (m *Mutator) deletePVBestEffort(ctx context.Context, name string) {
+	if err := m.Client.CoreV1().PersistentVolumes().Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		m.logger().Warn("rightsize_pvc: failed to delete orphaned PV; manual cleanup may be needed", "pv", name, "err", err)
+	}
+}
+
+func (m *Mutator) deletePodBestEffort(ctx context.Context, namespace, name string) {
+	if err := m.Client.CoreV1().Pods(namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		m.logger().Warn("rightsize_pvc: failed to delete mover pod", "pod", name, "err", err)
+	}
+}
+
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(d):
+		return nil
+	}
+}
+
+// ---- parity snapshot ----
+
+type pvcSnapshot struct {
+	labels          map[string]string
+	userAnnotations map[string]string
+	accessModes     []string
+	storageClass    string
+	volumeMode      string
+}
+
+func newPVCSnapshot(pvc *corev1.PersistentVolumeClaim) pvcSnapshot {
+	s := pvcSnapshot{
+		labels:          map[string]string{},
+		userAnnotations: filterUserAnnotations(pvc.Annotations),
+	}
+	for k, v := range pvc.Labels {
+		s.labels[k] = v
+	}
+	for _, am := range pvc.Spec.AccessModes {
+		s.accessModes = append(s.accessModes, string(am))
+	}
+	sort.Strings(s.accessModes)
+	if pvc.Spec.StorageClassName != nil {
+		s.storageClass = *pvc.Spec.StorageClassName
+	}
+	if pvc.Spec.VolumeMode != nil {
+		s.volumeMode = string(*pvc.Spec.VolumeMode)
+	}
+	return s
+}
+
+// verifyParity compares metadata/spec of the new PVC against the snapshot and
+// the expected size. Returns the list of mismatches (empty == parity holds).
+func (s pvcSnapshot) verifyParity(newPVC *corev1.PersistentVolumeClaim, expected resource.Quantity) []string {
+	var mm []string
+	for k, v := range s.labels {
+		if newPVC.Labels[k] != v {
+			mm = append(mm, fmt.Sprintf("label %q: want %q got %q", k, v, newPVC.Labels[k]))
+		}
+	}
+	newAnnots := filterUserAnnotations(newPVC.Annotations)
+	for k, v := range s.userAnnotations {
+		if newAnnots[k] != v {
+			mm = append(mm, fmt.Sprintf("annotation %q: want %q got %q", k, v, newAnnots[k]))
+		}
+	}
+	var newModes []string
+	for _, am := range newPVC.Spec.AccessModes {
+		newModes = append(newModes, string(am))
+	}
+	sort.Strings(newModes)
+	if strings.Join(newModes, ",") != strings.Join(s.accessModes, ",") {
+		mm = append(mm, fmt.Sprintf("accessModes: want %v got %v", s.accessModes, newModes))
+	}
+	newSC := ""
+	if newPVC.Spec.StorageClassName != nil {
+		newSC = *newPVC.Spec.StorageClassName
+	}
+	if newSC != s.storageClass {
+		mm = append(mm, fmt.Sprintf("storageClassName: want %q got %q", s.storageClass, newSC))
+	}
+	newVM := ""
+	if newPVC.Spec.VolumeMode != nil {
+		newVM = string(*newPVC.Spec.VolumeMode)
+	}
+	if newVM != s.volumeMode {
+		mm = append(mm, fmt.Sprintf("volumeMode: want %q got %q", s.volumeMode, newVM))
+	}
+	got := newPVC.Spec.Resources.Requests[corev1.ResourceStorage]
+	if got.Cmp(expected) != 0 {
+		mm = append(mm, fmt.Sprintf("storage: want %s got %s", expected.String(), got.String()))
+	}
+	return mm
+}
+
+func filterUserAnnotations(in map[string]string) map[string]string {
+	out := map[string]string{}
+	for k, v := range in {
+		if k == pvcScalerAnnotation || k8sInternalAnnotation.MatchString(k) {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}

--- a/runner/pkg/mutate/pvcdownsize_test.go
+++ b/runner/pkg/mutate/pvcdownsize_test.go
@@ -299,3 +299,19 @@ func TestVerifyParity(t *testing.T) {
 }
 
 func ptr32(i int32) *int32 { return &i }
+
+// TestRepointDeploymentPVC_Idempotent covers the retry case where a prior
+// Update applied server-side but the client saw a conflict: the re-Get shows
+// the volume already on newPVC, which must be treated as success (not a hard
+// "no volume referencing oldPVC" error that would fail the migration).
+func TestRepointDeploymentPVC_Idempotent(t *testing.T) {
+	cs := fake.NewClientset(deploymentMounting("data", "web", "data-new", 2))
+	m := New(cs, "", nil)
+	if err := m.repointDeploymentPVC(context.Background(), "data", "web", "data-old", "data-new"); err != nil {
+		t.Fatalf("already-repointed deployment should succeed, got %v", err)
+	}
+	// genuinely-missing volume still errors.
+	if err := m.repointDeploymentPVC(context.Background(), "data", "web", "data-old", "data-other"); err == nil {
+		t.Error("expected error when no volume references oldPVC and not already repointed")
+	}
+}

--- a/runner/pkg/mutate/pvcdownsize_test.go
+++ b/runner/pkg/mutate/pvcdownsize_test.go
@@ -1,0 +1,301 @@
+package mutate
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+
+	"github.com/nudgebee/nudgebee-agent/pkg/podexec"
+)
+
+// fakeExec stubs the SPDY pod-exec. The real mover pod never runs under the
+// fake clientset, so the copy is simulated by the configured result.
+type fakeExec struct {
+	res   *podexec.Result
+	err   error
+	calls int
+}
+
+func (f *fakeExec) Exec(_ context.Context, _ *podexec.Request) (*podexec.Result, error) {
+	f.calls++
+	return f.res, f.err
+}
+
+// markPodsRunning makes every created pod immediately Running so
+// waitForPodRunning returns without the real scheduler.
+func markPodsRunning(cs *fake.Clientset) {
+	cs.PrependReactor("create", "pods", func(a ktesting.Action) (bool, runtime.Object, error) {
+		pod := a.(ktesting.CreateAction).GetObject().(*corev1.Pod)
+		pod.Status.Phase = corev1.PodRunning
+		return false, nil, nil // fall through so the tracker stores the mutated pod
+	})
+}
+
+func q(s string) resource.Quantity { return resource.MustParse(s) }
+
+func boundPVC(ns, name, sc, pvName, size string) *corev1.PersistentVolumeClaim {
+	scn := sc
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns, Labels: map[string]string{"app": "x"}},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &scn,
+			VolumeName:       pvName,
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources:        corev1.VolumeResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceStorage: q(size)}},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Phase:    corev1.ClaimBound,
+			Capacity: corev1.ResourceList{corev1.ResourceStorage: q(size)},
+		},
+	}
+}
+
+func pvWith(name string, reclaim corev1.PersistentVolumeReclaimPolicy) *corev1.PersistentVolume {
+	return &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       corev1.PersistentVolumeSpec{PersistentVolumeReclaimPolicy: reclaim},
+	}
+}
+
+func deploymentMounting(ns, name, pvcName string, replicas int32) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": name}},
+			Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+				Volumes: []corev1.Volume{{Name: "d", VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: pvcName},
+				}}},
+			}},
+		},
+	}
+}
+
+func fastSC() *storagev1.StorageClass {
+	return &storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "fast"}}
+}
+
+func newMigrator(cs *fake.Clientset, fe podexec.Executor) *Mutator {
+	m := New(cs, "", nil)
+	m.SetExec(fe)
+	m.opTimeoutOverride = 2 * time.Second
+	m.podTermTimeoutOverride = 2 * time.Second
+	m.pollIntervalOverride = 2 * time.Millisecond
+	return m
+}
+
+func listPVCNames(t *testing.T, cs *fake.Clientset, ns string) []string {
+	t.Helper()
+	l, err := cs.CoreV1().PersistentVolumeClaims(ns).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var names []string
+	for _, p := range l.Items {
+		names = append(names, p.Name)
+	}
+	return names
+}
+
+func TestDownsizeDeployment_HappyPath(t *testing.T) {
+	cs := fake.NewClientset(
+		boundPVC("data", "vol", "fast", "pv-1", "20Gi"),
+		pvWith("pv-1", corev1.PersistentVolumeReclaimDelete),
+		fastSC(),
+		deploymentMounting("data", "web", "vol", 2),
+	)
+	markPodsRunning(cs)
+	m := newMigrator(cs, &fakeExec{res: &podexec.Result{Stdout: "COPY_SUCCESS", ExitCode: 0}})
+
+	got, err := m.DownsizePVC(context.Background(), "data", "vol", q("10Gi"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.(map[string]any)["success"] != true {
+		t.Fatalf("success=%v", got)
+	}
+
+	// Original PVC deleted; a downsized PVC exists at the new size.
+	var newName string
+	for _, n := range listPVCNames(t, cs, "data") {
+		if n == "vol" {
+			t.Error("original PVC should be deleted")
+		}
+		if strings.HasPrefix(n, "vol-downsized-") {
+			newName = n
+		}
+	}
+	if newName == "" {
+		t.Fatal("downsized PVC not found")
+	}
+	newPVC, _ := cs.CoreV1().PersistentVolumeClaims("data").Get(context.Background(), newName, metav1.GetOptions{})
+	if got := newPVC.Spec.Resources.Requests[corev1.ResourceStorage]; got.Cmp(q("10Gi")) != 0 {
+		t.Errorf("new pvc size = %s; want 10Gi", got.String())
+	}
+	// Deployment repointed and scaled back up.
+	dep, _ := cs.AppsV1().Deployments("data").Get(context.Background(), "web", metav1.GetOptions{})
+	if cn := dep.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ClaimName; cn != newName {
+		t.Errorf("deployment claim = %q; want %q", cn, newName)
+	}
+	if *dep.Spec.Replicas != 2 {
+		t.Errorf("replicas = %d; want 2 restored", *dep.Spec.Replicas)
+	}
+}
+
+func TestDownsizeStatefulSet_HappyPath(t *testing.T) {
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "db", Namespace: "data"},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: ptr32(1),
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "db"}},
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+				{ObjectMeta: metav1.ObjectMeta{Name: "data"}},
+			},
+		},
+	}
+	cs := fake.NewClientset(
+		boundPVC("data", "data-db-0", "fast", "pv-2", "20Gi"),
+		pvWith("pv-2", corev1.PersistentVolumeReclaimDelete),
+		fastSC(),
+		sts,
+	)
+	markPodsRunning(cs)
+	fe := &fakeExec{res: &podexec.Result{Stdout: "COPY_SUCCESS", ExitCode: 0}}
+	m := newMigrator(cs, fe)
+
+	if _, err := m.DownsizePVC(context.Background(), "data", "data-db-0", q("10Gi")); err != nil {
+		t.Fatal(err)
+	}
+	if fe.calls != 2 {
+		t.Errorf("expected 2 copies (orig→temp, temp→orig), got %d", fe.calls)
+	}
+	// Original name preserved at new size; temp PVC cleaned up.
+	final, err := cs.CoreV1().PersistentVolumeClaims("data").Get(context.Background(), "data-db-0", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("original-name PVC must survive: %v", err)
+	}
+	if got := final.Spec.Resources.Requests[corev1.ResourceStorage]; got.Cmp(q("10Gi")) != 0 {
+		t.Errorf("final size = %s; want 10Gi", got.String())
+	}
+	for _, n := range listPVCNames(t, cs, "data") {
+		if strings.Contains(n, "-tmp-") {
+			t.Errorf("temp PVC %q should be cleaned up", n)
+		}
+	}
+	// Orphaned PV deleted on success.
+	if _, err := cs.CoreV1().PersistentVolumes().Get(context.Background(), "pv-2", metav1.GetOptions{}); err == nil {
+		t.Error("orphaned PV should be deleted")
+	}
+	sf, _ := cs.AppsV1().StatefulSets("data").Get(context.Background(), "db", metav1.GetOptions{})
+	if *sf.Spec.Replicas != 1 {
+		t.Errorf("replicas = %d; want 1 restored", *sf.Spec.Replicas)
+	}
+}
+
+func TestDownsizeDeployment_RollbackOnCopyFailure(t *testing.T) {
+	cs := fake.NewClientset(
+		boundPVC("data", "vol", "fast", "pv-1", "20Gi"),
+		pvWith("pv-1", corev1.PersistentVolumeReclaimDelete),
+		fastSC(),
+		deploymentMounting("data", "web", "vol", 3),
+	)
+	markPodsRunning(cs)
+	// Copy fails before the point of no return.
+	m := newMigrator(cs, &fakeExec{res: &podexec.Result{Stdout: "", ExitCode: 1, Stderr: "disk full"}})
+
+	if _, err := m.DownsizePVC(context.Background(), "data", "vol", q("10Gi")); err == nil {
+		t.Fatal("expected copy failure to abort")
+	}
+	// Original intact, new PVC cleaned up, replicas restored, claim unchanged.
+	if _, err := cs.CoreV1().PersistentVolumeClaims("data").Get(context.Background(), "vol", metav1.GetOptions{}); err != nil {
+		t.Error("original PVC must remain after rollback")
+	}
+	for _, n := range listPVCNames(t, cs, "data") {
+		if strings.HasPrefix(n, "vol-downsized-") {
+			t.Errorf("new PVC %q should be deleted on rollback", n)
+		}
+	}
+	dep, _ := cs.AppsV1().Deployments("data").Get(context.Background(), "web", metav1.GetOptions{})
+	if *dep.Spec.Replicas != 3 {
+		t.Errorf("replicas = %d; want 3 restored", *dep.Spec.Replicas)
+	}
+	if cn := dep.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ClaimName; cn != "vol" {
+		t.Errorf("claim = %q; should be unchanged 'vol'", cn)
+	}
+}
+
+func TestDownsize_RequiresExec(t *testing.T) {
+	cs := fake.NewClientset(boundPVC("data", "vol", "fast", "pv-1", "20Gi"), pvWith("pv-1", "Delete"), fastSC())
+	m := New(cs, "", nil) // no SetExec
+	if _, err := m.DownsizePVC(context.Background(), "data", "vol", q("10Gi")); err == nil {
+		t.Fatal("expected error when exec capability is absent")
+	}
+}
+
+func TestValidateDownsizePrereqs(t *testing.T) {
+	// not Bound
+	pvc := boundPVC("data", "vol", "fast", "pv-1", "20Gi")
+	pvc.Status.Phase = corev1.ClaimPending
+	cs := fake.NewClientset(pvc, pvWith("pv-1", "Delete"), fastSC())
+	m := newMigrator(cs, &fakeExec{res: &podexec.Result{}})
+	if _, _, err := m.validateDownsizePrereqs(context.Background(), "data", "vol"); err == nil {
+		t.Error("expected error for non-Bound PVC")
+	}
+
+	// hostPath PV
+	pv := pvWith("pv-h", "Delete")
+	pv.Spec.HostPath = &corev1.HostPathVolumeSource{Path: "/tmp"}
+	cs2 := fake.NewClientset(boundPVC("data", "vh", "fast", "pv-h", "20Gi"), pv, fastSC())
+	m2 := newMigrator(cs2, &fakeExec{res: &podexec.Result{}})
+	if _, _, err := m2.validateDownsizePrereqs(context.Background(), "data", "vh"); err == nil {
+		t.Error("expected error for hostPath PV")
+	}
+}
+
+func TestGetWorkloadByPVC_StatefulSetTemplate(t *testing.T) {
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "db", Namespace: "data"},
+		Spec: appsv1.StatefulSetSpec{
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "data"}}},
+		},
+	}
+	cs := fake.NewClientset(sts)
+	m := New(cs, "", nil)
+	_, kind, err := m.getWorkloadByPVC(context.Background(), "data", "data-db-0")
+	if err != nil || kind != "StatefulSet" {
+		t.Fatalf("kind=%q err=%v; want StatefulSet", kind, err)
+	}
+	// non-matching ordinal suffix
+	_, kind, _ = m.getWorkloadByPVC(context.Background(), "data", "data-db-x")
+	if kind != "" {
+		t.Errorf("kind=%q; want no match for non-numeric ordinal", kind)
+	}
+}
+
+func TestVerifyParity(t *testing.T) {
+	src := boundPVC("data", "vol", "fast", "pv-1", "20Gi")
+	snap := newPVCSnapshot(src)
+	// faithful clone at 10Gi passes
+	clone := boundPVC("data", "vol2", "fast", "", "10Gi")
+	if mm := snap.verifyParity(clone, q("10Gi")); len(mm) != 0 {
+		t.Errorf("expected parity, got %v", mm)
+	}
+	// wrong storageclass fails
+	bad := boundPVC("data", "vol3", "slow", "", "10Gi")
+	if mm := snap.verifyParity(bad, q("10Gi")); len(mm) == 0 {
+		t.Error("expected storageClass mismatch")
+	}
+}
+
+func ptr32(i int32) *int32 { return &i }

--- a/runner/pkg/mutate/replica.go
+++ b/runner/pkg/mutate/replica.go
@@ -1,0 +1,93 @@
+// Package mutate — replica_rightsizing.
+//
+// replica_rightsizing changes a workload's replica count. It arrives only via
+// the agent_task poller (trusted path), built by the api-server for two flows:
+//   - abandoned_resource / scale-to-zero (replica_count int 0)
+//   - event-resolution increase_replicas (replica_count string, e.g. "3")
+//
+// so the handler coerces replica_count from either a JSON number or a numeric
+// string. Only Deployment/StatefulSet/Rollout are scalable (the legacy robusta
+// action no-op'd Pod/Job/DaemonSet). We merge-patch spec.replicas through the
+// dynamic client, which covers the built-in workloads and the Argo Rollout CRD
+// behind one code path.
+package mutate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// scalableWorkloadGVRs maps the lowercased kind to its GVR. Keyed lowercase so
+// the lookup tolerates whatever casing the api-server forwards (controllerKind
+// / SubjectOwnerKind are usually capitalized, but we don't depend on it).
+// Deliberately excludes DaemonSet (no spec.replicas) and ReplicaSet (legacy
+// excluded it; scaling a bare RS fights its owning controller).
+var scalableWorkloadGVRs = map[string]schema.GroupVersionResource{
+	"deployment":  {Group: "apps", Version: "v1", Resource: "deployments"},
+	"statefulset": {Group: "apps", Version: "v1", Resource: "statefulsets"},
+	"rollout":     {Group: "argoproj.io", Version: "v1alpha1", Resource: "rollouts"},
+}
+
+// ScaleWorkload sets spec.replicas on a Deployment/StatefulSet/Rollout via a
+// strategic-/merge-patch through the dynamic client. replicas may be 0
+// (scale-to-zero). namespace + name required; kind is case-insensitive.
+func (m *Mutator) ScaleWorkload(ctx context.Context, kind, namespace, name string, replicas int64) (any, error) {
+	if m.dynamic == nil {
+		return nil, errors.New("mutate: dynamic client not configured")
+	}
+	if namespace == "" || name == "" {
+		return nil, errors.New("mutate: namespace and name required")
+	}
+	if replicas < 0 {
+		return nil, fmt.Errorf("mutate: replica_count must be >= 0, got %d", replicas)
+	}
+	gvr, ok := scalableWorkloadGVRs[strings.ToLower(kind)]
+	if !ok {
+		return nil, fmt.Errorf("replica_rightsizing: unsupported kind %q (Deployment|StatefulSet|Rollout)", kind)
+	}
+
+	patch := fmt.Appendf(nil, `{"spec":{"replicas":%d}}`, replicas)
+	updated, err := m.dynamic.Resource(gvr).Namespace(namespace).
+		Patch(ctx, name, types.MergePatchType, patch, metav1.PatchOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("mutate: scale %s/%s/%s to %d: %w", kind, namespace, name, replicas, err)
+	}
+	return map[string]any{
+		"success": true,
+		"message": fmt.Sprintf("%s/%s/%s scaled to %d replicas", kind, namespace, name, replicas),
+		"updated": updated.UnstructuredContent(),
+	}, nil
+}
+
+// toInt64 coerces a JSON-decoded value that may be a float64 (number) or a
+// string (the event-resolution path sends replica_count as a string). Returns
+// false when the value is absent or not a whole number.
+func toInt64(v any) (int64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return int64(n), true
+	case int64:
+		return n, true
+	case int:
+		return int64(n), true
+	case string:
+		s := strings.TrimSpace(n)
+		if s == "" {
+			return 0, false
+		}
+		parsed, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return 0, false
+		}
+		return parsed, true
+	default:
+		return 0, false
+	}
+}

--- a/runner/pkg/mutate/replica_test.go
+++ b/runner/pkg/mutate/replica_test.go
@@ -1,0 +1,120 @@
+package mutate
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/client-go/dynamic/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestScaleWorkload_Deployment_ScaleToZero(t *testing.T) {
+	existing := seedExisting("apps/v1", "Deployment", "web", "shop", "100")
+	dyn := fake.NewSimpleDynamicClient(workloadScheme(), existing)
+	m := New(k8sfake.NewClientset(), "", nil)
+	m.SetDynamic(dyn)
+
+	got, err := m.ScaleWorkload(context.Background(), "Deployment", "shop", "web", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := got.(map[string]any)
+	if r["success"] != true {
+		t.Errorf("success = %v", r["success"])
+	}
+	updated := r["updated"].(map[string]any)
+	spec := updated["spec"].(map[string]any)
+	if got := asInt64(spec["replicas"]); got != 0 {
+		t.Errorf("replicas = %v; want 0", got)
+	}
+}
+
+// asInt64 normalises the replicas value, which the dynamic fake's Patch echoes
+// as int64 while the JSON wire path would surface it as float64.
+func asInt64(v any) int64 {
+	switch n := v.(type) {
+	case int64:
+		return n
+	case float64:
+		return int64(n)
+	default:
+		return -1
+	}
+}
+
+func TestHandleReplicaRightsizing_StringReplicaCount(t *testing.T) {
+	// event-resolution path sends replica_count as a string.
+	existing := seedExisting("apps/v1", "StatefulSet", "db", "data", "5")
+	dyn := fake.NewSimpleDynamicClient(workloadScheme(), existing)
+	m := New(k8sfake.NewClientset(), "", nil)
+	m.SetDynamic(dyn)
+	hs := Handlers(m)
+
+	got, err := hs["replica_rightsizing"](context.Background(), map[string]any{
+		"kind":          "StatefulSet",
+		"namespace":     "data",
+		"name":          "db",
+		"replica_count": "3",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	spec := got.(map[string]any)["updated"].(map[string]any)["spec"].(map[string]any)
+	if got := asInt64(spec["replicas"]); got != 3 {
+		t.Errorf("replicas = %v; want 3", got)
+	}
+}
+
+func TestHandleReplicaRightsizing_UnsupportedKind(t *testing.T) {
+	m := New(k8sfake.NewClientset(), "", nil)
+	m.SetDynamic(fake.NewSimpleDynamicClient(workloadScheme()))
+	hs := Handlers(m)
+	_, err := hs["replica_rightsizing"](context.Background(), map[string]any{
+		"kind": "DaemonSet", "namespace": "n", "name": "x", "replica_count": float64(2),
+	})
+	if err == nil {
+		t.Fatal("expected error for DaemonSet (not scalable)")
+	}
+}
+
+func TestHandleReplicaRightsizing_MissingReplicaCount(t *testing.T) {
+	m := New(k8sfake.NewClientset(), "", nil)
+	m.SetDynamic(fake.NewSimpleDynamicClient(workloadScheme()))
+	hs := Handlers(m)
+	_, err := hs["replica_rightsizing"](context.Background(), map[string]any{
+		"kind": "Deployment", "namespace": "n", "name": "x",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing replica_count")
+	}
+}
+
+func TestScaleWorkload_RequiresDynamic(t *testing.T) {
+	m := New(k8sfake.NewClientset(), "", nil) // no SetDynamic
+	if _, ok := Handlers(m)["replica_rightsizing"]; ok {
+		t.Error("replica_rightsizing should not register without a dynamic client")
+	}
+}
+
+func TestToInt64(t *testing.T) {
+	cases := []struct {
+		in   any
+		want int64
+		ok   bool
+	}{
+		{float64(0), 0, true},
+		{float64(3), 3, true},
+		{"3", 3, true},
+		{" 5 ", 5, true},
+		{"", 0, false},
+		{"abc", 0, false},
+		{nil, 0, false},
+		{int(7), 7, true},
+	}
+	for _, c := range cases {
+		got, ok := toInt64(c.in)
+		if ok != c.ok || (ok && got != c.want) {
+			t.Errorf("toInt64(%#v) = (%d,%v); want (%d,%v)", c.in, got, ok, c.want, c.ok)
+		}
+	}
+}

--- a/runner/pkg/tasks/poller.go
+++ b/runner/pkg/tasks/poller.go
@@ -45,6 +45,16 @@ type Service struct {
 	HTTP       *http.Client
 	Logger     *slog.Logger
 	Dispatch   Dispatcher
+
+	// LongActions names actions that may run for many minutes (the
+	// rightsize_pvc downsize migration). They are dispatched on a detached
+	// goroutine so a single slow task doesn't stall the sequential queue
+	// drain, and on a context decoupled from the poll cycle so the next
+	// Period tick / a brief shutdown doesn't cancel an in-flight migration.
+	// The collector already flipped the row to PROCESSING on GET, so it is
+	// not re-handed while running. Trade-off: an agent restart mid-migration
+	// orphans the task (it reaps to TIMEOUT, recoverable by re-applying).
+	LongActions map[string]struct{}
 }
 
 // Run blocks until ctx is done. Polls in a loop with Period spacing.
@@ -153,6 +163,20 @@ func (s *Service) process(ctx context.Context, t task) {
 	}
 	params, _ := payload["action_params"].(map[string]any)
 
+	if _, long := s.LongActions[actionName]; long {
+		// Detach from the poll-cycle context so the next Period tick (or a
+		// brief shutdown) doesn't cancel a multi-minute migration, and run
+		// off the drain goroutine so the rest of the queue keeps moving.
+		taskID, action, p := t.TaskID, actionName, params
+		go s.runTask(context.WithoutCancel(ctx), taskID, action, p)
+		return
+	}
+	s.runTask(ctx, t.TaskID, actionName, params)
+}
+
+// runTask dispatches one action through the trusted handler path and posts the
+// result back. Shared by the synchronous (short) and detached (long) paths.
+func (s *Service) runTask(ctx context.Context, taskID, actionName string, params map[string]any) {
 	start := time.Now()
 	data, ok, err := s.Dispatch.HandleTrusted(ctx, actionName, params, false)
 	elapsed := time.Since(start)
@@ -160,10 +184,10 @@ func (s *Service) process(ctx context.Context, t task) {
 	var resp map[string]any
 	switch {
 	case !ok:
-		s.Logger.Warn("task: action not registered", "task_id", t.TaskID, "action_name", actionName)
+		s.Logger.Warn("task: action not registered", "task_id", taskID, "action_name", actionName)
 		resp = map[string]any{"success": false, "msg": "action not registered: " + actionName}
 	case err != nil:
-		s.Logger.Warn("task: handler error", "task_id", t.TaskID, "action_name", actionName, "err", err)
+		s.Logger.Warn("task: handler error", "task_id", taskID, "action_name", actionName, "err", err)
 		resp = map[string]any{"success": false, "msg": err.Error()}
 	default:
 		// Handlers already return {success, ...} for thin actions; for
@@ -181,7 +205,7 @@ func (s *Service) process(ctx context.Context, t task) {
 		}
 	}
 	resp["task_processing_duration"] = int(elapsed.Round(time.Second).Seconds())
-	s.respond(ctx, t.TaskID, resp)
+	s.respond(ctx, taskID, resp)
 }
 
 // respond posts the task result back to /v1/k8s/tasks/<task_id>.

--- a/runner/pkg/tasks/poller.go
+++ b/runner/pkg/tasks/poller.go
@@ -47,13 +47,13 @@ type Service struct {
 	Dispatch   Dispatcher
 
 	// LongActions names actions that may run for many minutes (the
-	// rightsize_pvc downsize migration). They are dispatched on a detached
+	// rightsize_pvc downsize migration). They are dispatched on a separate
 	// goroutine so a single slow task doesn't stall the sequential queue
-	// drain, and on a context decoupled from the poll cycle so the next
-	// Period tick / a brief shutdown doesn't cancel an in-flight migration.
-	// The collector already flipped the row to PROCESSING on GET, so it is
-	// not re-handed while running. Trade-off: an agent restart mid-migration
-	// orphans the task (it reaps to TIMEOUT, recoverable by re-applying).
+	// drain. The collector already flipped the row to PROCESSING on GET, so it
+	// is not re-handed while running. On shutdown the agent context is
+	// cancelled, so an in-flight migration aborts and its rollback defers run
+	// within the termination grace; a hard kill still orphans the task (it
+	// reaps to TIMEOUT, recoverable by re-applying).
 	LongActions map[string]struct{}
 }
 
@@ -164,11 +164,13 @@ func (s *Service) process(ctx context.Context, t task) {
 	params, _ := payload["action_params"].(map[string]any)
 
 	if _, long := s.LongActions[actionName]; long {
-		// Detach from the poll-cycle context so the next Period tick (or a
-		// brief shutdown) doesn't cancel a multi-minute migration, and run
-		// off the drain goroutine so the rest of the queue keeps moving.
+		// Run off the drain goroutine so a multi-minute task doesn't stall the
+		// rest of the queue. We keep the agent context (it's the long-lived
+		// lifecycle ctx — the poll loop reuses it, so only shutdown cancels it)
+		// so a graceful shutdown propagates cancellation and the migration's
+		// rollback defers can clean up within the termination grace.
 		taskID, action, p := t.TaskID, actionName, params
-		go s.runTask(context.WithoutCancel(ctx), taskID, action, p)
+		go s.runTask(ctx, taskID, action, p)
 		return
 	}
 	s.runTask(ctx, t.TaskID, actionName, params)

--- a/runner/pkg/tasks/poller_test.go
+++ b/runner/pkg/tasks/poller_test.go
@@ -183,10 +183,10 @@ func (g *gateDispatch) HandleTrusted(_ context.Context, _ string, _ map[string]a
 func TestService_LongActionRunsAsync(t *testing.T) {
 	posted := make(chan map[string]any, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet:
+		switch r.Method {
+		case http.MethodGet:
 			_, _ = w.Write([]byte(`{"data":[{"task_id":"m1","payload":{"action_name":"rightsize_pvc","action_params":{}},"source":"recommendation"}],"remaining_task_count":0}`))
-		case r.Method == http.MethodPost:
+		case http.MethodPost:
 			body, _ := io.ReadAll(r.Body)
 			var v map[string]any
 			_ = json.Unmarshal(body, &v)

--- a/runner/pkg/tasks/poller_test.go
+++ b/runner/pkg/tasks/poller_test.go
@@ -161,3 +161,70 @@ func TestParseTaskWindow(t *testing.T) {
 		}
 	}
 }
+
+// gateDispatch blocks in HandleTrusted until released, so the test can observe
+// that a long action does not block the drain loop.
+type gateDispatch struct {
+	started  chan struct{}
+	release  chan struct{}
+	finished atomic.Bool
+}
+
+func (g *gateDispatch) HandleTrusted(_ context.Context, _ string, _ map[string]any, _ bool) (any, bool, error) {
+	close(g.started)
+	<-g.release
+	g.finished.Store(true)
+	return map[string]any{"success": true}, true, nil
+}
+
+// TestService_LongActionRunsAsync asserts a LongActions task is dispatched on a
+// detached goroutine: drain() returns before the handler finishes, and the
+// result is still POSTed once the handler completes.
+func TestService_LongActionRunsAsync(t *testing.T) {
+	posted := make(chan map[string]any, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`{"data":[{"task_id":"m1","payload":{"action_name":"rightsize_pvc","action_params":{}},"source":"recommendation"}],"remaining_task_count":0}`))
+		case r.Method == http.MethodPost:
+			body, _ := io.ReadAll(r.Body)
+			var v map[string]any
+			_ = json.Unmarshal(body, &v)
+			posted <- v
+			w.WriteHeader(200)
+		}
+	}))
+	defer srv.Close()
+
+	g := &gateDispatch{started: make(chan struct{}), release: make(chan struct{})}
+	s := &Service{
+		Endpoint:    srv.URL,
+		Period:      time.Hour,
+		Logger:      slog.Default(),
+		Dispatch:    g,
+		LongActions: map[string]struct{}{"rightsize_pvc": {}},
+	}
+
+	if err := s.drain(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	<-g.started // handler is in flight
+	if g.finished.Load() {
+		t.Fatal("drain should have returned before the long handler finished")
+	}
+	select {
+	case <-posted:
+		t.Fatal("result posted before handler released")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(g.release) // let the handler complete
+	select {
+	case v := <-posted:
+		if v["success"] != true {
+			t.Errorf("posted result = %+v", v)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("long action result never posted")
+	}
+}


### PR DESCRIPTION
## What & why

The api-server enqueues several remediation/apply actions onto the `agent_task` queue that the Go agent's poller dispatches by `action_name`. Three were unimplemented — the poller replied **"action not registered"**, so applying these recommendations failed:

- **`replica_rightsizing`** — scale-to-zero of abandoned workloads + event-resolution `increase_replicas`
- **`rightsize_pvc`** — PVC resize recommendations (expand *and* downsize)
- **`volume_delete`** — delete unused PersistentVolumes

This PR implements all three (ports the legacy robusta behavior), plus the execution-model changes the long-running downsize migration needs.

## Changes

**Handlers (`pkg/mutate`)**
- `replica_rightsizing`: scale Deployment/StatefulSet/Rollout via the dynamic client; `replica_count` coerced from JSON number **or** numeric string (both wire forms).
- `rightsize_pvc`: routes by provisioned capacity. Expansion patches the storage request after checking `allowVolumeExpansion`. **Downsize** runs a copy-migration — Deployment (new PVC → copy → repoint → delete original) and StatefulSet (name-preserving double copy with PV reclaim→Retain before the destructive delete). Data is moved by a transient `ubuntu` mover pod (`cp -a`) exec'd over SPDY, with config-parity verification and stage-aware rollback that keeps two data copies past the point of no return.
- `volume_delete`: deletes the PV (payload `name` is the cluster-scoped PV) and its bound PVC via `claimRef`; 404-tolerant.
- All three are delivered via the **trusted** `agent_task` poller and stay **out** of the light-action allowlist (same posture as `rightsizing_resource`).

**Execution model (`pkg/dispatch`, `pkg/tasks`)**
- Per-action `LongTaskTimeout` so the migration isn't killed by the 180s dispatch cap. Default 50m (env `LONG_TASK_TIMEOUT_SECONDS`), kept under the server's 60m `PROCESSING→TIMEOUT` reap.
- Poller runs long actions on a detached goroutine so a migration doesn't stall the queue drain or get cancelled by the next poll tick.

**Tooling / tests**
- `pkg/mutate/live_test.go` (`//go:build live`): asserted end-to-end tests against a real cluster — expand, replica scale, downsize-with-data-survival, volume_delete. Excluded from normal builds; sizes/SC env-tunable.
- `cmd/actionctl`: small dev CLI to invoke a single handler against the cluster without the relay/backend.

## Testing
- Unit tests (fake client/dynamic/exec) for every handler, rollback, parity, coercion; plus dispatch long-timeout and poller async-dispatch tests.
- **Live-verified on GKE dev** — all four `TestLive*` pass, including data preserved across the full downsize migration (mover pod copy → repoint → original deleted → token read back from the new PVC).

## Notes
- RBAC: the runner ServiceAccount already grants everything the migration needs (PV patch/delete, PVC create/delete, pods + pods/exec, deployments/statefulsets update, storageclasses get) — no chart change.
- Per-copy is bounded by a shell `timeout 300`; integrity check is `cp -a` exit + `COPY_SUCCESS` marker (no checksum) — both inherited from the legacy action.
- An agent restart mid-migration orphans the task (reaps to TIMEOUT, recoverable by re-applying).