### PR TITLE
fix(alerts): resolve PVC/HPA/Job subjects, not the prometheus scrape job

### DIFF
--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -61,7 +61,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-06-24T09-11-47_3a1509d4227a9a3064a1b3429b0304d2969c5a07
+    tag: 2026-06-27T09-28-03_2072de99c20cc6aec33003167699d0ccedb4b936
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/runner/pkg/alerts/finding.go
+++ b/runner/pkg/alerts/finding.go
@@ -404,8 +404,14 @@ func alertSubject(labels map[string]string) (string, string) {
 		{"deployment", "deployment"},
 		{"statefulset", "statefulset"},
 		{"daemonset", "daemonset"},
-		{"job", "job"},
-		{"hpa", "horizontalpodautoscaler"},
+		// `job_name` is the real kubernetes Job (kube-state-metrics emits it
+		// on kube_job_* series). The prometheus `job` label is a scrape
+		// target (kubelet, kube-state-metrics, …), NOT a resource — handled
+		// as a last-resort fallback below. Mirrors robusta's
+		// ResourceMapping(RobustaJob, "job", "job_name").
+		{"job_name", "job"},
+		{"horizontalpodautoscaler", "horizontalpodautoscaler"}, // canonical kube-state-metrics label
+		{"hpa", "horizontalpodautoscaler"},                     // relabel alias
 		{"persistentvolumeclaim", "persistentvolumeclaim"},
 		{"workload", "deployment"}, // some alerts emit a generic workload label
 		{"node", "node"},
@@ -415,6 +421,17 @@ func alertSubject(labels map[string]string) (string, string) {
 			return v, candidate.kind
 		}
 	}
+	// Prometheus `job` is a scrape target, not a kubernetes resource. It is
+	// present on every series the exporter emits, so using it as the subject
+	// mis-attributes resource alerts to the scraper — e.g.
+	// KubePersistentVolumeFillingUp carries job=kubelet alongside
+	// persistentvolumeclaim=<pvc>, and the PVC (handled above) is the real
+	// subject. Only treat `job` as the subject for self-targeting alerts
+	// (KubeSchedulerDown → job=kube-scheduler) where no more-specific label
+	// exists, and never for known exporters.
+	if v := labels["job"]; v != "" && !isScrapeExporter(v) {
+		return v, "job"
+	}
 	if v := labels["kubernetes_kind"]; v != "" {
 		// kubernetes_kind tells us the type but not the name — the labels
 		// above are the only source of name, so this is reachable only if
@@ -422,6 +439,19 @@ func alertSubject(labels map[string]string) (string, string) {
 		return "", strings.ToLower(v)
 	}
 	return "", ""
+}
+
+// isScrapeExporter reports whether a prometheus `job` label value names an
+// infrastructure scrape target (exporter) rather than a workload. These jobs
+// scrape OTHER resources' metrics (kubelet exposes PVC/volume stats,
+// kube-state-metrics exposes every object's state), so their name must never
+// become a finding subject.
+func isScrapeExporter(job string) bool {
+	switch strings.ToLower(job) {
+	case "kubelet", "kube-state-metrics", "node-exporter", "cadvisor":
+		return true
+	}
+	return strings.Contains(job, "kube-state-metrics") || strings.Contains(job, "node-exporter")
 }
 
 // severityToPriority maps Prometheus alert `severity` labels to the

--- a/runner/pkg/alerts/finding_test.go
+++ b/runner/pkg/alerts/finding_test.go
@@ -31,6 +31,22 @@ func TestBuilder_Alert_SubjectFallbackOrder(t *testing.T) {
 		{"daemonset", map[string]string{"alertname": "X", "daemonset": "ds"}, "ds", "daemonset"},
 		{"node only", map[string]string{"alertname": "X", "node": "n1"}, "n1", "node"},
 		{"hpa", map[string]string{"alertname": "X", "hpa": "h"}, "h", "horizontalpodautoscaler"},
+		// kube-state-metrics emits the full `horizontalpodautoscaler` label,
+		// alongside job=kube-state-metrics — the HPA is the subject.
+		{"hpa canonical label wins over scrape job", map[string]string{"alertname": "KubeHpaMaxedOut", "job": "kube-state-metrics", "horizontalpodautoscaler": "frontend", "namespace": "shop"}, "frontend", "horizontalpodautoscaler"},
+		// PVC alerts (KubePersistentVolumeFillingUp/Errors) carry the
+		// persistentvolumeclaim label alongside job=kubelet (the scrape
+		// target). The PVC is the subject, never the kubelet scraper.
+		{"pvc wins over scrape job", map[string]string{"alertname": "KubePersistentVolumeFillingUp", "job": "kubelet", "namespace": "hive", "persistentvolumeclaim": "dfs-hive-metastore-hdfs-datanode-0"}, "dfs-hive-metastore-hdfs-datanode-0", "persistentvolumeclaim"},
+		// Real k8s Job alerts (KubeJobFailed) come from kube-state-metrics:
+		// job_name is the Job, job=kube-state-metrics is the scraper.
+		{"job_name is the subject, not the scraper job", map[string]string{"alertname": "KubeJobFailed", "job": "kube-state-metrics", "job_name": "backup-1234", "namespace": "ops"}, "backup-1234", "job"},
+		// A bare exporter `job` is never a subject — falls through to the
+		// alertname placeholder with an empty subject type.
+		{"scrape exporter job is not a subject", map[string]string{"alertname": "KubeletTooManyPods", "job": "kubelet"}, "KubeletTooManyPods", ""},
+		// Self-targeting control-plane alerts: the job IS the component and
+		// no more-specific label exists, so it is a usable last resort.
+		{"control-plane job used as last resort", map[string]string{"alertname": "KubeSchedulerDown", "job": "kube-scheduler"}, "kube-scheduler", "job"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Problem

`alertSubject` (the `source=prometheus` Alertmanager path) treated the prometheus `job` label — a scrape target like `kubelet` or `kube-state-metrics`, present on every series the exporter emits — as a subject candidate, ordered **before** `persistentvolumeclaim`.

So `KubePersistentVolumeFillingUp` (`job=kubelet` + `persistentvolumeclaim=<pvc>`) resolved to `subject=kubelet`, and downstream enrichers (pod metrics, logs) queried a non-existent pod and returned empty. The same class of bug hit `KubeJobFailed` (→ `kube-state-metrics`) and HPA alerts.

## Fix (mirrors robusta's `ResourceMapping` precedence)

- Read `job_name` (the real K8s Job, emitted by kube-state-metrics on `kube_job_*` series) instead of the prometheus scrape `job`.
- Add the canonical `horizontalpodautoscaler` label. Previously only the short `hpa` alias was checked, so KSM-sourced HPA alerts would never have resolved once `job` stopped masking them (latent bug).
- Demote raw `job` to a last-resort fallback that excludes known exporters via `isScrapeExporter` (kubelet, kube-state-metrics, node-exporter, cadvisor). Self-targeting control-plane alerts (`KubeSchedulerDown` → `job=kube-scheduler`) still resolve; exporters never become a subject.

| Alert family | Subject label | Before | After |
|---|---|---|---|
| `KubePersistentVolumeFillingUp/Errors` | `persistentvolumeclaim` | `kubelet` | the PVC |
| `KubeJobFailed/NotCompleted` | `job_name` | `kube-state-metrics` | the Job |
| `KubeHpaMaxedOut/ReplicasMismatch` | `horizontalpodautoscaler` | scraper | the HPA |

The api-server PagerDuty webhook handler has the same class of bug for `source=pagerduty_webhook` events (the actual path that produced the reported event); fixed separately in the api-server repo.

## Testing

- [x] `TestBuilder_Alert_SubjectFallbackOrder` extended with PVC / `job_name` / exporter / canonical-HPA / control-plane cases — all pass
- [x] `go build ./...`, `go test ./pkg/alerts/`, `gofmt` clean