### PR TITLE
chore(chart): bump nudgebee-agent chart version to 0.1.5

### DIFF
--- a/charts/nudgebee-agent/Chart.yaml
+++ b/charts/nudgebee-agent/Chart.yaml
@@ -29,7 +29,7 @@ annotations:
 # these are set to the right value by .github/workflows/release.yaml
 # we use 0.0.1 as a placeholder for the version` because Helm wont allow `0.0.0` and we want to be able to run
 # `helm install` on development checkouts without updating this file. the version doesn't matter in that case anyway
-version: 0.1.4
+version: 0.1.5
 appVersion: 0.1.3
 dependencies:
 - name: opencost

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -61,7 +61,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-06-27T09-28-03_2072de99c20cc6aec33003167699d0ccedb4b936
+    tag: 2026-06-29T04-56-02_c5821d5110f76decc1b7952d8fcb6fb79aaca6cc
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.


### PR DESCRIPTION
# Description

The full-release workflow 422'd creating `nudgebee-agent-0.1.4` because that tag already exists (released 2026-06-25, before the matcher work). Bump the chart `version` so `chart-releaser` cuts a fresh `nudgebee-agent-0.1.5`.

This release carries what's on `main` since 0.1.4:
- #500 — detect single-OOM pods + node/pod condition matchers (OOM-on-`restartPolicy:Never`, node/pod unschedulable, node pressure)
- #501 — resolve PVC/HPA/Job subjects, not the prometheus scrape job

`appVersion` left at 0.1.3 (decoupled — the release pins the runner image by its GHCR `<timestamp>_<sha>` tag, not `appVersion`).

## Type of change

- [x] Chore (non-breaking change which does not modify src or test files)

# How Has This Been Tested?

- [x] Chart-only change; `version` is what `chart-releaser` tags. Re-run the `release` workflow_dispatch after merge to publish `nudgebee-agent-0.1.5`.