### PR TITLE
feat(chart): batching on by default, in-cluster opencost off by default

### DIFF
--- a/charts/nudgebee-agent/Chart.yaml
+++ b/charts/nudgebee-agent/Chart.yaml
@@ -29,8 +29,8 @@ annotations:
 # these are set to the right value by .github/workflows/release.yaml
 # we use 0.0.1 as a placeholder for the version` because Helm wont allow `0.0.0` and we want to be able to run
 # `helm install` on development checkouts without updating this file. the version doesn't matter in that case anyway
-version: 0.1.2
-appVersion: 0.1.2
+version: 0.1.3
+appVersion: 0.1.3
 dependencies:
 - name: opencost
   version: 2.0.1

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -100,12 +100,12 @@ runner:
   # Scalability tunables for large clusters. All optional — unset
   # keys fall back to the binary defaults. The wire-changing knobs
   # (snapshotBatching, incrementalBatchSize > 1, emitTombstones) require matching
-  # collector support and MUST stay off until the collector ships it.
-  scaling: {}
-  # snapshotBatching: false      # batch the full-load snapshot (needs collector batch reassembly)
-  # batchSize: 1000              # items per snapshot batch when snapshotBatching is on
-  # incrementalBatchSize: 1      # coalesce N informer events per incremental POST (>1 needs collector to iterate data)
-  # emitTombstones: false        # emit deleted:true on delete (needs collector incremental-delete support)
+  # collector support, which has shipped, so they are enabled by default.
+  scaling:
+    snapshotBatching: true       # batch the full-load snapshot (needs collector batch reassembly)
+    batchSize: 1000              # items per snapshot batch when snapshotBatching is on
+    incrementalBatchSize: 100    # coalesce N informer events per incremental POST (>1 needs collector to iterate data)
+    emitTombstones: true         # emit deleted:true on delete (needs collector incremental-delete support)
   # forwardPoolSize: 64          # bound concurrent event-forward goroutines
   # relayHandlerPoolSize: 32     # bound concurrent inbound WS handler goroutines
   tolerations: []
@@ -212,13 +212,14 @@ nodeAgent:
   env:
     - name: SENSITIVE_HEADERS
       value: "Authorization,Proxy-Authorization,Cookie,Set-Cookie,X-Auth-Token,X-CSRF-Token,X-Session-ID,X-JWT-Token,X-Api-Key,X-Api-Token,X-Access-Token,X-Secret-Token,X-Refresh-Token,X-User-Token,X-Firebase-Auth,X-Google-Auth,X-Authorization,X-Wsse,X-WebService-Token,Authentication,Proxy-Authentication,X-Authentication-Token,X-Device-ID,X-Device-Token,X-Device-Key"
-# OpenCost runs per-cluster in the agent by default. To move a cluster to the
-# central server-side OpenCost instead, set `--set opencost.enabled=false`: the
-# agent then ships no in-cluster OpenCost AND the runner stops discovering/polling
-# cost (see OPENCOST_ENABLED), so the server detects cost is off and computes this
-# cluster's allocations centrally (reaching its Prometheus via the relay).
+# OpenCost is disabled by default: cost is computed centrally on the server side.
+# With opencost.enabled=false the agent ships no in-cluster OpenCost AND the runner
+# stops discovering/polling cost (see OPENCOST_ENABLED), so the server detects cost
+# is off and computes this cluster's allocations centrally (reaching its Prometheus
+# via the relay). To run OpenCost per-cluster in the agent, set
+# `--set opencost.enabled=true`.
 opencost:
-  enabled: true
+  enabled: false
   nameOverride: ""
   fullnameOverride: ""
   opencost:

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -61,7 +61,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-06-15T10-47-06_f694c523c6ce9a8c5d2fc3c923866e6bbed0b0c8
+    tag: 2026-06-16T09-26-56_9f3d1d6ddfda812859fcf8675ef0041f12c5689b
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.
@@ -102,10 +102,10 @@ runner:
   # (snapshotBatching, incrementalBatchSize > 1, emitTombstones) require matching
   # collector support, which has shipped, so they are enabled by default.
   scaling:
-    snapshotBatching: true       # batch the full-load snapshot (needs collector batch reassembly)
-    batchSize: 1000              # items per snapshot batch when snapshotBatching is on
-    incrementalBatchSize: 100    # coalesce N informer events per incremental POST (>1 needs collector to iterate data)
-    emitTombstones: true         # emit deleted:true on delete (needs collector incremental-delete support)
+    snapshotBatching: true # batch the full-load snapshot (needs collector batch reassembly)
+    batchSize: 1000 # items per snapshot batch when snapshotBatching is on
+    incrementalBatchSize: 100 # coalesce N informer events per incremental POST (>1 needs collector to iterate data)
+    emitTombstones: true # emit deleted:true on delete (needs collector incremental-delete support)
   # forwardPoolSize: 64          # bound concurrent event-forward goroutines
   # relayHandlerPoolSize: 32     # bound concurrent inbound WS handler goroutines
   tolerations: []


### PR DESCRIPTION
## What

- **Discovery batching on by default.** The wire-changing `runner.scaling` knobs now have collector support, so they ship enabled: `snapshotBatching=true`, `batchSize=1000`, `incrementalBatchSize=100`, `emitTombstones=true`.
- **In-cluster OpenCost off by default** (`opencost.enabled: false`). Cost is computed centrally on the server side; the agent ships no in-cluster OpenCost and the runner stops discovering/polling cost (`OPENCOST_ENABLED`). Set `--set opencost.enabled=true` to run OpenCost per-cluster in the agent.
- Chart version bumped `0.1.2 -> 0.1.3`.

## Why batchSize=1000

A gzipped 1000-item batch is ~150–300 KB on the wire — safe under the nginx 1m ingress default and well below the collector's 100 MB per-message RabbitMQ warning. Going above ~2000 would require confirming the collector ingress sets `proxy-body-size` (the SaaS prod overlay isn't in this repo), so the conservative default is kept.

## Verification

- `helm lint` passes
- `helm template` renders `DISCOVERY_SNAPSHOT_BATCHING=true`, `DISCOVERY_BATCH_SIZE=1000`, `DISCOVERY_INCREMENTAL_BATCH_SIZE=100`, `DISCOVERY_EMIT_TOMBSTONES=true`, and `OPENCOST_ENABLED="false"` with no in-cluster OpenCost deployment