### PR TITLE
feat(scanners): opt-in auto-copy of image-pull secrets for private-image scans

### DIFF
--- a/charts/nudgebee-agent/Chart.yaml
+++ b/charts/nudgebee-agent/Chart.yaml
@@ -29,7 +29,7 @@ annotations:
 # these are set to the right value by .github/workflows/release.yaml
 # we use 0.0.1 as a placeholder for the version` because Helm wont allow `0.0.0` and we want to be able to run
 # `helm install` on development checkouts without updating this file. the version doesn't matter in that case anyway
-version: 0.1.3
+version: 0.1.4
 appVersion: 0.1.3
 dependencies:
 - name: opencost

--- a/charts/nudgebee-agent/templates/_helpers.tpl
+++ b/charts/nudgebee-agent/templates/_helpers.tpl
@@ -91,6 +91,10 @@ Runner container template. Invoked with root context: include "nudgebee.runner.c
       value: {{ .Release.Namespace }}
     - name: SCANNER_SERVICE_ACCOUNT
       value: {{ include "nudgebee-agent.fullname" . }}-runner-service-account
+    {{- if .Values.runner.scannerAutoCopyPullSecrets }}
+    - name: SCANNER_AUTO_COPY_PULL_SECRETS
+      value: "true"
+    {{- end }}
     {{- with .Values.runner.scaling }}
     {{- if hasKey . "snapshotBatching" }}
     - name: DISCOVERY_SNAPSHOT_BATCHING

--- a/charts/nudgebee-agent/templates/runner-service-account.yaml
+++ b/charts/nudgebee-agent/templates/runner-service-account.yaml
@@ -565,3 +565,39 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "nudgebee-agent.fullname" . }}-runner-service-account
     namespace: {{ .Release.Namespace }}
+{{- if .Values.runner.scannerAutoCopyPullSecrets }}
+---
+# Auto-copy image-scan pull secrets (runner.scannerAutoCopyPullSecrets).
+# The base ClusterRole already grants secrets get/list/watch + create cluster-wide;
+# auto-copy additionally needs update/patch/delete to set the GC ownerReference
+# on, and clean up, the copies. Those destructive verbs are scoped to THIS
+# namespace only (where the copies live), not cluster-wide.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "nudgebee-agent.fullname" . }}-runner-scanner-pullsecrets
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - update
+      - patch
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "nudgebee-agent.fullname" . }}-runner-scanner-pullsecrets
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "nudgebee-agent.fullname" . }}-runner-scanner-pullsecrets
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "nudgebee-agent.fullname" . }}-runner-service-account
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -123,6 +123,15 @@ runner:
   # not here. Set to false for a strictly read-only deployment where every
   # mutate action — light-action or not — is unregistered at startup.
   mutateEnabled: true
+  # Let image scans pull private workload images by copying the scanned pod's
+  # imagePullSecrets into the scanner namespace for the duration of the scan
+  # Job. Off by default (least privilege): when off, the agent never reads or
+  # copies registry credentials, and private-image scans rely on whatever pull
+  # secrets the runner service account already carries
+  # (runnerServiceAccount.imagePullSecrets). Enabling this also grants the
+  # runner secret update/patch/delete in the release namespace (for GC of the
+  # copies) — see runner-service-account.yaml.
+  scannerAutoCopyPullSecrets: false
   customClusterRoleRules: []
   imagePullSecrets: []
   extraVolumes: []

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -61,7 +61,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-06-18T08-03-27_f048f62d0348572793afa98b8a9b1cc383115071
+    tag: 2026-06-19T07-29-09_0c10bd2144db2a151cd74f2b5997347cebd67745
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/runner/cmd/agent/main.go
+++ b/runner/cmd/agent/main.go
@@ -461,6 +461,7 @@ func run(ctx context.Context, logger *slog.Logger, cfg *config.Config) error {
 
 	if cfg.ScannersEnabled {
 		runner := scanners.NewRunner(typedKube, cfg.ScannerNamespace, cfg.ScannerServiceAccount)
+		runner.AutoCopyPullSecrets = cfg.ScannerAutoCopyPullSecrets
 		sh := scanners.Handlers(runner)
 		maps.Copy(handlers, sh)
 		// schedule_k8s_job / wait_for_k8s_job / get_k8s_job_logs are light-actions.

--- a/runner/pkg/config/config.go
+++ b/runner/pkg/config/config.go
@@ -135,6 +135,13 @@ type Config struct {
 	ScannerNamespace      string
 	ScannerServiceAccount string
 
+	// ScannerAutoCopyPullSecrets lets image scans pull private images by copying
+	// the scanned workload's imagePullSecrets into the scanner namespace. Off by
+	// default (least privilege): when off, the agent never reads/copies registry
+	// credentials and private-image scans rely on the scanner SA's own pull
+	// secrets. Paired with the chart's conditional secret-write RBAC.
+	ScannerAutoCopyPullSecrets bool
+
 	// PodExecEnabled (group D): pod_bash_enricher / pod_script_run_enricher.
 	// MUST be paired with RSA partial-keys auth in production.
 	PodExecEnabled bool
@@ -220,21 +227,22 @@ func FromEnv() (*Config, error) {
 		KubectlAllowWrite:         envBool("KUBECTL_ALLOW_WRITE", false),
 		PodExecEnabled:            envBool("PODEXEC_ENABLED", true),
 		// Off by default — these need extra config (RSA key, scanner SA, GCP ADC):
-		ScannersEnabled:       envBool("SCANNERS_ENABLED", false),
-		ScannerNamespace:      cmp(os.Getenv("SCANNER_NAMESPACE"), "nudgebee-agent"),
-		ScannerServiceAccount: os.Getenv("SCANNER_SERVICE_ACCOUNT"),
-		MutateEnabled:         envBool("MUTATE_ENABLED", false),
-		AlertManagerURL:       os.Getenv("ALERTMANAGER_URL"),
-		RSAPrivateKeyPath:     os.Getenv("RSA_PRIVATE_KEY_PATH"),
-		GCPEnabled:            envBool("GCP_ENABLED", false),
-		GCPProjectID:          os.Getenv("GCP_PROJECT_ID"),
-		ClickHouseEnabled:     envBool("CLICKHOUSE_ENABLED", true),
-		ClickHouseHost:        os.Getenv("CLICKHOUSE_HOST"),
-		ClickHousePort:        envInt("CLICKHOUSE_PORT", 8123),
-		ClickHouseUser:        os.Getenv("CLICKHOUSE_USER"),
-		ClickHousePassword:    os.Getenv("CLICKHOUSE_PASSWORD"),
-		ClickHouseDB:          cmp(os.Getenv("CLICKHOUSE_DB"), "default"),
-		ClickHouseSSL:         envBool("CLICKHOUSE_SSL_ENABLED", false),
+		ScannersEnabled:            envBool("SCANNERS_ENABLED", false),
+		ScannerNamespace:           cmp(os.Getenv("SCANNER_NAMESPACE"), "nudgebee-agent"),
+		ScannerServiceAccount:      os.Getenv("SCANNER_SERVICE_ACCOUNT"),
+		ScannerAutoCopyPullSecrets: envBool("SCANNER_AUTO_COPY_PULL_SECRETS", false),
+		MutateEnabled:              envBool("MUTATE_ENABLED", false),
+		AlertManagerURL:            os.Getenv("ALERTMANAGER_URL"),
+		RSAPrivateKeyPath:          os.Getenv("RSA_PRIVATE_KEY_PATH"),
+		GCPEnabled:                 envBool("GCP_ENABLED", false),
+		GCPProjectID:               os.Getenv("GCP_PROJECT_ID"),
+		ClickHouseEnabled:          envBool("CLICKHOUSE_ENABLED", true),
+		ClickHouseHost:             os.Getenv("CLICKHOUSE_HOST"),
+		ClickHousePort:             envInt("CLICKHOUSE_PORT", 8123),
+		ClickHouseUser:             os.Getenv("CLICKHOUSE_USER"),
+		ClickHousePassword:         os.Getenv("CLICKHOUSE_PASSWORD"),
+		ClickHouseDB:               cmp(os.Getenv("CLICKHOUSE_DB"), "default"),
+		ClickHouseSSL:              envBool("CLICKHOUSE_SSL_ENABLED", false),
 	}
 	if c.RelayURL == "" {
 		return nil, errors.New("WEBSOCKET_RELAY_ADDRESS not set")

--- a/runner/pkg/scanners/jobspec.go
+++ b/runner/pkg/scanners/jobspec.go
@@ -50,8 +50,26 @@ type JobSpec struct {
 	Volumes      []corev1.Volume      `json:"volumes,omitempty"`       // for kube-bench /etc, /var/lib/etcd hostPath mounts; image_scanner's shared emptyDir
 	VolumeMounts []corev1.VolumeMount `json:"volume_mounts,omitempty"` // matching mounts inside the main container
 
+	// ImagePullSecretsFrom names a pod whose effective image-pull secrets the
+	// agent should make available to this Job, so a scan can pull the workload's
+	// private image. The agent resolves the pod's pod-level + ServiceAccount-level
+	// imagePullSecrets, copies those Secrets into the scanner namespace, and
+	// attaches them to the Job's pod (GC'd with the Job via ownerReference).
+	//
+	// Honored ONLY when the agent runs with auto-copy enabled
+	// (SCANNER_AUTO_COPY_PULL_SECRETS); ignored otherwise, so a server can always
+	// send it without assuming the agent's posture.
+	ImagePullSecretsFrom *PodRef `json:"image_pull_secrets_from,omitempty"`
+
 	// TimeoutHintSeconds is the api-server orchestrator's expected upper bound
 	// for this Job. Agent ignores it — the api-server polls and decides when to
 	// give up. Carried through purely so audit logs can record server intent.
 	TimeoutHintSeconds int `json:"timeout_hint_seconds,omitempty"`
+}
+
+// PodRef identifies a pod by namespace+name. Used by ImagePullSecretsFrom to
+// point the agent at the workload whose pull credentials a scan needs.
+type PodRef struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
 }

--- a/runner/pkg/scanners/primitives.go
+++ b/runner/pkg/scanners/primitives.go
@@ -68,12 +68,12 @@ func (r *Runner) handleScheduleJob(ctx context.Context, params map[string]any) (
 	// Opt-in: make the target workload's image-pull credentials available so the
 	// Job can pull a private image. Gated by AutoCopyPullSecrets — when off, the
 	// field is ignored and no credentials are read or copied.
-	var copiedPullSecrets []string
+	var copiedPullSecrets []*corev1.Secret
 	if r.AutoCopyPullSecrets && spec.ImagePullSecretsFrom != nil {
 		copiedPullSecrets = r.resolveAndCopyPullSecrets(ctx, *spec.ImagePullSecretsFrom, jobName)
-		for _, name := range copiedPullSecrets {
+		for _, s := range copiedPullSecrets {
 			job.Spec.Template.Spec.ImagePullSecrets = append(
-				job.Spec.Template.Spec.ImagePullSecrets, corev1.LocalObjectReference{Name: name})
+				job.Spec.Template.Spec.ImagePullSecrets, corev1.LocalObjectReference{Name: s.Name})
 		}
 	}
 

--- a/runner/pkg/scanners/primitives.go
+++ b/runner/pkg/scanners/primitives.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 
 	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -64,10 +65,26 @@ func (r *Runner) handleScheduleJob(ctx context.Context, params map[string]any) (
 	jobUUID := uuid.NewString()
 	job := r.BuildJob(spec, jobName, jobUUID)
 
+	// Opt-in: make the target workload's image-pull credentials available so the
+	// Job can pull a private image. Gated by AutoCopyPullSecrets — when off, the
+	// field is ignored and no credentials are read or copied.
+	var copiedPullSecrets []string
+	if r.AutoCopyPullSecrets && spec.ImagePullSecretsFrom != nil {
+		copiedPullSecrets = r.resolveAndCopyPullSecrets(ctx, *spec.ImagePullSecretsFrom, jobName)
+		for _, name := range copiedPullSecrets {
+			job.Spec.Template.Spec.ImagePullSecrets = append(
+				job.Spec.Template.Spec.ImagePullSecrets, corev1.LocalObjectReference{Name: name})
+		}
+	}
+
 	created, err := r.Client.BatchV1().Jobs(r.Namespace).Create(ctx, job, metav1.CreateOptions{})
 	if err != nil {
+		// Don't leak the copied credentials if the Job never came up to own them.
+		r.deleteCopiedSecrets(ctx, copiedPullSecrets)
 		return nil, fmt.Errorf("schedule_k8s_job: create: %w", err)
 	}
+	// GC the copies with the Job (ownerReference; Job TTL cleans both up).
+	r.ownReferencedSecrets(ctx, copiedPullSecrets, created)
 
 	slog.Info("schedule_k8s_job: created",
 		"job_name", created.Name,

--- a/runner/pkg/scanners/pullsecrets.go
+++ b/runner/pkg/scanners/pullsecrets.go
@@ -1,0 +1,140 @@
+package scanners
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+// copiedPullSecretLabel marks Secrets the agent copied for an image scan, so a
+// stray one (e.g. left behind if the agent died between copy and ownerRef set)
+// is identifiable for a sweep.
+const copiedPullSecretLabel = "nudgebee.com/copied-pull-secret"
+
+// resolveAndCopyPullSecrets makes the image-pull credentials of pod `ref`
+// available in the scanner namespace so a scan Job can pull that workload's
+// (private) image. It returns the names of the copied Secrets, all living in
+// r.Namespace. Best-effort: a secret that can't be read/copied is logged and
+// skipped rather than failing the whole scan.
+//
+// The "effective" pull secrets of a pod are its pod-level imagePullSecrets plus
+// its ServiceAccount's imagePullSecrets — both are consulted by the kubelet, so
+// both are needed to reproduce the pull.
+func (r *Runner) resolveAndCopyPullSecrets(ctx context.Context, ref PodRef, jobName string) []string {
+	pod, err := r.Client.CoreV1().Pods(ref.Namespace).Get(ctx, ref.Name, metav1.GetOptions{})
+	if err != nil {
+		slog.Warn("image scan: cannot read target pod for pull secrets; scan may fail to pull a private image",
+			"namespace", ref.Namespace, "pod", ref.Name, "error", err)
+		return nil
+	}
+
+	// Gather the distinct secret names the kubelet would use for this pod.
+	names := map[string]struct{}{}
+	for _, s := range pod.Spec.ImagePullSecrets {
+		if s.Name != "" {
+			names[s.Name] = struct{}{}
+		}
+	}
+	saName := pod.Spec.ServiceAccountName
+	if saName == "" {
+		saName = "default"
+	}
+	if sa, err := r.Client.CoreV1().ServiceAccounts(ref.Namespace).Get(ctx, saName, metav1.GetOptions{}); err == nil {
+		for _, s := range sa.ImagePullSecrets {
+			if s.Name != "" {
+				names[s.Name] = struct{}{}
+			}
+		}
+	} else {
+		slog.Warn("image scan: cannot read target ServiceAccount for pull secrets",
+			"namespace", ref.Namespace, "service_account", saName, "error", err)
+	}
+
+	copied := make([]string, 0, len(names))
+	for name := range names {
+		src, err := r.Client.CoreV1().Secrets(ref.Namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			slog.Warn("image scan: cannot read pull secret", "namespace", ref.Namespace, "secret", name, "error", err)
+			continue
+		}
+		// Only registry credentials — never copy arbitrary secrets even if a pod
+		// happens to list one under imagePullSecrets.
+		if src.Type != corev1.SecretTypeDockerConfigJson && src.Type != corev1.SecretTypeDockercfg {
+			continue
+		}
+		dstName := copiedSecretName(jobName, ref.Namespace, name)
+		dst := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      dstName,
+				Namespace: r.Namespace,
+				Labels: map[string]string{
+					managedByLabel:        managedByValue,
+					copiedPullSecretLabel: "true",
+				},
+			},
+			Type: src.Type,
+			Data: src.Data,
+		}
+		_, err = r.Client.CoreV1().Secrets(r.Namespace).Create(ctx, dst, metav1.CreateOptions{})
+		if err != nil && !apierrors.IsAlreadyExists(err) {
+			slog.Warn("image scan: cannot copy pull secret into scanner namespace",
+				"secret", dstName, "scanner_namespace", r.Namespace, "error", err)
+			continue
+		}
+		copied = append(copied, dstName)
+	}
+	return copied
+}
+
+// ownReferencedSecrets points the copied Secrets at the Job so they are
+// garbage-collected when the Job's TTL deletes it. The Job UID is only known
+// after creation, hence this post-create step. Same namespace, so the
+// ownerReference is valid. Best-effort: a failed patch only risks a short-lived
+// orphan that the next sweep / namespace cleanup removes.
+func (r *Runner) ownReferencedSecrets(ctx context.Context, secretNames []string, job *batchv1.Job) {
+	owner := metav1.OwnerReference{
+		APIVersion:         "batch/v1",
+		Kind:               "Job",
+		Name:               job.Name,
+		UID:                job.UID,
+		BlockOwnerDeletion: ptr.To(true),
+	}
+	for _, name := range secretNames {
+		s, err := r.Client.CoreV1().Secrets(r.Namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			continue
+		}
+		s.OwnerReferences = append(s.OwnerReferences, owner)
+		if _, err := r.Client.CoreV1().Secrets(r.Namespace).Update(ctx, s, metav1.UpdateOptions{}); err != nil {
+			slog.Warn("image scan: cannot set ownerReference on copied pull secret (will rely on sweep)",
+				"secret", name, "error", err)
+		}
+	}
+}
+
+// deleteCopiedSecrets removes copied Secrets, used when Job creation fails so we
+// don't leak credentials. Best-effort.
+func (r *Runner) deleteCopiedSecrets(ctx context.Context, secretNames []string) {
+	for _, name := range secretNames {
+		if err := r.Client.CoreV1().Secrets(r.Namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			slog.Warn("image scan: cannot delete copied pull secret after job-create failure",
+				"secret", name, "error", err)
+		}
+	}
+}
+
+// copiedSecretName is deterministic per (job, source secret) and DNS-1123 safe.
+// The hash disambiguates two source secrets that share a name across namespaces
+// and keeps the result bounded regardless of source name length.
+func copiedSecretName(jobName, srcNamespace, srcName string) string {
+	sum := sha256.Sum256([]byte(srcNamespace + "/" + srcName))
+	return fmt.Sprintf("imgps-%s-%s", jobName, hex.EncodeToString(sum[:])[:8])
+}

--- a/runner/pkg/scanners/pullsecrets.go
+++ b/runner/pkg/scanners/pullsecrets.go
@@ -28,7 +28,7 @@ const copiedPullSecretLabel = "nudgebee.com/copied-pull-secret"
 // The "effective" pull secrets of a pod are its pod-level imagePullSecrets plus
 // its ServiceAccount's imagePullSecrets — both are consulted by the kubelet, so
 // both are needed to reproduce the pull.
-func (r *Runner) resolveAndCopyPullSecrets(ctx context.Context, ref PodRef, jobName string) []string {
+func (r *Runner) resolveAndCopyPullSecrets(ctx context.Context, ref PodRef, jobName string) []*corev1.Secret {
 	pod, err := r.Client.CoreV1().Pods(ref.Namespace).Get(ctx, ref.Name, metav1.GetOptions{})
 	if err != nil {
 		slog.Warn("image scan: cannot read target pod for pull secrets; scan may fail to pull a private image",
@@ -58,7 +58,7 @@ func (r *Runner) resolveAndCopyPullSecrets(ctx context.Context, ref PodRef, jobN
 			"namespace", ref.Namespace, "service_account", saName, "error", err)
 	}
 
-	copied := make([]string, 0, len(names))
+	copied := make([]*corev1.Secret, 0, len(names))
 	for name := range names {
 		src, err := r.Client.CoreV1().Secrets(ref.Namespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
@@ -83,13 +83,20 @@ func (r *Runner) resolveAndCopyPullSecrets(ctx context.Context, ref PodRef, jobN
 			Type: src.Type,
 			Data: src.Data,
 		}
-		_, err = r.Client.CoreV1().Secrets(r.Namespace).Create(ctx, dst, metav1.CreateOptions{})
-		if err != nil && !apierrors.IsAlreadyExists(err) {
-			slog.Warn("image scan: cannot copy pull secret into scanner namespace",
-				"secret", dstName, "scanner_namespace", r.Namespace, "error", err)
+		created, err := r.Client.CoreV1().Secrets(r.Namespace).Create(ctx, dst, metav1.CreateOptions{})
+		if err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				// Deterministic name → a prior attempt for this same Job. Reuse it.
+				if existing, getErr := r.Client.CoreV1().Secrets(r.Namespace).Get(ctx, dstName, metav1.GetOptions{}); getErr == nil {
+					copied = append(copied, existing)
+				}
+			} else {
+				slog.Warn("image scan: cannot copy pull secret into scanner namespace",
+					"secret", dstName, "scanner_namespace", r.Namespace, "error", err)
+			}
 			continue
 		}
-		copied = append(copied, dstName)
+		copied = append(copied, created)
 	}
 	return copied
 }
@@ -97,9 +104,10 @@ func (r *Runner) resolveAndCopyPullSecrets(ctx context.Context, ref PodRef, jobN
 // ownReferencedSecrets points the copied Secrets at the Job so they are
 // garbage-collected when the Job's TTL deletes it. The Job UID is only known
 // after creation, hence this post-create step. Same namespace, so the
-// ownerReference is valid. Best-effort: a failed patch only risks a short-lived
-// orphan that the next sweep / namespace cleanup removes.
-func (r *Runner) ownReferencedSecrets(ctx context.Context, secretNames []string, job *batchv1.Job) {
+// ownerReference is valid. Operates on the objects returned by the copy step
+// (their ResourceVersion is current), so no extra Get is needed. Best-effort: a
+// failed update only risks a short-lived orphan that namespace cleanup removes.
+func (r *Runner) ownReferencedSecrets(ctx context.Context, secrets []*corev1.Secret, job *batchv1.Job) {
 	owner := metav1.OwnerReference{
 		APIVersion:         "batch/v1",
 		Kind:               "Job",
@@ -107,26 +115,22 @@ func (r *Runner) ownReferencedSecrets(ctx context.Context, secretNames []string,
 		UID:                job.UID,
 		BlockOwnerDeletion: ptr.To(true),
 	}
-	for _, name := range secretNames {
-		s, err := r.Client.CoreV1().Secrets(r.Namespace).Get(ctx, name, metav1.GetOptions{})
-		if err != nil {
-			continue
-		}
+	for _, s := range secrets {
 		s.OwnerReferences = append(s.OwnerReferences, owner)
 		if _, err := r.Client.CoreV1().Secrets(r.Namespace).Update(ctx, s, metav1.UpdateOptions{}); err != nil {
 			slog.Warn("image scan: cannot set ownerReference on copied pull secret (will rely on sweep)",
-				"secret", name, "error", err)
+				"secret", s.Name, "error", err)
 		}
 	}
 }
 
 // deleteCopiedSecrets removes copied Secrets, used when Job creation fails so we
 // don't leak credentials. Best-effort.
-func (r *Runner) deleteCopiedSecrets(ctx context.Context, secretNames []string) {
-	for _, name := range secretNames {
-		if err := r.Client.CoreV1().Secrets(r.Namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+func (r *Runner) deleteCopiedSecrets(ctx context.Context, secrets []*corev1.Secret) {
+	for _, s := range secrets {
+		if err := r.Client.CoreV1().Secrets(r.Namespace).Delete(ctx, s.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 			slog.Warn("image scan: cannot delete copied pull secret after job-create failure",
-				"secret", name, "error", err)
+				"secret", s.Name, "error", err)
 		}
 	}
 }

--- a/runner/pkg/scanners/pullsecrets_test.go
+++ b/runner/pkg/scanners/pullsecrets_test.go
@@ -1,0 +1,105 @@
+package scanners
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// fixtures: a workload pod in "app" with a pod-level pull secret + a SA-level
+// pull secret, plus a non-registry secret that must be ignored.
+func pullSecretFixtures() *fake.Clientset {
+	return fake.NewClientset(
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "app"},
+			Spec: corev1.PodSpec{
+				ServiceAccountName: "web-sa",
+				ImagePullSecrets:   []corev1.LocalObjectReference{{Name: "reg-pod"}, {Name: "not-a-registry"}},
+			},
+		},
+		&corev1.ServiceAccount{
+			ObjectMeta:       metav1.ObjectMeta{Name: "web-sa", Namespace: "app"},
+			ImagePullSecrets: []corev1.LocalObjectReference{{Name: "reg-sa"}},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "reg-pod", Namespace: "app"},
+			Type:       corev1.SecretTypeDockerConfigJson,
+			Data:       map[string][]byte{".dockerconfigjson": []byte("{}")},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "reg-sa", Namespace: "app"},
+			Type:       corev1.SecretTypeDockercfg,
+			Data:       map[string][]byte{".dockercfg": []byte("{}")},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "not-a-registry", Namespace: "app"},
+			Type:       corev1.SecretTypeOpaque,
+			Data:       map[string][]byte{"token": []byte("x")},
+		},
+	)
+}
+
+func scheduleWithPullFrom(t *testing.T, r *Runner) {
+	t.Helper()
+	_, err := r.handleScheduleJob(context.Background(), map[string]any{
+		"spec": JobSpec{
+			NamePrefix:           "trivy-image-scan",
+			Image:                "registry.private.example.com/web:v1",
+			ImagePullSecretsFrom: &PodRef{Namespace: "app", Name: "web"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("handleScheduleJob: %v", err)
+	}
+}
+
+func TestAutoCopyPullSecrets_CopiesRegistrySecretsAndAttaches(t *testing.T) {
+	cs := pullSecretFixtures()
+	r := NewRunner(cs, "scan-ns", "scan-sa")
+	r.AutoCopyPullSecrets = true
+
+	scheduleWithPullFrom(t, r)
+
+	// Both registry secrets (pod-level + SA-level) copied into the scanner ns;
+	// the opaque one ignored.
+	copied, _ := cs.CoreV1().Secrets("scan-ns").List(context.Background(), metav1.ListOptions{})
+	if len(copied.Items) != 2 {
+		t.Fatalf("copied secrets = %d; want 2 (reg-pod + reg-sa, opaque skipped)", len(copied.Items))
+	}
+	for _, s := range copied.Items {
+		if s.Type != corev1.SecretTypeDockerConfigJson && s.Type != corev1.SecretTypeDockercfg {
+			t.Errorf("copied a non-registry secret: %s (%s)", s.Name, s.Type)
+		}
+		if len(s.OwnerReferences) != 1 || s.OwnerReferences[0].Kind != "Job" {
+			t.Errorf("copied secret %s missing Job ownerReference for GC: %+v", s.Name, s.OwnerReferences)
+		}
+	}
+
+	// The Job's pod references the copies.
+	jobs, _ := cs.BatchV1().Jobs("scan-ns").List(context.Background(), metav1.ListOptions{})
+	if len(jobs.Items) != 1 {
+		t.Fatalf("jobs = %d; want 1", len(jobs.Items))
+	}
+	if got := len(jobs.Items[0].Spec.Template.Spec.ImagePullSecrets); got != 2 {
+		t.Errorf("job imagePullSecrets = %d; want 2", got)
+	}
+}
+
+func TestAutoCopyPullSecrets_DisabledIgnoresField(t *testing.T) {
+	cs := pullSecretFixtures()
+	r := NewRunner(cs, "scan-ns", "scan-sa") // AutoCopyPullSecrets defaults false
+
+	scheduleWithPullFrom(t, r)
+
+	copied, _ := cs.CoreV1().Secrets("scan-ns").List(context.Background(), metav1.ListOptions{})
+	if len(copied.Items) != 0 {
+		t.Errorf("auto-copy off must read/copy no secrets; got %d", len(copied.Items))
+	}
+	jobs, _ := cs.BatchV1().Jobs("scan-ns").List(context.Background(), metav1.ListOptions{})
+	if len(jobs.Items) != 1 || len(jobs.Items[0].Spec.Template.Spec.ImagePullSecrets) != 0 {
+		t.Errorf("auto-copy off must leave the Job's imagePullSecrets empty")
+	}
+}

--- a/runner/pkg/scanners/scanners.go
+++ b/runner/pkg/scanners/scanners.go
@@ -58,6 +58,12 @@ type Runner struct {
 	DefaultSA         string // applied when JobSpec.ServiceAccount == ""
 	MaxConcurrentJobs int    // 0 → defaultMaxConcurrent
 	LogCapBytes       int    // 0 → defaultLogCapBytes
+
+	// AutoCopyPullSecrets gates the JobSpec.ImagePullSecretsFrom behavior. When
+	// false (default), the field is ignored and the agent never reads or copies
+	// registry credentials — scans rely on whatever pull secrets the scanner
+	// ServiceAccount already carries. Set from SCANNER_AUTO_COPY_PULL_SECRETS.
+	AutoCopyPullSecrets bool
 }
 
 // NewRunner returns a Runner with the canonical defaults.

--- a/runner/pkg/scanners/scanners_envtest_integration_test.go
+++ b/runner/pkg/scanners/scanners_envtest_integration_test.go
@@ -183,4 +183,86 @@ func TestPrimitives_RealAPIServer(t *testing.T) {
 			t.Errorf("failure_reason = %v", resp["failure_reason"])
 		}
 	})
+
+	t.Run("ScheduleJob_AutoCopyPullSecrets", func(t *testing.T) {
+		// Source workload in "default": a pod with a pod-level registry pull
+		// secret + a SA-level one, plus an opaque secret that must NOT be copied.
+		mkSecret := func(name string, typ corev1.SecretType, key string) {
+			if _, err := cs.CoreV1().Secrets("default").Create(ctx, &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+				Type:       typ,
+				Data:       map[string][]byte{key: []byte("{}")},
+			}, metav1.CreateOptions{}); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = cs.CoreV1().Secrets("default").Delete(context.Background(), name, metav1.DeleteOptions{}) })
+		}
+		mkSecret("ac-reg-pod", corev1.SecretTypeDockerConfigJson, ".dockerconfigjson")
+		mkSecret("ac-reg-sa", corev1.SecretTypeDockercfg, ".dockercfg")
+		mkSecret("ac-opaque", corev1.SecretTypeOpaque, "tok")
+		if _, err := cs.CoreV1().ServiceAccounts("default").Create(ctx, &corev1.ServiceAccount{
+			ObjectMeta:       metav1.ObjectMeta{Name: "ac-sa", Namespace: "default"},
+			ImagePullSecrets: []corev1.LocalObjectReference{{Name: "ac-reg-sa"}},
+		}, metav1.CreateOptions{}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := cs.CoreV1().Pods("default").Create(ctx, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "ac-pod", Namespace: "default"},
+			Spec: corev1.PodSpec{
+				ServiceAccountName: "ac-sa",
+				ImagePullSecrets:   []corev1.LocalObjectReference{{Name: "ac-reg-pod"}, {Name: "ac-opaque"}},
+				Containers:         []corev1.Container{{Name: "c", Image: "x:1"}},
+			},
+		}, metav1.CreateOptions{}); err != nil {
+			t.Fatal(err)
+		}
+
+		r2 := NewRunner(cs, "default", "")
+		r2.AutoCopyPullSecrets = true
+		out, err := r2.handleScheduleJob(ctx, map[string]any{
+			"spec": map[string]any{
+				"name_prefix":             "imgscan-ac",
+				"image":                   "registry.private.example.com/app:v1",
+				"image_pull_secrets_from": map[string]any{"namespace": "default", "name": "ac-pod"},
+			},
+		})
+		if err != nil {
+			t.Fatalf("schedule_k8s_job: %v", err)
+		}
+		jobName := out.(map[string]any)["job_name"].(string)
+		t.Cleanup(func() { _ = cs.BatchV1().Jobs("default").Delete(context.Background(), jobName, metav1.DeleteOptions{}) })
+
+		job, err := cs.BatchV1().Jobs("default").Get(ctx, jobName, metav1.GetOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Both registry secrets attached; the opaque one skipped.
+		if got := len(job.Spec.Template.Spec.ImagePullSecrets); got != 2 {
+			t.Fatalf("job imagePullSecrets = %d; want 2 (pod + SA registry secrets, opaque skipped)", got)
+		}
+		// Each copy exists in the scanner ns, is a registry secret, and is owned
+		// by the Job (so it GCs with the Job — verified against a real apiserver,
+		// which enforces ownerReference semantics a fake client doesn't).
+		for _, ref := range job.Spec.Template.Spec.ImagePullSecrets {
+			s, err := cs.CoreV1().Secrets("default").Get(ctx, ref.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("copied secret %s missing: %v", ref.Name, err)
+			}
+			t.Cleanup(func() {
+				_ = cs.CoreV1().Secrets("default").Delete(context.Background(), s.Name, metav1.DeleteOptions{})
+			})
+			if s.Type != corev1.SecretTypeDockerConfigJson && s.Type != corev1.SecretTypeDockercfg {
+				t.Errorf("copied a non-registry secret %s (%s)", s.Name, s.Type)
+			}
+			owned := false
+			for _, o := range s.OwnerReferences {
+				if o.Kind == "Job" && o.Name == jobName {
+					owned = true
+				}
+			}
+			if !owned {
+				t.Errorf("copied secret %s not owned by job %s (GC would leak it)", s.Name, jobName)
+			}
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Image scans of **private-registry** images fail on clusters that enforce per-pod image-pull credential verification (e.g. GKE): a scan Job can't reuse a node-cached private image without presenting the registry credential, so node-local reuse alone is **not** credential-free. The workload already running the image holds exactly the right credential.

This adds an **opt-in, default-off** path to source it:

- `JobSpec.ImagePullSecretsFrom{namespace,name}` points the agent at a pod running the image.
- When `SCANNER_AUTO_COPY_PULL_SECRETS=true`, the agent resolves that pod's **effective** pull secrets (pod-level + ServiceAccount-level `imagePullSecrets`), copies the `dockercfg`/`dockerconfigjson` Secrets into the scanner namespace, attaches them to the scan Job, and **GCs them with the Job** via `ownerReference`. Non-registry secrets are never copied.
- When **off** (default), the field is ignored — the agent reads/copies **no** credentials — so api-server can always send it regardless of agent posture.

## Why opt-in / default off

The base runner ClusterRole **already** grants `secrets: get/list/watch` + `create` cluster-wide, so auto-copy mostly *uses existing access*. The only **new** grant is `secrets: update/patch/delete` **scoped to the release namespace** (for GC), added by a `Role` gated on `runner.scannerAutoCopyPullSecrets`. A stock install carries **no** new secret access. Default-off keeps least privilege the out-of-box posture for a security product; enabling pulls in both the behavior and its namespaced RBAC together.

## Changes

- `JobSpec.ImagePullSecretsFrom` + `PodRef`; `Runner.AutoCopyPullSecrets`; `SCANNER_AUTO_COPY_PULL_SECRETS` config (default false).
- `pullsecrets.go`: resolve effective pull secrets, copy (registry-type only), `ownerReference` GC, cleanup-on-failure. Unit tests cover copy+attach+ownerRef and the disabled path.
- Chart: `runner.scannerAutoCopyPullSecrets` value, env wiring, conditional namespaced `Role`/`RoleBinding`, `Chart.yaml` 0.1.3 → 0.1.4.

## Type of change

- [x] New feature (non-breaking)

## Chart version

- [x] Bumped `version` 0.1.3 → 0.1.4 (new value + conditional RBAC)

## Test plan

- [x] `go build ./...`, `go test ./pkg/scanners/` pass (new `pullsecrets_test.go`: registry secrets copied + attached + ownerReferenced; opaque skipped; disabled path copies nothing)
- [x] `gofmt`/`golangci-lint` clean
- [x] `helm lint`; `helm template` renders the env + Role/RoleBinding **only** when `runner.scannerAutoCopyPullSecrets=true`, absent by default
- [ ] Installed on a cluster with auto-copy on + verified a private-image scan produces data

## Related

Companion api-server change: nudgebee/nudgebee-enterprise#32622 (threads the workload pod into the scan spec).
