### PR TITLE
feat(scanners): support node-pinned init-container Jobs for image rootfs scan

### DIFF
--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -61,7 +61,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-06-16T09-26-56_9f3d1d6ddfda812859fcf8675ef0041f12c5689b
+    tag: 2026-06-18T08-03-27_f048f62d0348572793afa98b8a9b1cc383115071
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/runner/pkg/scanners/jobspec.go
+++ b/runner/pkg/scanners/jobspec.go
@@ -24,8 +24,31 @@ type JobSpec struct {
 	HostPID     bool `json:"host_pid,omitempty"`     // pod.spec.hostPID
 	HostNetwork bool `json:"host_network,omitempty"` // pod.spec.hostNetwork
 
-	Volumes      []corev1.Volume      `json:"volumes,omitempty"`       // for kube-bench /etc, /var/lib/etcd hostPath mounts
-	VolumeMounts []corev1.VolumeMount `json:"volume_mounts,omitempty"` // matching mounts inside the container
+	// NodeName pins the Job's pod to a specific node (pod.spec.nodeName), bypassing
+	// the scheduler. The image_scanner uses this to land the scan on the node where
+	// the target image is already pulled, so a `trivy fs` rootfs scan can reuse the
+	// node-local image (imagePullPolicy=IfNotPresent) instead of pulling it from the
+	// registry — which is why image scans need no registry credentials.
+	NodeName string `json:"node_name,omitempty"`
+
+	// ImagePullPolicy overrides the main container's pull policy. Empty → the
+	// kubelet default (Always for :latest, IfNotPresent otherwise). image_scanner
+	// sets IfNotPresent so the node-local copy is reused.
+	ImagePullPolicy string `json:"image_pull_policy,omitempty"`
+
+	// RunAsUser sets the main container's securityContext.runAsUser. Pointer so an
+	// explicit 0 (root — needed for `trivy fs` to read every file in the scanned
+	// rootfs) is distinguishable from "unset". nil → image default.
+	RunAsUser *int64 `json:"run_as_user,omitempty"`
+
+	// InitContainers run before the main container. image_scanner uses one to copy
+	// the trivy binary from the scanner image into a shared emptyDir, so the main
+	// container (the target image itself) can run `trivy fs /` against its own
+	// rootfs without the target image needing trivy installed.
+	InitContainers []corev1.Container `json:"init_containers,omitempty"`
+
+	Volumes      []corev1.Volume      `json:"volumes,omitempty"`       // for kube-bench /etc, /var/lib/etcd hostPath mounts; image_scanner's shared emptyDir
+	VolumeMounts []corev1.VolumeMount `json:"volume_mounts,omitempty"` // matching mounts inside the main container
 
 	// TimeoutHintSeconds is the api-server orchestrator's expected upper bound
 	// for this Job. Agent ignores it — the api-server polls and decides when to

--- a/runner/pkg/scanners/scanners.go
+++ b/runner/pkg/scanners/scanners.go
@@ -103,8 +103,20 @@ func (r *Runner) BuildJob(spec JobSpec, jobName, jobUUID string) *batchv1.Job {
 		Env:          envs,
 		VolumeMounts: spec.VolumeMounts,
 	}
-	if spec.Privileged {
-		container.SecurityContext = &corev1.SecurityContext{Privileged: ptr.To(true)}
+	if spec.ImagePullPolicy != "" {
+		container.ImagePullPolicy = corev1.PullPolicy(spec.ImagePullPolicy)
+	}
+	// SecurityContext is built only when the server asks for something — privileged
+	// (kube-bench) and/or a specific runAsUser (image_scanner runs as root so
+	// `trivy fs` can read the whole rootfs).
+	if spec.Privileged || spec.RunAsUser != nil {
+		container.SecurityContext = &corev1.SecurityContext{}
+		if spec.Privileged {
+			container.SecurityContext.Privileged = ptr.To(true)
+		}
+		if spec.RunAsUser != nil {
+			container.SecurityContext.RunAsUser = spec.RunAsUser
+		}
 	}
 
 	saName := spec.ServiceAccount
@@ -114,9 +126,11 @@ func (r *Runner) BuildJob(spec JobSpec, jobName, jobUUID string) *batchv1.Job {
 
 	podSpec := corev1.PodSpec{
 		RestartPolicy:      corev1.RestartPolicyNever,
+		InitContainers:     spec.InitContainers,
 		Containers:         []corev1.Container{container},
 		HostPID:            spec.HostPID,
 		HostNetwork:        spec.HostNetwork,
+		NodeName:           spec.NodeName,
 		ServiceAccountName: saName,
 		Volumes:            spec.Volumes,
 	}

--- a/runner/pkg/scanners/scanners_test.go
+++ b/runner/pkg/scanners/scanners_test.go
@@ -14,6 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/ptr"
 )
 
 // ---------- Runner construction & BuildJob hygiene ----------
@@ -130,6 +131,50 @@ func TestBuildJob_VolumesAndMounts(t *testing.T) {
 	c := job.Spec.Template.Spec.Containers[0]
 	if len(c.VolumeMounts) != 1 || c.VolumeMounts[0].MountPath != "/etc" {
 		t.Errorf("volume mounts lost: %v", c.VolumeMounts)
+	}
+}
+
+func TestBuildJob_ImageScanFsShape(t *testing.T) {
+	// image_scanner runs a rootfs scan: pinned to a node, target image as the
+	// main container with IfNotPresent + runAsUser=0, and an init container that
+	// stages the trivy binary into a shared volume. Verify all of it round-trips.
+	r := NewRunner(fake.NewClientset(), "ns", "scanner-sa")
+	job := r.BuildJob(JobSpec{
+		NamePrefix:      "trivy-image-scan",
+		Image:           "registry.private.example.com/app:v1",
+		Command:         []string{"sh", "-c", "/var/trivy-operator/trivy fs --format json /"},
+		NodeName:        "node-7",
+		ImagePullPolicy: "IfNotPresent",
+		RunAsUser:       ptr.To(int64(0)),
+		InitContainers: []corev1.Container{
+			{
+				Name:    "trivy-get-binary",
+				Image:   "ghcr.io/nudgebee/trivy:0.58.0",
+				Command: []string{"cp", "/usr/local/bin/trivy", "/var/trivy-operator/trivy"},
+			},
+		},
+	}, "trivy-image-scan-1", "uuid-img")
+
+	ps := job.Spec.Template.Spec
+	if ps.NodeName != "node-7" {
+		t.Errorf("NodeName = %q; want node-7 (image scan must pin to the node)", ps.NodeName)
+	}
+	if len(ps.InitContainers) != 1 || ps.InitContainers[0].Name != "trivy-get-binary" {
+		t.Fatalf("init container lost: %v", ps.InitContainers)
+	}
+	c := ps.Containers[0]
+	if c.Image != "registry.private.example.com/app:v1" {
+		t.Errorf("main container image = %q; want the target image itself", c.Image)
+	}
+	if c.ImagePullPolicy != corev1.PullIfNotPresent {
+		t.Errorf("ImagePullPolicy = %q; want IfNotPresent (reuse node-local image)", c.ImagePullPolicy)
+	}
+	if c.SecurityContext == nil || c.SecurityContext.RunAsUser == nil || *c.SecurityContext.RunAsUser != 0 {
+		t.Errorf("RunAsUser not honored: %+v", c.SecurityContext)
+	}
+	// Privileged must stay unset when only RunAsUser was requested.
+	if c.SecurityContext.Privileged != nil {
+		t.Errorf("Privileged should be nil when not requested: %+v", c.SecurityContext.Privileged)
 	}
 }
 


### PR DESCRIPTION
## Summary

Generalizes the scanner `JobSpec` so api-server can orchestrate a **filesystem (rootfs) image scan** instead of a registry pull. This is the agent-side half of restoring image-vulnerability scanning after the legacy-agent → Go-agent migration.

**Problem:** the api-server `image_scanner` currently runs `trivy image <ref>`, which pulls the image from the registry as a client and so needs registry credentials. Private-registry images (e.g. `registry.*.nudgebee.*`) have no creds in the scan Job, so the Job fails with `Job has reached the specified backoff limit` and no scan data is produced.

**Fix:** scan the image's **already-pulled rootfs on the node** (the approach the legacy agent used), which needs zero registry credentials:
- pin the scan Job to the node where a pod using the image runs (`NodeName`), so the image layers are already present;
- run the **target image itself** as the main container with `ImagePullPolicy: IfNotPresent`, so the kubelet reuses the node-local copy and never hits the registry;
- an **init container** copies the trivy binary into a shared `emptyDir`, and the main container overrides its entrypoint to run `trivy fs /` against its own root filesystem (the target image's real entrypoint never executes);
- `RunAsUser: 0` so trivy can read every file in the scanned rootfs.

Four new opaque `JobSpec` fields, applied in `BuildJob`: `NodeName`, `ImagePullPolicy`, `RunAsUser` (pointer so an explicit `0` survives JSON `omitempty`), `InitContainers`. The agent stays scanner-agnostic — no `image_scanner`-specific logic. Hygiene gates (namespace clamp, TTL, BackoffLimit, concurrency cap, log cap) are unchanged.

> Rollout: the matching api-server change must be deployed **after** this. An old agent ignores the new fields and would mis-run the fs-scan spec.

## Type of change

- [x] New feature (non-breaking)

## Chart version

- [x] No version bump needed (runner Go code only; no chart files changed)

## Test plan

- [x] `go build ./pkg/scanners/` + `go test ./pkg/scanners/` pass (new `TestBuildJob_ImageScanFsShape` covers node pinning, target-image-as-main-container, `IfNotPresent`, `RunAsUser=0`, init container round-trip; existing `Privileged`/volume tests still pass)
- [x] `gofmt` clean, `golangci-lint run ./pkg/scanners/...` → 0 issues
- [ ] Installed on a real/kind cluster and verified the change