### PR TITLE
feat(runner): authorize UI workload mutations + add delete/create_workload

### DIFF
--- a/charts/nudgebee-agent/templates/_helpers.tpl
+++ b/charts/nudgebee-agent/templates/_helpers.tpl
@@ -156,6 +156,14 @@ Runner container template. Invoked with root context: include "nudgebee.runner.c
     - name: RSA_PRIVATE_KEY_PATH
       value: /etc/nudgebee/auth/prv
     {{- end }}
+    {{- if .Values.runner.nudgebee.relay_signing_public_key }}
+    # Relay Ed25519 public key — the agent verifies relay-signed requests with
+    # it and authorizes UI-triggered workload mutations. A valid relay signature
+    # is required for mutations; reads always fall back to the light-action path,
+    # so this is purely additive.
+    - name: RELAY_SIGNING_PUBLIC_KEY
+      value: {{ .Values.runner.nudgebee.relay_signing_public_key | quote }}
+    {{- end }}
     {{- if or (index (default (dict) (index .Values "opentelemetry-collector")) "enabled") .Values.runner.clickhouse_enabled }}
     {{- $clickhouseSecret := .Values.runner.clickhouse_secret }}
     {{- if not $clickhouseSecret }}

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -61,7 +61,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-06-19T07-29-09_0c10bd2144db2a151cd74f2b5997347cebd67745
+    tag: 2026-06-20T09-33-11_75cc137fae195c9fc972e41d4537bda18bdc3776
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -188,6 +188,11 @@ runner:
   nudgebee:
     endpoint: https://collector.nudgebee.com
     auth_secret_key: ""
+    # Relay Ed25519 public key. Lets the agent verify relay-signed requests and
+    # authorize UI-triggered workload mutations (delete/create/replace/restart/
+    # scale). The UI install command populates this from the server's
+    # SIGNING_PUBLIC_KEY. Empty = relay signatures ignored (mutations stay 401).
+    relay_signing_public_key: ''
   serviceAccount:
     annotations: {}
 nodeAgent:

--- a/installation.sh
+++ b/installation.sh
@@ -16,6 +16,7 @@ values=""
 alert_manager_url=""
 prometheus_org_id=""
 relay_address=""
+relay_signing_public_key=""
 collector_endpoint=""
 image_registry=""
 disable_opencost=""
@@ -40,6 +41,7 @@ usage() {
   echo "  -m <alert_manager_url> Alert manager URL"
   echo "  -r <prometheus-org-id> Prometheus org id"
   echo "  -w <relay_address>    WebSocket relay address (self-hosted)"
+  echo "  -S <relay_signing_public_key> Relay Ed25519 public key (authorizes UI workload mutations)"
   echo "  -c <collector_endpoint> Collector endpoint URL (self-hosted)"
   echo "  -i <image_registry>   Image registry (air-gapped/on-prem)"
   echo "  -x <disable_opencost> Disable OpenCost (true/false)"
@@ -50,7 +52,7 @@ usage() {
   exit 1
 }
 
-while getopts ":a:k:o:p:s:n:z:h:e:d:f:m:r:w:c:i:x:t:g:" opt; do
+while getopts ":a:k:o:p:s:n:z:h:e:d:f:m:r:w:S:c:i:x:t:g:" opt; do
   case $opt in
     a)
       auth_key="$OPTARG"
@@ -87,6 +89,9 @@ while getopts ":a:k:o:p:s:n:z:h:e:d:f:m:r:w:c:i:x:t:g:" opt; do
       ;;
     w)
       relay_address="$OPTARG"
+      ;;
+    S)
+      relay_signing_public_key="$OPTARG"
       ;;
     c)
       collector_endpoint="$OPTARG"
@@ -304,6 +309,13 @@ if [ -n "$relay_address" ]; then
   relay_address_args=(--set "runner.relay_address=$relay_address")
 fi
 
+relay_signing_public_key_args=()
+if [ -n "$relay_signing_public_key" ]; then
+  # --set-string: the key may contain '=' (base64 padding) or spaces (ssh form),
+  # which plain --set would mis-parse.
+  relay_signing_public_key_args=(--set-string "runner.nudgebee.relay_signing_public_key=$relay_signing_public_key")
+fi
+
 collector_endpoint_args=()
 if [ -n "$collector_endpoint" ]; then
   collector_endpoint_args=(--set "runner.nudgebee.endpoint=$collector_endpoint")
@@ -341,6 +353,7 @@ helm_args+=(
   "${alert_manager_url_args[@]}"
   "${prometheus_org_id_args[@]}"
   "${relay_address_args[@]}"
+  "${relay_signing_public_key_args[@]}"
   "${collector_endpoint_args[@]}"
   "${image_registry_args[@]}"
   "${disable_opencost_args[@]}"

--- a/runner/.env.example
+++ b/runner/.env.example
@@ -49,6 +49,12 @@ NUDGEBEE_ENDPOINT=https://api.nudgebee.com
 # MUTATE_ENABLED=true
 # RSA_PRIVATE_KEY_PATH=/etc/nudgebee/agent.key
 
+# Relay signing public key(s) (Ed25519; comma/whitespace-separated for rotation).
+# When set, the agent verifies relay-signed requests — this is how UI-triggered
+# workload mutations (delete/create/replace/restart/scale) are authorized. The
+# value is the relay's SIGNING_PUBLIC_KEY. Unset = relay signatures ignored.
+# RELAY_SIGNING_PUBLIC_KEY=ssh-ed25519 AAAA...
+
 # SCANNERS_ENABLED=true
 # SCANNER_NAMESPACE=nudgebee
 # SCANNER_SERVICE_ACCOUNT=nudgebee-scanner

--- a/runner/cmd/agent/main.go
+++ b/runner/cmd/agent/main.go
@@ -54,6 +54,7 @@ import (
 	"github.com/nudgebee/nudgebee-agent/pkg/podrunner"
 	"github.com/nudgebee/nudgebee-agent/pkg/podshell"
 	"github.com/nudgebee/nudgebee-agent/pkg/relay"
+	"github.com/nudgebee/nudgebee-agent/pkg/relaysig"
 	"github.com/nudgebee/nudgebee-agent/pkg/rightsize"
 	"github.com/nudgebee/nudgebee-agent/pkg/scanners"
 	"github.com/nudgebee/nudgebee-agent/pkg/servicemap"
@@ -633,6 +634,14 @@ func run(ctx context.Context, logger *slog.Logger, cfg *config.Config) error {
 		validator.PrivateKey = priv
 		logger.Info("RSA partial-keys auth enabled", "key_path", cfg.RSAPrivateKeyPath)
 	}
+	// Relay-signature verification: when the relay's public key is provisioned,
+	// a valid relay signature authorizes any action (this is how UI mutations
+	// reach native k8s agents). Absent key = relay signatures ignored.
+	relayVerifier, err := relaysig.NewVerifier(cfg.RelaySigningPublicKey, logger)
+	if err != nil {
+		return fmt.Errorf("init relay signature verifier: %w", err)
+	}
+	validator.RelayVerifier = relayVerifier
 
 	// refresh_playbook hot-reloads the allowlist from the backend so we can
 	// add new actions to a running agent without a customer Helm upgrade.

--- a/runner/go.mod
+++ b/runner/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/prometheus/client_golang v1.23.2
 	github.com/testcontainers/testcontainers-go v0.42.0
+	golang.org/x/crypto v0.52.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.21.0
 	k8s.io/api v0.36.2
@@ -89,7 +90,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.41.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/term v0.43.0 // indirect

--- a/runner/pkg/auth/auth.go
+++ b/runner/pkg/auth/auth.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/nudgebee/nudgebee-agent/pkg/canonjson"
+	"github.com/nudgebee/nudgebee-agent/pkg/relaysig"
 )
 
 // LoadPrivateKey reads a PEM-encoded RSA private key from disk. Supports
@@ -66,6 +67,12 @@ type Request struct {
 	Signature    string // HMAC mode
 	PartialAuthA string // RSA partial keys mode (encrypted, base64)
 	PartialAuthB string // RSA partial keys mode (encrypted, base64)
+
+	// RelaySig + BodyRaw drive the relay-signature path. BodyRaw is the exact
+	// bytes of the wire `body` field (a json.RawMessage) — NOT a re-marshaled
+	// Body map — so it matches the bytes the relay signed.
+	RelaySig relaysig.Envelope
+	BodyRaw  []byte
 }
 
 // Validator holds the agent's auth state.
@@ -89,6 +96,13 @@ type Validator struct {
 	// lightActionsAtomic, when non-nil, takes precedence over LightActions.
 	// Set via SetLightActions.
 	lightActionsAtomic atomic.Pointer[map[string]struct{}]
+
+	// RelayVerifier validates an Ed25519 relay signature over the raw body.
+	// When set and Enabled(), a present+valid relay signature authorizes ANY
+	// action (bypassing the HMAC/partial/lightAction modes). Nil or disabled =
+	// the relay signature is ignored and the request falls through to the
+	// existing modes, so reads keep working on un-keyed agents.
+	RelayVerifier *relaysig.Verifier
 }
 
 // SetLightActions atomically replaces the light-action allowlist. Concurrent
@@ -117,9 +131,30 @@ func (v *Validator) LightActionsSet() map[string]struct{} {
 	return v.LightActions
 }
 
-// Validate returns nil if the request is authentic per any of the three modes.
-// Mirrors the backend's dispatch logic.
+// Validate returns nil if the request is authentic per any of the supported
+// modes. Mirrors the backend's dispatch logic.
+//
+// Relay-signature handling is a non-fatal pre-check: a VALID relay signature
+// (verifier configured + enabled) authorizes any action; anything else — no
+// signature, no key, or a signature that fails verification (bad sig, clock
+// skew, replay) — FALLS THROUGH to the existing modes rather than hard-failing.
+//
+// Falling through is deliberate and load-bearing: the relay signs every k8s
+// request (reads included), so a hard 401 on a failed signature would break
+// reads that work today via lightActions — e.g. on an upgraded-but-unkeyed
+// agent, or under clock skew. With fall-through, reads always survive via
+// lightActions and only mutations (which aren't light actions) effectively
+// require a valid relay signature. Falling through never grants extra access:
+// a forged/invalid mutation signature still hits the lightAction check and is
+// rejected.
 func (v *Validator) Validate(r *Request) error {
+	if r.RelaySig.Present() && v.RelayVerifier != nil && v.RelayVerifier.Enabled() {
+		if err := v.RelayVerifier.VerifyBody(r.BodyRaw, r.RelaySig); err == nil {
+			return nil // valid relay signature authorizes any action
+		}
+		// Verification failed — fall through to the existing modes (reads keep
+		// working via lightActions; mutations get rejected there).
+	}
 	switch {
 	case r.Signature != "":
 		return v.validateHMAC(r)

--- a/runner/pkg/auth/auth_relaysig_test.go
+++ b/runner/pkg/auth/auth_relaysig_test.go
@@ -1,0 +1,135 @@
+package auth
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/nudgebee/nudgebee-agent/pkg/relaysig"
+)
+
+// These tests pin the back-compat matrix for the relay-signature path: a valid
+// relay signature authorizes any action; an absent one falls through to the
+// existing modes; and a present-but-unverifiable one (no key) is IGNORED so
+// reads don't 401 on an upgraded-but-unkeyed agent.
+
+func relaysigKey(t *testing.T) (ed25519.PrivateKey, string) {
+	t.Helper()
+	seed := make([]byte, 32)
+	for i := range seed {
+		seed[i] = byte(i + 3)
+	}
+	priv := ed25519.NewKeyFromSeed(seed)
+	pub := priv.Public().(ed25519.PublicKey)
+	return priv, base64.StdEncoding.EncodeToString(pub)
+}
+
+func discardLogger() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+func signedRelayReq(priv ed25519.PrivateKey, bodyRaw []byte, actionName, nonce string) *Request {
+	sig := ed25519.Sign(priv, bodyRaw)
+	return &Request{
+		ActionName: actionName,
+		BodyRaw:    bodyRaw,
+		RelaySig: relaysig.Envelope{
+			Signature: base64.StdEncoding.EncodeToString(sig),
+			SignedAt:  time.Now().UTC().Format(time.RFC3339),
+			Nonce:     nonce,
+		},
+	}
+}
+
+// (a) valid relay sig authorizes a NON-lightAction.
+func TestValidate_RelaySig_AuthorizesMutation(t *testing.T) {
+	priv, pub := relaysigKey(t)
+	ver, err := relaysig.NewVerifier(pub, discardLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	v := &Validator{LightActions: map[string]struct{}{"get_resource": {}}, RelayVerifier: ver}
+
+	body := []byte(`{"account_id":"a","action_name":"delete_workload","action_params":{"kind":"deployment"}}`)
+	if err := v.Validate(signedRelayReq(priv, body, "delete_workload", "m1")); err != nil {
+		t.Fatalf("valid relay sig should authorize delete_workload: %v", err)
+	}
+}
+
+// (b) absent relay sig → mutation still rejected, read still allowed.
+func TestValidate_NoRelaySig_FallsThrough(t *testing.T) {
+	_, pub := relaysigKey(t)
+	ver, _ := relaysig.NewVerifier(pub, discardLogger())
+	v := &Validator{LightActions: map[string]struct{}{"get_resource": {}}, RelayVerifier: ver}
+
+	if err := v.Validate(&Request{ActionName: "get_resource"}); err != nil {
+		t.Errorf("read without relay sig should pass via lightActions: %v", err)
+	}
+	if err := v.Validate(&Request{ActionName: "delete_workload"}); err == nil {
+		t.Error("mutation without relay sig should be rejected")
+	}
+}
+
+// (c) relay sig present but verifier disabled (no key) → IGNORED, fall through.
+// Read still 200, mutation still 401 — crucially NOT a hard 401 on the read.
+func TestValidate_RelaySigPresent_VerifierDisabled_Ignored(t *testing.T) {
+	priv, _ := relaysigKey(t)
+	disabled, _ := relaysig.NewVerifier("", discardLogger()) // no key
+	v := &Validator{LightActions: map[string]struct{}{"get_resource": {}}, RelayVerifier: disabled}
+
+	readBody := []byte(`{"action_name":"get_resource"}`)
+	if err := v.Validate(signedRelayReq(priv, readBody, "get_resource", "c1")); err != nil {
+		t.Errorf("read with relay sig but no verifier key should still pass via lightActions: %v", err)
+	}
+	mutBody := []byte(`{"action_name":"delete_workload"}`)
+	if err := v.Validate(signedRelayReq(priv, mutBody, "delete_workload", "c2")); err == nil {
+		t.Error("mutation with unverifiable relay sig should fall through and be rejected")
+	}
+}
+
+// Same as (c) but RelayVerifier is nil entirely.
+func TestValidate_RelaySigPresent_NoVerifier_Ignored(t *testing.T) {
+	priv, _ := relaysigKey(t)
+	v := &Validator{LightActions: map[string]struct{}{"get_resource": {}}}
+	readBody := []byte(`{"action_name":"get_resource"}`)
+	if err := v.Validate(signedRelayReq(priv, readBody, "get_resource", "n1")); err != nil {
+		t.Errorf("read with relay sig and nil verifier should pass via lightActions: %v", err)
+	}
+}
+
+// (d) relay sig present + verifier enabled but signature invalid → the MUTATION
+// falls through to the lightAction check and is rejected there (delete_workload
+// isn't a light action). Still a 401, just via fall-through rather than a hard
+// signature failure.
+func TestValidate_RelaySig_InvalidMutationRejected(t *testing.T) {
+	priv, pub := relaysigKey(t)
+	ver, _ := relaysig.NewVerifier(pub, discardLogger())
+	v := &Validator{LightActions: map[string]struct{}{"get_resource": {}}, RelayVerifier: ver}
+
+	body := []byte(`{"action_name":"delete_workload"}`)
+	req := signedRelayReq(priv, body, "delete_workload", "d1")
+	// Corrupt the body after signing → signature no longer matches.
+	req.BodyRaw = []byte(`{"action_name":"delete_workload","action_params":{"evil":true}}`)
+	if err := v.Validate(req); err == nil {
+		t.Fatal("invalid relay sig on a mutation should still be rejected")
+	}
+}
+
+// (e) THE load-bearing safety property: an invalid/failed relay signature on a
+// READ must FALL THROUGH to lightActions and succeed — never a hard 401. This
+// is what makes signing every k8s request (reads included) safe under clock
+// skew / verify bugs once an agent is keyed.
+func TestValidate_RelaySig_InvalidRead_FallsThroughToLightAction(t *testing.T) {
+	priv, pub := relaysigKey(t)
+	ver, _ := relaysig.NewVerifier(pub, discardLogger())
+	v := &Validator{LightActions: map[string]struct{}{"get_resource": {}}, RelayVerifier: ver}
+
+	body := []byte(`{"action_name":"get_resource"}`)
+	req := signedRelayReq(priv, body, "get_resource", "e1")
+	// Corrupt the body after signing → signature fails verification.
+	req.BodyRaw = []byte(`{"action_name":"get_resource","action_params":{"x":1}}`)
+	if err := v.Validate(req); err != nil {
+		t.Fatalf("read with a failed relay sig must fall through to lightActions, got: %v", err)
+	}
+}

--- a/runner/pkg/config/config.go
+++ b/runner/pkg/config/config.go
@@ -156,6 +156,13 @@ type Config struct {
 	// fall back to HMAC signature only.
 	RSAPrivateKeyPath string
 
+	// RelaySigningPublicKey is the relay-server's global Ed25519 PUBLIC key(s)
+	// (comma/whitespace-separated for rotation). When set, the agent verifies
+	// relay-signed requests and authorizes any action carrying a valid relay
+	// signature — this is how UI-triggered mutations are authorized on native
+	// k8s agents. Unset = relay signatures ignored (back-compat).
+	RelaySigningPublicKey string
+
 	// ClickHouse — backs the `query_data` action. The chart sets these from
 	// the in-cluster ClickHouse Service the agent ships alongside.
 	ClickHouseEnabled  bool
@@ -172,6 +179,7 @@ type Config struct {
 func FromEnv() (*Config, error) {
 	c := &Config{
 		AuthSecretKey:         os.Getenv("NUDGEBEE_AUTH_SECRET_KEY"),
+		RelaySigningPublicKey: os.Getenv("RELAY_SIGNING_PUBLIC_KEY"),
 		RelayURL:              os.Getenv("WEBSOCKET_RELAY_ADDRESS"),
 		BackendEndpoint:       os.Getenv("NUDGEBEE_ENDPOINT"),
 		AccountID:             os.Getenv("ACCOUNT_ID"),

--- a/runner/pkg/dispatch/dispatch.go
+++ b/runner/pkg/dispatch/dispatch.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/nudgebee/nudgebee-agent/pkg/auth"
 	"github.com/nudgebee/nudgebee-agent/pkg/relay"
+	"github.com/nudgebee/nudgebee-agent/pkg/relaysig"
 )
 
 // Handler is one action implementation. It receives a request-scoped context
@@ -239,16 +240,28 @@ func (d *Dispatcher) Handle(ctx context.Context, msg []byte, send relay.SendFunc
 	// Parse the envelope as a generic map first so we can pass the body to the
 	// auth validator (which needs the raw map for canonical-JSON re-encoding).
 	var raw struct {
-		Body         map[string]any `json:"body"`
-		Signature    string         `json:"signature,omitempty"`
-		PartialAuthA string         `json:"partial_auth_a,omitempty"`
-		PartialAuthB string         `json:"partial_auth_b,omitempty"`
-		RequestID    string         `json:"request_id,omitempty"`
+		Body           map[string]any `json:"body"`
+		Signature      string         `json:"signature,omitempty"`
+		PartialAuthA   string         `json:"partial_auth_a,omitempty"`
+		PartialAuthB   string         `json:"partial_auth_b,omitempty"`
+		RequestID      string         `json:"request_id,omitempty"`
+		RelaySignature string         `json:"relay_signature,omitempty"`
+		RelaySignedAt  string         `json:"relay_signed_at,omitempty"`
+		RelayNonce     string         `json:"relay_nonce,omitempty"`
+		RelayKeyID     string         `json:"relay_key_id,omitempty"`
 	}
 	if err := json.Unmarshal(msg, &raw); err != nil {
 		d.cfg.Logger.Error("dispatch: failed to parse envelope", "err", err)
 		return
 	}
+
+	// Capture the raw `body` bytes separately (a struct can't share the "body"
+	// json tag with the decoded map). The relay signs these exact bytes, so the
+	// verifier must check them — never a re-marshaled map.
+	var bodyEnvelope struct {
+		Body json.RawMessage `json:"body"`
+	}
+	_ = json.Unmarshal(msg, &bodyEnvelope)
 
 	actionName, _ := raw.Body["action_name"].(string)
 	logger := d.cfg.Logger.With("action_name", actionName, "request_id", raw.RequestID)
@@ -260,6 +273,13 @@ func (d *Dispatcher) Handle(ctx context.Context, msg []byte, send relay.SendFunc
 			Signature:    raw.Signature,
 			PartialAuthA: raw.PartialAuthA,
 			PartialAuthB: raw.PartialAuthB,
+			BodyRaw:      bodyEnvelope.Body,
+			RelaySig: relaysig.Envelope{
+				Signature: raw.RelaySignature,
+				SignedAt:  raw.RelaySignedAt,
+				Nonce:     raw.RelayNonce,
+				KeyID:     raw.RelayKeyID,
+			},
 		}
 		if err := d.auth.Validate(authReq); err != nil {
 			logger.Warn("dispatch: auth rejected", "err", err)

--- a/runner/pkg/mutate/handlers.go
+++ b/runner/pkg/mutate/handlers.go
@@ -29,7 +29,9 @@ func Handlers(m *Mutator) map[string]dispatch.Handler {
 	if m.dynamic != nil {
 		hs["create_or_replace_alert_rule"] = wrap(m, handleCreateOrReplacePromRule)
 		hs["delete_alert_rule"] = wrapErr(m, handleDeletePromRule)
+		hs["create_workload"] = wrap(m, handleCreateWorkload)
 		hs["replace_workload"] = wrap(m, handleReplaceWorkload)
+		hs["delete_workload"] = wrap(m, handleDeleteWorkload)
 		// replica_rightsizing scales Deployment/StatefulSet/Rollout via the
 		// dynamic client. Delivered through the agent_task poller (trusted),
 		// so — like rightsizing_resource — it is deliberately NOT a lightAction.
@@ -224,6 +226,52 @@ func handleReplaceWorkload(ctx context.Context, m *Mutator, p map[string]any) (a
 	return map[string]any{
 		"updated": updated,
 		"message": fmt.Sprintf("%s/%s updated", kind, loc),
+	}, nil
+}
+
+// handleDeleteWorkload deletes a workload by kind/namespace/name. The delete UI
+// sends `kind` lowercased (KubernetesWorkloads.jsx); DeleteWorkload resolves the
+// kind case-insensitively, so no normalisation is needed here. DeleteWorkload
+// already returns the success {success, message} map.
+func handleDeleteWorkload(ctx context.Context, m *Mutator, p map[string]any) (any, error) {
+	kind := str(p, "kind")
+	if kind == "" {
+		return nil, errors.New("delete_workload: kind required (Deployment|DaemonSet|StatefulSet|ReplicaSet|Rollout|NodePool|EC2NodeClass)")
+	}
+	return m.DeleteWorkload(ctx, kind, str(p, "namespace"), str(p, "name"))
+}
+
+// handleCreateWorkload mirrors handleReplaceWorkload's body handling (per-kind
+// field, `body`, or top-level manifest) but creates rather than replaces. The
+// kind is canonicalised before picking the per-kind body field so a caller that
+// sends a non-TitleCase kind still resolves the right field name.
+func handleCreateWorkload(ctx context.Context, m *Mutator, p map[string]any) (any, error) {
+	kind := str(p, "kind")
+	if kind == "" {
+		return nil, errors.New("create_workload: kind required (Deployment|DaemonSet|StatefulSet|ReplicaSet|Rollout|NodePool|EC2NodeClass)")
+	}
+	bodyKind := kind
+	if canonical, _, ok := resolveWorkloadKind(kind); ok {
+		bodyKind = canonical
+	}
+	name := str(p, "name")
+	namespace := str(p, "namespace")
+	body := pickReplaceBody(bodyKind, p)
+	if body == nil {
+		return nil, fmt.Errorf("create_workload: body required (pass under %q, %q, or full manifest at top level)",
+			perKindBodyField(bodyKind), "body")
+	}
+	created, err := m.CreateWorkload(ctx, kind, namespace, name, body)
+	if err != nil {
+		return nil, err
+	}
+	loc := name
+	if namespace != "" {
+		loc = namespace + "/" + name
+	}
+	return map[string]any{
+		"created": created,
+		"message": fmt.Sprintf("%s/%s created", kind, loc),
 	}, nil
 }
 

--- a/runner/pkg/mutate/workload.go
+++ b/runner/pkg/mutate/workload.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -77,6 +78,114 @@ var supportedWorkloadKinds = map[string]workloadKindEntry{
 		namespaced:   false,
 		expectedKind: "EC2NodeClass",
 	},
+}
+
+// resolveWorkloadKind does a case-insensitive lookup of the user-facing kind
+// against supportedWorkloadKinds. Callers aren't consistent about casing: the
+// edit/create UI sends TitleCase ("Deployment", "NodePool") while the delete UI
+// sends `kind.toLowerCase()` ("deployment") — see
+// app/src/components/k8s/details/KubernetesWorkloads.jsx. It returns the
+// canonical map key alongside the entry so callers render messages and pick the
+// per-kind body field with the canonical spelling.
+func resolveWorkloadKind(kind string) (canonical string, entry workloadKindEntry, ok bool) {
+	for k, e := range supportedWorkloadKinds {
+		if strings.EqualFold(k, kind) {
+			return k, e, true
+		}
+	}
+	return "", workloadKindEntry{}, false
+}
+
+// DeleteWorkload deletes the named workload via the dynamic client, reusing
+// ReplaceWorkload's per-kind GVR + scope lookup. Propagation is Background so
+// the apiserver garbage-collects dependents (ReplicaSets/Pods) — matching
+// `kubectl delete deployment` rather than orphaning them.
+func (m *Mutator) DeleteWorkload(ctx context.Context, kind, namespace, name string) (any, error) {
+	if m.dynamic == nil {
+		return nil, errors.New("mutate: dynamic client not configured")
+	}
+	if name == "" {
+		return nil, errors.New("mutate: name required")
+	}
+	canonical, entry, ok := resolveWorkloadKind(kind)
+	if !ok {
+		return nil, fmt.Errorf("mutate: delete_workload not supported for kind %q", kind)
+	}
+	if entry.namespaced && namespace == "" {
+		return nil, fmt.Errorf("mutate: namespace required for %s", canonical)
+	}
+
+	prop := metav1.DeletePropagationBackground
+	opts := metav1.DeleteOptions{PropagationPolicy: &prop}
+	ri := m.dynamic.Resource(entry.gvr)
+	var err error
+	if entry.namespaced {
+		err = ri.Namespace(namespace).Delete(ctx, name, opts)
+	} else {
+		err = ri.Delete(ctx, name, opts)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("mutate: delete %s/%s: %w", canonical, name, err)
+	}
+
+	loc := name
+	if namespace != "" {
+		loc = namespace + "/" + name
+	}
+	return map[string]any{
+		"success": true,
+		"message": fmt.Sprintf("%s/%s deleted", canonical, loc),
+	}, nil
+}
+
+// CreateWorkload creates a new workload from the supplied manifest via the
+// dynamic client. It shares unstructuredFromBody + the per-kind GVR lookup with
+// ReplaceWorkload so the create/edit UI can send the same payload shape to
+// either action — the only difference is Create vs Update (no Get/ResourceVersion
+// dance, since there is no existing object). On success the apiserver-echoed
+// object is returned so the dispatch handler can render a success Finding.
+func (m *Mutator) CreateWorkload(ctx context.Context, kind, namespace, name string, body any) (any, error) {
+	if m.dynamic == nil {
+		return nil, errors.New("mutate: dynamic client not configured")
+	}
+	canonical, entry, ok := resolveWorkloadKind(kind)
+	if !ok {
+		return nil, fmt.Errorf("mutate: create_workload not supported for kind %q", kind)
+	}
+	if entry.namespaced && namespace == "" {
+		return nil, fmt.Errorf("mutate: namespace required for %s", canonical)
+	}
+
+	u, err := unstructuredFromBody(body)
+	if err != nil {
+		return nil, err
+	}
+	// Force kind/apiVersion so a body that omits them still targets the right
+	// GVR; name/namespace from params win over the body when provided (the
+	// delete/replace handlers do the same), otherwise we trust metadata.name.
+	u.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   entry.gvr.Group,
+		Version: entry.gvr.Version,
+		Kind:    entry.expectedKind,
+	})
+	if name != "" {
+		u.SetName(name)
+	}
+	if entry.namespaced {
+		u.SetNamespace(namespace)
+	}
+
+	ri := m.dynamic.Resource(entry.gvr)
+	var created *unstructured.Unstructured
+	if entry.namespaced {
+		created, err = ri.Namespace(namespace).Create(ctx, u, metav1.CreateOptions{})
+	} else {
+		created, err = ri.Create(ctx, u, metav1.CreateOptions{})
+	}
+	if err != nil {
+		return nil, fmt.Errorf("mutate: create %s/%s: %w", canonical, u.GetName(), err)
+	}
+	return created.UnstructuredContent(), nil
 }
 
 // ReplaceWorkload runs a Replace (full-spec PUT) against the named

--- a/runner/pkg/mutate/workload_test.go
+++ b/runner/pkg/mutate/workload_test.go
@@ -372,3 +372,211 @@ func TestHandleReplaceWorkload_NotRegisteredWithoutDynamic(t *testing.T) {
 		t.Error("replace_workload registered without dynamic client — gating broken")
 	}
 }
+
+// ---------- delete_workload ----------
+
+// TestDeleteWorkload_Deployment_LowercaseKind covers the delete UI's casing:
+// KubernetesWorkloads.jsx sends kind.toLowerCase(), so "deployment" must resolve
+// to the Deployment GVR via the case-insensitive lookup.
+func TestDeleteWorkload_Deployment_LowercaseKind(t *testing.T) {
+	existing := seedExisting("apps/v1", "Deployment", "web", "shop", "100")
+	dyn := dynamicfake.NewSimpleDynamicClient(workloadScheme(), existing)
+	m := New(fake.NewClientset(), "", nil)
+	m.SetDynamic(dyn)
+
+	got, err := m.DeleteWorkload(context.Background(), "deployment", "shop", "web")
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotMap := got.(map[string]any)
+	if gotMap["success"] != true {
+		t.Errorf("success = %v; want true", gotMap["success"])
+	}
+	if msg, _ := gotMap["message"].(string); !strings.Contains(msg, "Deployment/shop/web deleted") {
+		t.Errorf("message = %q; want canonical 'Deployment/shop/web deleted'", msg)
+	}
+	// The object must actually be gone from the tracker.
+	gvr := supportedWorkloadKinds["Deployment"].gvr
+	if _, err := dyn.Resource(gvr).Namespace("shop").Get(context.Background(), "web", metav1.GetOptions{}); err == nil {
+		t.Error("deployment still present after DeleteWorkload")
+	}
+}
+
+func TestDeleteWorkload_NodePool_ClusterScoped(t *testing.T) {
+	existing := seedExisting("karpenter.sh/v1", "NodePool", "default", "", "1")
+	dyn := dynamicfake.NewSimpleDynamicClient(workloadScheme(), existing)
+	m := New(fake.NewClientset(), "", nil)
+	m.SetDynamic(dyn)
+
+	if _, err := m.DeleteWorkload(context.Background(), "NodePool", "", "default"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDeleteWorkload_UnsupportedKind(t *testing.T) {
+	dyn := dynamicfake.NewSimpleDynamicClient(workloadScheme())
+	m := New(fake.NewClientset(), "", nil)
+	m.SetDynamic(dyn)
+
+	_, err := m.DeleteWorkload(context.Background(), "Pod", "shop", "web")
+	if err == nil || !strings.Contains(err.Error(), "not supported") {
+		t.Errorf("err = %v; want 'not supported' rejection", err)
+	}
+}
+
+func TestDeleteWorkload_NoDynamicClient(t *testing.T) {
+	m := New(fake.NewClientset(), "", nil)
+	_, err := m.DeleteWorkload(context.Background(), "Deployment", "shop", "web")
+	if err == nil || !strings.Contains(err.Error(), "dynamic client") {
+		t.Errorf("err = %v; want 'dynamic client not configured'", err)
+	}
+}
+
+func TestDeleteWorkload_NamespacedRequiresNamespace(t *testing.T) {
+	dyn := dynamicfake.NewSimpleDynamicClient(workloadScheme())
+	m := New(fake.NewClientset(), "", nil)
+	m.SetDynamic(dyn)
+
+	_, err := m.DeleteWorkload(context.Background(), "Deployment", "", "web")
+	if err == nil || !strings.Contains(err.Error(), "namespace required") {
+		t.Errorf("err = %v; want 'namespace required'", err)
+	}
+}
+
+// ---------- create_workload ----------
+
+func TestCreateWorkload_Deployment(t *testing.T) {
+	dyn := dynamicfake.NewSimpleDynamicClient(workloadScheme())
+	m := New(fake.NewClientset(), "", nil)
+	m.SetDynamic(dyn)
+
+	body := newWorkloadManifest("apps/v1", "Deployment", "web", "shop", map[string]any{"replicas": int64(3)})
+	got, err := m.CreateWorkload(context.Background(), "Deployment", "shop", "web", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotMap := got.(map[string]any)
+	if spec, _ := gotMap["spec"].(map[string]any); spec["replicas"] != float64(3) {
+		t.Errorf("replicas = %v; want 3", gotMap["spec"])
+	}
+	// Verify it persisted.
+	gvr := supportedWorkloadKinds["Deployment"].gvr
+	if _, err := dyn.Resource(gvr).Namespace("shop").Get(context.Background(), "web", metav1.GetOptions{}); err != nil {
+		t.Errorf("created deployment not found: %v", err)
+	}
+}
+
+func TestCreateWorkload_NodePool_ClusterScoped(t *testing.T) {
+	dyn := dynamicfake.NewSimpleDynamicClient(workloadScheme())
+	m := New(fake.NewClientset(), "", nil)
+	m.SetDynamic(dyn)
+
+	body := newWorkloadManifest("karpenter.sh/v1", "NodePool", "default", "", nil)
+	if _, err := m.CreateWorkload(context.Background(), "NodePool", "", "default", body); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCreateWorkload_UnsupportedKind(t *testing.T) {
+	dyn := dynamicfake.NewSimpleDynamicClient(workloadScheme())
+	m := New(fake.NewClientset(), "", nil)
+	m.SetDynamic(dyn)
+
+	_, err := m.CreateWorkload(context.Background(), "Pod", "shop", "web", map[string]any{})
+	if err == nil || !strings.Contains(err.Error(), "not supported") {
+		t.Errorf("err = %v; want 'not supported' rejection", err)
+	}
+}
+
+func TestCreateWorkload_NoDynamicClient(t *testing.T) {
+	m := New(fake.NewClientset(), "", nil)
+	_, err := m.CreateWorkload(context.Background(), "Deployment", "shop", "web", map[string]any{})
+	if err == nil || !strings.Contains(err.Error(), "dynamic client") {
+		t.Errorf("err = %v; want 'dynamic client not configured'", err)
+	}
+}
+
+// ---------- handler registration + dispatch shape ----------
+
+// TestHandlers_RegistersWorkloadMutationsWithDynamic verifies create/replace/
+// delete_workload are wired only when the dynamic client is present (they live
+// in the m.dynamic != nil block).
+func TestHandlers_RegistersWorkloadMutationsWithDynamic(t *testing.T) {
+	want := []string{"create_workload", "replace_workload", "delete_workload"}
+
+	bare := New(fake.NewClientset(), "", nil)
+	for _, a := range want {
+		if _, ok := Handlers(bare)[a]; ok {
+			t.Errorf("%q should not be registered without a dynamic client", a)
+		}
+	}
+
+	withDyn := New(fake.NewClientset(), "", nil)
+	withDyn.SetDynamic(dynamicfake.NewSimpleDynamicClient(workloadScheme()))
+	for _, a := range want {
+		if _, ok := Handlers(withDyn)[a]; !ok {
+			t.Errorf("missing %q with dynamic client set", a)
+		}
+	}
+}
+
+func TestHandleDeleteWorkload_HappyPath(t *testing.T) {
+	existing := seedExisting("apps/v1", "Deployment", "web", "shop", "1")
+	m := New(fake.NewClientset(), "", nil)
+	m.SetDynamic(dynamicfake.NewSimpleDynamicClient(workloadScheme(), existing))
+	hs := Handlers(m)
+
+	// kind lowercased, exactly as the delete UI sends it.
+	got, err := hs["delete_workload"](context.Background(), map[string]any{
+		"kind": "deployment", "namespace": "shop", "name": "web",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r, _ := got.(map[string]any); r["success"] != true {
+		t.Errorf("response = %v", got)
+	}
+}
+
+func TestHandleDeleteWorkload_KindRequired(t *testing.T) {
+	m := New(fake.NewClientset(), "", nil)
+	m.SetDynamic(dynamicfake.NewSimpleDynamicClient(workloadScheme()))
+	hs := Handlers(m)
+
+	_, err := hs["delete_workload"](context.Background(), map[string]any{"namespace": "shop", "name": "web"})
+	if err == nil || !strings.Contains(err.Error(), "kind required") {
+		t.Errorf("err = %v; want 'kind required'", err)
+	}
+}
+
+func TestHandleCreateWorkload_PerKindBody(t *testing.T) {
+	m := New(fake.NewClientset(), "", nil)
+	m.SetDynamic(dynamicfake.NewSimpleDynamicClient(workloadScheme()))
+	hs := Handlers(m)
+
+	// NodePool create UI shape: kind TitleCase, manifest under the per-kind
+	// `nodepool` field, cluster-scoped (empty namespace).
+	manifest := newWorkloadManifest("karpenter.sh/v1", "NodePool", "default", "", nil)
+	got, err := hs["create_workload"](context.Background(), map[string]any{
+		"kind": "NodePool", "namespace": "", "name": "default", "nodepool": manifest,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r, _ := got.(map[string]any); r["created"] == nil {
+		t.Errorf("response missing created object: %v", got)
+	}
+}
+
+func TestHandleCreateWorkload_BodyRequired(t *testing.T) {
+	m := New(fake.NewClientset(), "", nil)
+	m.SetDynamic(dynamicfake.NewSimpleDynamicClient(workloadScheme()))
+	hs := Handlers(m)
+
+	_, err := hs["create_workload"](context.Background(), map[string]any{
+		"kind": "Deployment", "namespace": "shop", "name": "web",
+	})
+	if err == nil || !strings.Contains(err.Error(), "body required") {
+		t.Errorf("err = %v; want 'body required'", err)
+	}
+}

--- a/runner/pkg/relaysig/verify.go
+++ b/runner/pkg/relaysig/verify.go
@@ -1,0 +1,247 @@
+// Package relaysig verifies Ed25519 signatures that the relay-server stamps on
+// requests forwarded to native ("k8s") agents.
+//
+// Unlike the agent's per-account HMAC/RSA auth (pkg/auth), this proves a request
+// transited the trusted relay: the relay signs the raw bytes of the request's
+// `body` field with its global Ed25519 key, and the agent verifies that exact
+// byte string with the relay's public key. A valid relay signature authorizes
+// any action (the relay already enforced the api-server's per-action permission
+// check + X-SECRET-KEY gate); see pkg/auth.Validator.
+//
+// The signature is carried in NEW envelope fields (`relay_signature`,
+// `relay_signed_at`, `relay_nonce`, `relay_key_id`) — deliberately NOT the
+// `signature` field, which the HMAC path owns. Old agents ignore the new fields,
+// so this is purely additive.
+//
+// Binding the raw `body` bytes (rather than an extracted/canonicalised subset)
+// means the signature covers account_id + action_name + action_params +
+// timestamp together, and the agent verifies the identical bytes it executes —
+// so there is no payload-substitution gap and no canonicalisation ambiguity. The
+// transport (RabbitMQ → WS) passes the payload through byte-for-byte.
+package relaysig
+
+import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+const (
+	// maxTimestampSkew bounds the gap between relay_signed_at and now.
+	maxTimestampSkew = 5 * time.Minute
+	// maxNonces caps the replay-prevention set before time-based eviction.
+	maxNonces = 10000
+)
+
+// Envelope is the relay signature metadata, parsed by the caller from the
+// `relay_*` top-level fields of the request.
+type Envelope struct {
+	Signature string // base64 Ed25519 signature over the raw `body` bytes
+	SignedAt  string // RFC3339 timestamp
+	Nonce     string // unique id for replay prevention
+	KeyID     string // optional key id (rotation/logging)
+}
+
+// Present reports whether a relay signature is attached.
+func (e Envelope) Present() bool { return e.Signature != "" }
+
+// Verifier validates relay Ed25519 signatures over request bodies. It holds one
+// or more public keys so the relay's signing key can be rotated without a
+// synchronized agent restart (verification succeeds if ANY configured key
+// matches).
+type Verifier struct {
+	publicKeys []ed25519.PublicKey
+	logger     *slog.Logger
+
+	seenNonces map[string]time.Time
+	nonceMu    sync.Mutex
+}
+
+// NewVerifier builds a verifier from one or more public keys (comma- or
+// whitespace-separated). Each key may be OpenSSH `ssh-ed25519 ...`, PEM (PKIX),
+// or raw base64 (32 bytes). An empty string yields a disabled verifier
+// (Enabled()==false) — the caller then ignores any relay signature and falls
+// back to existing auth, so reads keep working on un-keyed agents.
+func NewVerifier(publicKeysStr string, logger *slog.Logger) (*Verifier, error) {
+	v := &Verifier{logger: logger, seenNonces: make(map[string]time.Time)}
+
+	keys, err := parsePublicKeys(publicKeysStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid relay signing public key: %w", err)
+	}
+	v.publicKeys = keys
+	if len(keys) == 0 {
+		logger.Warn("relay signature verification disabled: no RELAY_SIGNING_PUBLIC_KEY configured")
+	} else {
+		logger.Info("relay signature verification enabled", "keys", len(keys))
+	}
+	return v, nil
+}
+
+// Enabled reports whether at least one public key is loaded.
+func (v *Verifier) Enabled() bool { return len(v.publicKeys) > 0 }
+
+// VerifyBody checks the relay signature over bodyRaw — the exact bytes of the
+// request's `body` field as received. Returns nil only when the signature is
+// valid under some configured key, the timestamp is within skew, and the nonce
+// has not been seen. Callers MUST pass the raw `body` bytes (e.g. a
+// json.RawMessage), never a re-marshaled map, so the bytes match what the relay
+// signed.
+func (v *Verifier) VerifyBody(bodyRaw []byte, env Envelope) error {
+	if !v.Enabled() {
+		return fmt.Errorf("relay signature verification not configured")
+	}
+	if env.Signature == "" {
+		return fmt.Errorf("relay signature: missing relay_signature")
+	}
+	if env.SignedAt == "" {
+		return fmt.Errorf("relay signature: missing relay_signed_at")
+	}
+	if env.Nonce == "" {
+		return fmt.Errorf("relay signature: missing relay_nonce")
+	}
+	if len(bodyRaw) == 0 {
+		return fmt.Errorf("relay signature: empty body")
+	}
+
+	signedAt, err := time.Parse(time.RFC3339, env.SignedAt)
+	if err != nil {
+		return fmt.Errorf("relay signature: invalid relay_signed_at: %w", err)
+	}
+	if absDuration(time.Since(signedAt)) > maxTimestampSkew {
+		return fmt.Errorf("relay signature: relay_signed_at %s outside ±%s window", env.SignedAt, maxTimestampSkew)
+	}
+
+	if v.isReplayedNonce(env.Nonce) {
+		return fmt.Errorf("relay signature: nonce %s already seen (replay)", env.Nonce)
+	}
+
+	sig, err := base64.StdEncoding.DecodeString(env.Signature)
+	if err != nil {
+		return fmt.Errorf("relay signature: invalid signature encoding: %w", err)
+	}
+
+	verified := false
+	for _, pk := range v.publicKeys {
+		if ed25519.Verify(pk, bodyRaw, sig) {
+			verified = true
+			break
+		}
+	}
+	if !verified {
+		return fmt.Errorf("relay signature: invalid signature")
+	}
+
+	// Record the nonce only after a fully successful verification so a forged
+	// or stale message can't consume a nonce a legitimate retry might reuse.
+	v.recordNonce(env.Nonce)
+	return nil
+}
+
+// parsePublicKeys splits on commas/whitespace and parses each entry. Returns an
+// empty slice (no error) for an empty input.
+func parsePublicKeys(s string) ([]ed25519.PublicKey, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, nil
+	}
+	// PEM keys contain newlines internally, so only split on commas when the
+	// input isn't a PEM block; otherwise treat the whole string as one key.
+	var fields []string
+	if strings.Contains(s, "-----BEGIN") {
+		fields = []string{s}
+	} else {
+		fields = strings.FieldsFunc(s, func(r rune) bool { return r == ',' || r == '\n' })
+	}
+	var keys []ed25519.PublicKey
+	for _, f := range fields {
+		f = strings.TrimSpace(f)
+		if f == "" {
+			continue
+		}
+		k, err := parsePublicKey(f)
+		if err != nil {
+			return nil, err
+		}
+		keys = append(keys, k)
+	}
+	return keys, nil
+}
+
+// parsePublicKey accepts OpenSSH authorized_keys, PEM (PKIX), or raw base64.
+func parsePublicKey(s string) (ed25519.PublicKey, error) {
+	s = strings.TrimSpace(s)
+
+	if strings.HasPrefix(s, "ssh-ed25519 ") {
+		pubKey, _, _, _, err := ssh.ParseAuthorizedKey([]byte(s))
+		if err != nil {
+			return nil, fmt.Errorf("OpenSSH public key parse failed: %w", err)
+		}
+		cryptoPub, ok := pubKey.(ssh.CryptoPublicKey)
+		if !ok {
+			return nil, fmt.Errorf("OpenSSH key does not implement CryptoPublicKey")
+		}
+		edKey, ok := cryptoPub.CryptoPublicKey().(ed25519.PublicKey)
+		if !ok {
+			return nil, fmt.Errorf("OpenSSH key is not Ed25519")
+		}
+		return edKey, nil
+	}
+
+	if block, _ := pem.Decode([]byte(s)); block != nil {
+		key, err := x509.ParsePKIXPublicKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("PEM parse failed: %w", err)
+		}
+		edKey, ok := key.(ed25519.PublicKey)
+		if !ok {
+			return nil, fmt.Errorf("PEM key is not Ed25519")
+		}
+		return edKey, nil
+	}
+
+	keyBytes, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return nil, fmt.Errorf("base64 decode failed: %w", err)
+	}
+	if len(keyBytes) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("expected %d bytes, got %d", ed25519.PublicKeySize, len(keyBytes))
+	}
+	return ed25519.PublicKey(keyBytes), nil
+}
+
+func (v *Verifier) isReplayedNonce(nonce string) bool {
+	v.nonceMu.Lock()
+	defer v.nonceMu.Unlock()
+	_, seen := v.seenNonces[nonce]
+	return seen
+}
+
+func (v *Verifier) recordNonce(nonce string) {
+	v.nonceMu.Lock()
+	defer v.nonceMu.Unlock()
+	v.seenNonces[nonce] = time.Now()
+	if len(v.seenNonces) > maxNonces {
+		cutoff := time.Now().Add(-maxTimestampSkew * 2)
+		for n, t := range v.seenNonces {
+			if t.Before(cutoff) {
+				delete(v.seenNonces, n)
+			}
+		}
+	}
+}
+
+func absDuration(d time.Duration) time.Duration {
+	if d < 0 {
+		return -d
+	}
+	return d
+}

--- a/runner/pkg/relaysig/verify.go
+++ b/runner/pkg/relaysig/verify.go
@@ -61,8 +61,9 @@ type Verifier struct {
 	publicKeys []ed25519.PublicKey
 	logger     *slog.Logger
 
-	seenNonces map[string]time.Time
-	nonceMu    sync.Mutex
+	seenNonces  map[string]time.Time
+	lastCleanup time.Time
+	nonceMu     sync.Mutex
 }
 
 // NewVerifier builds a verifier from one or more public keys (comma- or
@@ -120,10 +121,6 @@ func (v *Verifier) VerifyBody(bodyRaw []byte, env Envelope) error {
 		return fmt.Errorf("relay signature: relay_signed_at %s outside ±%s window", env.SignedAt, maxTimestampSkew)
 	}
 
-	if v.isReplayedNonce(env.Nonce) {
-		return fmt.Errorf("relay signature: nonce %s already seen (replay)", env.Nonce)
-	}
-
 	sig, err := base64.StdEncoding.DecodeString(env.Signature)
 	if err != nil {
 		return fmt.Errorf("relay signature: invalid signature encoding: %w", err)
@@ -140,10 +137,12 @@ func (v *Verifier) VerifyBody(bodyRaw []byte, env Envelope) error {
 		return fmt.Errorf("relay signature: invalid signature")
 	}
 
-	// Record the nonce only after a fully successful verification so a forged
-	// or stale message can't consume a nonce a legitimate retry might reuse.
-	v.recordNonce(env.Nonce)
-	return nil
+	// Check + record the nonce atomically, and only after a fully successful
+	// signature verification: a single locked operation closes the TOCTOU gap
+	// where two concurrent identical requests could both pass a separate
+	// pre-check before either records, and gating it behind verification means
+	// forged/stale messages can't burn a nonce a legitimate retry might reuse.
+	return v.checkAndRecordNonce(env.Nonce)
 }
 
 // parsePublicKeys splits on commas/whitespace and parses each entry. Returns an
@@ -218,25 +217,29 @@ func parsePublicKey(s string) (ed25519.PublicKey, error) {
 	return ed25519.PublicKey(keyBytes), nil
 }
 
-func (v *Verifier) isReplayedNonce(nonce string) bool {
+// checkAndRecordNonce rejects a nonce it has already seen and otherwise records
+// it, both under a single lock so there is no check-then-record race. To keep
+// the hot path O(1), the O(N) eviction sweep runs at most once per minute once
+// the set exceeds maxNonces (entries older than 2× the skew window are pruned;
+// they can never pass the skew check again).
+func (v *Verifier) checkAndRecordNonce(nonce string) error {
 	v.nonceMu.Lock()
 	defer v.nonceMu.Unlock()
-	_, seen := v.seenNonces[nonce]
-	return seen
-}
-
-func (v *Verifier) recordNonce(nonce string) {
-	v.nonceMu.Lock()
-	defer v.nonceMu.Unlock()
-	v.seenNonces[nonce] = time.Now()
-	if len(v.seenNonces) > maxNonces {
-		cutoff := time.Now().Add(-maxTimestampSkew * 2)
+	if _, seen := v.seenNonces[nonce]; seen {
+		return fmt.Errorf("relay signature: nonce %s already seen (replay)", nonce)
+	}
+	now := time.Now()
+	v.seenNonces[nonce] = now
+	if len(v.seenNonces) > maxNonces && now.Sub(v.lastCleanup) > time.Minute {
+		v.lastCleanup = now
+		cutoff := now.Add(-maxTimestampSkew * 2)
 		for n, t := range v.seenNonces {
 			if t.Before(cutoff) {
 				delete(v.seenNonces, n)
 			}
 		}
 	}
+	return nil
 }
 
 func absDuration(d time.Duration) time.Duration {

--- a/runner/pkg/relaysig/verify_test.go
+++ b/runner/pkg/relaysig/verify_test.go
@@ -1,0 +1,163 @@
+package relaysig
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+func testLogger() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+// --- Shared cross-repo signing vector ---------------------------------------
+// These MUST stay byte-identical to the relay-server's signer_test.go vector so
+// the two implementations can't silently drift. Seed → key; signing `vectorBody`
+// with that key yields exactly vectorSigB64. (Mirrors the v0:/v0= HMAC contract.)
+const (
+	vectorSeedB64 = "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA="
+	vectorPubB64  = "ebVWLo/mVPlAeLES6KmLp5AfhTrmlb7X4OORC60ElmQ="
+	vectorSigB64  = "EuCrun1jNPY3biXu7Faf7M3K1mAqMF18jXxm36ltMoHFjZfCaWafUzgorxWysf4mb/I6vgip2C+b++FMytCCDw=="
+	vectorBody    = `{"account_id":"acct-1","action_name":"delete_workload","action_params":{"kind":"deployment","name":"web","namespace":"shop"},"timestamp":1700000000}`
+)
+
+func mustSeedKey(t *testing.T, seedB64 string) ed25519.PrivateKey {
+	t.Helper()
+	seed, err := base64.StdEncoding.DecodeString(seedB64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ed25519.NewKeyFromSeed(seed)
+}
+
+func freshEnv(priv ed25519.PrivateKey, body []byte, nonce string) Envelope {
+	sig := ed25519.Sign(priv, body)
+	return Envelope{
+		Signature: base64.StdEncoding.EncodeToString(sig),
+		SignedAt:  time.Now().UTC().Format(time.RFC3339),
+		Nonce:     nonce,
+		KeyID:     "test",
+	}
+}
+
+// TestVector_CrossImplStability guards against drift between this verifier and
+// the relay signer: the fixed seed signing the fixed body must produce exactly
+// the fixed signature, and that signature must verify under the fixed pub key.
+func TestVector_CrossImplStability(t *testing.T) {
+	priv := mustSeedKey(t, vectorSeedB64)
+	gotSig := base64.StdEncoding.EncodeToString(ed25519.Sign(priv, []byte(vectorBody)))
+	if gotSig != vectorSigB64 {
+		t.Fatalf("signature drift:\n got %s\nwant %s", gotSig, vectorSigB64)
+	}
+	v, err := NewVerifier(vectorPubB64, testLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := Envelope{Signature: vectorSigB64, SignedAt: time.Now().UTC().Format(time.RFC3339), Nonce: "n-vec"}
+	if err := v.VerifyBody([]byte(vectorBody), env); err != nil {
+		t.Fatalf("vector did not verify: %v", err)
+	}
+}
+
+func TestVerifyBody_HappyPath(t *testing.T) {
+	priv := mustSeedKey(t, vectorSeedB64)
+	v, err := NewVerifier(vectorPubB64, testLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := []byte(vectorBody)
+	if err := v.VerifyBody(body, freshEnv(priv, body, "n1")); err != nil {
+		t.Fatalf("happy path failed: %v", err)
+	}
+}
+
+func TestVerifyBody_Tamper(t *testing.T) {
+	priv := mustSeedKey(t, vectorSeedB64)
+	v, _ := NewVerifier(vectorPubB64, testLogger())
+	body := []byte(vectorBody)
+	env := freshEnv(priv, body, "n2")
+	// Verify against a body whose params were altered after signing.
+	tampered := []byte(`{"account_id":"acct-1","action_name":"delete_workload","action_params":{"kind":"deployment","name":"PROD","namespace":"shop"},"timestamp":1700000000}`)
+	if err := v.VerifyBody(tampered, env); err == nil {
+		t.Fatal("tampered body verified; want failure")
+	}
+}
+
+func TestVerifyBody_WrongKey(t *testing.T) {
+	priv := mustSeedKey(t, vectorSeedB64)
+	// Verifier configured with a DIFFERENT key.
+	otherSeed := make([]byte, 32)
+	otherSeed[0] = 99
+	otherPub := ed25519.NewKeyFromSeed(otherSeed).Public().(ed25519.PublicKey)
+	v, _ := NewVerifier(base64.StdEncoding.EncodeToString(otherPub), testLogger())
+	body := []byte(vectorBody)
+	if err := v.VerifyBody(body, freshEnv(priv, body, "n3")); err == nil {
+		t.Fatal("wrong-key verify passed; want failure")
+	}
+}
+
+func TestVerifyBody_Replay(t *testing.T) {
+	priv := mustSeedKey(t, vectorSeedB64)
+	v, _ := NewVerifier(vectorPubB64, testLogger())
+	body := []byte(vectorBody)
+	env := freshEnv(priv, body, "dup")
+	if err := v.VerifyBody(body, env); err != nil {
+		t.Fatalf("first verify failed: %v", err)
+	}
+	// Same nonce again → replay rejection.
+	env2 := freshEnv(priv, body, "dup")
+	if err := v.VerifyBody(body, env2); err == nil {
+		t.Fatal("replayed nonce verified; want failure")
+	}
+}
+
+func TestVerifyBody_Skew(t *testing.T) {
+	priv := mustSeedKey(t, vectorSeedB64)
+	v, _ := NewVerifier(vectorPubB64, testLogger())
+	body := []byte(vectorBody)
+	env := freshEnv(priv, body, "n4")
+	env.SignedAt = time.Now().UTC().Add(-10 * time.Minute).Format(time.RFC3339)
+	if err := v.VerifyBody(body, env); err == nil {
+		t.Fatal("stale signed_at verified; want failure")
+	}
+}
+
+func TestVerifyBody_MultiKey(t *testing.T) {
+	priv := mustSeedKey(t, vectorSeedB64)
+	// Two keys configured (rotation): first is unrelated, second is the signer.
+	other := make([]byte, 32)
+	other[0] = 7
+	otherPub := ed25519.NewKeyFromSeed(other).Public().(ed25519.PublicKey)
+	v, err := NewVerifier(base64.StdEncoding.EncodeToString(otherPub)+","+vectorPubB64, testLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := []byte(vectorBody)
+	if err := v.VerifyBody(body, freshEnv(priv, body, "n5")); err != nil {
+		t.Fatalf("multi-key verify failed: %v", err)
+	}
+}
+
+func TestNewVerifier_DisabledWhenEmpty(t *testing.T) {
+	v, err := NewVerifier("", testLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.Enabled() {
+		t.Fatal("verifier with no key should be disabled")
+	}
+	if err := v.VerifyBody([]byte(vectorBody), Envelope{Signature: "x", SignedAt: "y", Nonce: "z"}); err == nil {
+		t.Fatal("disabled verifier should refuse VerifyBody")
+	}
+}
+
+func TestParsePublicKey_Formats(t *testing.T) {
+	// raw base64 (covered by vectorPubB64) already exercised; ensure it parses.
+	if _, err := parsePublicKey(vectorPubB64); err != nil {
+		t.Fatalf("raw base64 pubkey parse: %v", err)
+	}
+	if _, err := parsePublicKey("not-a-key"); err == nil {
+		t.Fatal("garbage key parsed; want error")
+	}
+}

--- a/runner/pkg/relaysig/verify_test.go
+++ b/runner/pkg/relaysig/verify_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/base64"
 	"io"
 	"log/slog"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -136,6 +138,37 @@ func TestVerifyBody_MultiKey(t *testing.T) {
 	body := []byte(vectorBody)
 	if err := v.VerifyBody(body, freshEnv(priv, body, "n5")); err != nil {
 		t.Fatalf("multi-key verify failed: %v", err)
+	}
+}
+
+// TestVerifyBody_ConcurrentReplay fires many goroutines verifying the SAME
+// valid signed message with the SAME nonce. Exactly one must succeed; the rest
+// must be rejected as replays. This guards the atomic check-and-record fix
+// against the TOCTOU race a separate pre-check would reopen.
+func TestVerifyBody_ConcurrentReplay(t *testing.T) {
+	priv := mustSeedKey(t, vectorSeedB64)
+	v, err := NewVerifier(vectorPubB64, testLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := []byte(vectorBody)
+	env := freshEnv(priv, body, "concurrent-nonce")
+
+	const n = 64
+	var wg sync.WaitGroup
+	var successes int64
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			if err := v.VerifyBody(body, env); err == nil {
+				atomic.AddInt64(&successes, 1)
+			}
+		}()
+	}
+	wg.Wait()
+	if successes != 1 {
+		t.Fatalf("concurrent replay: %d goroutines succeeded, want exactly 1", successes)
 	}
 }
 


### PR DESCRIPTION
# Description

Native k8s agents rejected UI-triggered workload mutations. `delete_workload` / `create_workload` had no handler (404), and the other mutations are not light actions so unsigned UI requests 401.

This adds the missing handlers and an Ed25519 relay-signature path: a valid relay signature (from the relay-server's global signing key) authorizes any action; absent/unverifiable signatures fall through to the existing modes so reads never regress.

Pairs with **nudgebee/nudgebee-enterprise** (relay-server signing + app install command). Both must land together. Cross-repo signing vector is pinned in both repos' tests.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# What changed

- **mutate**: `DeleteWorkload` / `CreateWorkload` (dynamic client, per-kind GVR, case-insensitive kind); registered handlers.
- **relaysig** (new): Ed25519 verifier — multi-key (rotation), ±5min skew, replay cache; binds the raw request `body` bytes.
- **auth / dispatch**: valid relay sig → authorize any action; absent/unverifiable → fall through to HMAC/RSA/light-action (reads safe on old/un-keyed agents).
- **config / chart / installation.sh**: provision `RELAY_SIGNING_PUBLIC_KEY` (`-S` flag, `--set-string runner.nudgebee.relay_signing_public_key`).

# How Has This Been Tested?

- [x] `go build/vet/test ./...` green; `gofmt` clean
- [x] relaysig: happy / tamper / wrong-key / replay / skew / multi-key
- [x] auth back-compat matrix incl. failed-sig-on-read falls through to light action
- [x] Shared cross-repo signing vector matches the relay-server
- [x] `helm lint`; `installation.sh` syntax check
- [ ] End-to-end UI→relay→agent delete against a keyed agent (needs deployed env)

# Risks & Counterarguments

- **Raw-body byte identity** is load-bearing: signature binds `gjson(body).Raw`; a future layer that re-serializes the payload would break verification. Guarded by a body-preservation test + comments.
- Existing agents must be **re-keyed** (re-run install / set env) to gain mutation capability — they don't break, just stay read-only for mutations until then.
- **Clock skew** (>5min) blocks mutations on that agent (reads unaffected via fall-through).
- Makes workload **deletion** reachable from the UI; gated by api-server UPDATE permission + relay secret + ed25519 signature + `MUTATE_ENABLED` + UI name-confirmation.