### PR TITLE
fix(alerts): forward alerts with no resolvable k8s subject

### DIFF
--- a/runner/pkg/alerts/finding.go
+++ b/runner/pkg/alerts/finding.go
@@ -320,10 +320,14 @@ func (b *Builder) alertToFinding(a alertManagerAlert) (FindingEnvelope, error) {
 	if subjectName == "" {
 		// No kubernetes object resolvable from the alert labels (cluster-
 		// level / control-plane / custom application alerts like Watchdog,
-		// KubeSchedulerDown, HighP95Latency). Mirror robusta's behaviour:
-		// don't drop — emit the Finding with a placeholder subject so the
-		// alert still surfaces. subjectType stays empty (TYPE_NONE).
-		subjectName = "Unresolved"
+		// KubeSchedulerDown, HighP95Latency). Don't drop — fall back to the
+		// alertname as the subject so the alert still surfaces and each alert
+		// type keeps a distinct service_key in the UI (a static placeholder
+		// would group unrelated alerts together). subjectType stays empty.
+		subjectName = pickLabel(a.Labels, "alertname")
+		if subjectName == "" {
+			subjectName = "UnnamedAlert"
+		}
 	}
 	subjectNamespace := pickLabel(a.Labels, "namespace", "exported_namespace")
 	subjectNode := pickLabel(a.Labels, "node", "instance")

--- a/runner/pkg/alerts/finding.go
+++ b/runner/pkg/alerts/finding.go
@@ -213,9 +213,11 @@ func (m MatchedTrigger) Description() string {
 // one envelope per alert so the existing UI dedupes / aggregates per
 // alertname the same way it does today.
 //
-// Returns (envelopes, dropped_count). dropped_count is the number of
-// alerts in the batch that lacked a resolvable subject_name; those are
-// silently skipped.
+// Returns (envelopes, dropped_count). Alerts with no resolvable
+// kubernetes subject are NOT dropped — they get a placeholder subject
+// (see alertToFinding) so they still surface, matching robusta. So
+// dropped_count only counts alerts that failed to build (e.g. the raw
+// alert could not be marshalled); those are skipped.
 func (b *Builder) FromAlertManager(rawWebhook []byte) ([]FindingEnvelope, int, error) {
 	var webhook struct {
 		Alerts []alertManagerAlert `json:"alerts"`
@@ -316,7 +318,12 @@ func (b *Builder) FromKubewatchEvent(rawData []byte) (*FindingEnvelope, error) {
 func (b *Builder) alertToFinding(a alertManagerAlert) (FindingEnvelope, error) {
 	subjectName, subjectType := alertSubject(a.Labels)
 	if subjectName == "" {
-		return FindingEnvelope{}, errors.New("alertmanager: no subject_name resolvable from labels")
+		// No kubernetes object resolvable from the alert labels (cluster-
+		// level / control-plane / custom application alerts like Watchdog,
+		// KubeSchedulerDown, HighP95Latency). Mirror robusta's behaviour:
+		// don't drop — emit the Finding with a placeholder subject so the
+		// alert still surfaces. subjectType stays empty (TYPE_NONE).
+		subjectName = "Unresolved"
 	}
 	subjectNamespace := pickLabel(a.Labels, "namespace", "exported_namespace")
 	subjectNode := pickLabel(a.Labels, "node", "instance")

--- a/runner/pkg/alerts/finding_test.go
+++ b/runner/pkg/alerts/finding_test.go
@@ -53,9 +53,11 @@ func TestBuilder_Alert_SubjectFallbackOrder(t *testing.T) {
 	}
 }
 
-func TestBuilder_Alert_DropsAlertsMissingSubject(t *testing.T) {
+func TestBuilder_Alert_MissingSubjectGetsPlaceholder(t *testing.T) {
 	b := &Builder{AccountID: "acc", Cluster: "c"}
 	// 3 alerts: first has pod, second has no subject label, third has node.
+	// Subject-less alerts must NOT be dropped (matches robusta) — they get
+	// a placeholder subject so they still surface.
 	raw := []byte(`{"alerts":[
 		{"labels":{"alertname":"A","pod":"p"}},
 		{"labels":{"alertname":"B","severity":"critical"}},
@@ -65,11 +67,18 @@ func TestBuilder_Alert_DropsAlertsMissingSubject(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(out) != 2 {
-		t.Errorf("envelopes = %d; want 2 (middle alert has no subject)", len(out))
+	if len(out) != 3 {
+		t.Fatalf("envelopes = %d; want 3 (subject-less alert is kept)", len(out))
 	}
-	if dropped != 1 {
-		t.Errorf("dropped = %d; want 1", dropped)
+	if dropped != 0 {
+		t.Errorf("dropped = %d; want 0", dropped)
+	}
+	// middle alert: placeholder name, empty (TYPE_NONE) subject type.
+	if got := out[1].Finding.SubjectName; got != "Unresolved" {
+		t.Errorf("subject_name = %q; want %q", got, "Unresolved")
+	}
+	if got := out[1].Finding.SubjectType; got != "" {
+		t.Errorf("subject_type = %q; want empty", got)
 	}
 }
 

--- a/runner/pkg/alerts/finding_test.go
+++ b/runner/pkg/alerts/finding_test.go
@@ -73,9 +73,9 @@ func TestBuilder_Alert_MissingSubjectGetsPlaceholder(t *testing.T) {
 	if dropped != 0 {
 		t.Errorf("dropped = %d; want 0", dropped)
 	}
-	// middle alert: placeholder name, empty (TYPE_NONE) subject type.
-	if got := out[1].Finding.SubjectName; got != "Unresolved" {
-		t.Errorf("subject_name = %q; want %q", got, "Unresolved")
+	// middle alert: alertname fallback, empty (TYPE_NONE) subject type.
+	if got := out[1].Finding.SubjectName; got != "B" {
+		t.Errorf("subject_name = %q; want %q", got, "B")
 	}
 	if got := out[1].Finding.SubjectType; got != "" {
 		t.Errorf("subject_type = %q; want empty", got)

--- a/runner/pkg/alerts/server.go
+++ b/runner/pkg/alerts/server.go
@@ -149,14 +149,14 @@ func (f *Forwarder) handleAlert(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusAccepted)
 
 	f.spawnForward("alertmanager", func() {
-		envelopes, droppedSubjects, err := f.builder.FromAlertManager(body)
+		envelopes, dropped, err := f.builder.FromAlertManager(body)
 		if err != nil {
 			f.recordDrop("alertmanager", err)
 			return
 		}
-		if droppedSubjects > 0 {
-			f.Logger.Info("alertmanager: dropped alerts with no resolvable subject",
-				"count", droppedSubjects)
+		if dropped > 0 {
+			f.Logger.Warn("alertmanager: dropped alerts that failed to build",
+				"count", dropped)
 		}
 		for i := range envelopes {
 			if err := f.forward(context.Background(), &envelopes[i]); err != nil {

--- a/runner/pkg/alerts/server_test.go
+++ b/runner/pkg/alerts/server_test.go
@@ -119,9 +119,10 @@ func TestForwarder_AlertHappyPath(t *testing.T) {
 // application alerts) must still be forwarded, with a placeholder subject,
 // matching robusta's behaviour. They are NOT dropped.
 func TestForwarder_AlertWithoutSubjectIsForwarded(t *testing.T) {
-	var hits int
+	got := make(chan []byte, 1)
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		hits++
+		body, _ := io.ReadAll(r.Body)
+		got <- body
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer backend.Close()
@@ -137,9 +138,18 @@ func TestForwarder_AlertWithoutSubjectIsForwarded(t *testing.T) {
 		t.Fatal(err)
 	}
 	resp.Body.Close()
-	time.Sleep(200 * time.Millisecond)
-	if hits != 1 {
-		t.Errorf("backend received %d forwards; want 1 (subject-less alert is forwarded)", hits)
+
+	select {
+	case body := <-got:
+		var env FindingEnvelope
+		if err := json.Unmarshal(body, &env); err != nil {
+			t.Fatalf("forwarded body is not a FindingEnvelope: %v\n%s", err, body)
+		}
+		if env.Finding.SubjectName != "GenericFire" {
+			t.Errorf("subject_name = %q; want alertname fallback %q", env.Finding.SubjectName, "GenericFire")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("backend never received subject-less alert (it must be forwarded, not dropped)")
 	}
 }
 

--- a/runner/pkg/alerts/server_test.go
+++ b/runner/pkg/alerts/server_test.go
@@ -114,12 +114,11 @@ func TestForwarder_AlertHappyPath(t *testing.T) {
 	}
 }
 
-// TestForwarder_AlertWithoutSubjectIsDropped — alerts that don't carry a
-// pod/deployment/node/etc. label can't produce a Finding the consumer
-// will accept hard-drops on missing
-// subject_name). The forwarder counts it as dropped instead of letting
-// the consumer silently swallow it.
-func TestForwarder_AlertWithoutSubjectIsDropped(t *testing.T) {
+// TestForwarder_AlertWithoutSubjectIsForwarded — alerts that don't carry a
+// pod/deployment/node/etc. label (cluster-level / control-plane / custom
+// application alerts) must still be forwarded, with a placeholder subject,
+// matching robusta's behaviour. They are NOT dropped.
+func TestForwarder_AlertWithoutSubjectIsForwarded(t *testing.T) {
 	var hits int
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		hits++
@@ -139,8 +138,8 @@ func TestForwarder_AlertWithoutSubjectIsDropped(t *testing.T) {
 	}
 	resp.Body.Close()
 	time.Sleep(200 * time.Millisecond)
-	if hits != 0 {
-		t.Errorf("backend received %d forwards; want 0 (alert with no subject must be dropped)", hits)
+	if hits != 1 {
+		t.Errorf("backend received %d forwards; want 1 (subject-less alert is forwarded)", hits)
 	}
 }
 


### PR DESCRIPTION
## Problem

The agent runner's AlertManager webhook handler (`/api/alerts`) dropped any alert whose labels did not resolve to a Kubernetes object — i.e. none of `deployment / statefulset / daemonset / job / hpa / persistentvolumeclaim / workload / node / pod`.

Cluster-level, control-plane, and custom application alerts carry none of those labels, so they were silently skipped and never surfaced as Findings. Observed in the cluster being dropped on every AlertManager fan-out:

- `Watchdog`
- `KubeControllerManagerDown`, `KubeSchedulerDown`
- `PostgreSQLCacheHitRatio`, `HighP95Latency`, `ApplicationAPIFailures`

Every agent runner logged `INFO alertmanager: dropped alerts with no resolvable subject count=1` on a loop.

## Change

- `alertToFinding`: instead of returning an error (→ drop) when no subject resolves, fall back to the alert's `alertname` as the subject name (empty subject type). The alert is forwarded so it surfaces, and each alert type keeps a distinct `service_key` so unrelated cluster-level alerts don't group together in the UI. Namespace still comes from the alert's `namespace` label.
- The `dropped` counter now only counts genuine build failures (e.g. an alert that can't be marshalled). Its log line was reworded from `INFO ... no resolvable subject` to `WARN alertmanager: dropped alerts that failed to build`.
- Updated the two unit tests that asserted the old skip behavior.

## Note

This relies on the collector consumer accepting a Finding with an empty `subject_type`. Worth confirming there's no non-null/whitelist validation on that field downstream.