### PR TITLE
fix(chart): default relay_signing_public_key to Nudgebee Cloud relay key

### DIFF
--- a/charts/nudgebee-agent/Chart.yaml
+++ b/charts/nudgebee-agent/Chart.yaml
@@ -29,7 +29,7 @@ annotations:
 # these are set to the right value by .github/workflows/release.yaml
 # we use 0.0.1 as a placeholder for the version` because Helm wont allow `0.0.0` and we want to be able to run
 # `helm install` on development checkouts without updating this file. the version doesn't matter in that case anyway
-version: 0.1.5
+version: 0.1.6
 appVersion: 0.1.3
 dependencies:
 - name: opencost

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -190,9 +190,15 @@ runner:
     auth_secret_key: ""
     # Relay Ed25519 public key. Lets the agent verify relay-signed requests and
     # authorize UI-triggered workload mutations (delete/create/replace/restart/
-    # scale). The UI install command populates this from the server's
-    # SIGNING_PUBLIC_KEY. Empty = relay signatures ignored (mutations stay 401).
-    relay_signing_public_key: ''
+    # scale). Default is Nudgebee Cloud's relay key, paired with the
+    # `relay_address`/`endpoint` SaaS defaults above — so a plain `helm install`
+    # against Nudgebee Cloud authorizes mutations out of the box. The UI install
+    # command also sets this (--set-string) from the server's SIGNING_PUBLIC_KEY,
+    # which overrides the default. Override it when pointing `relay_address` at a
+    # self-hosted relay (use that relay's SIGNING_PUBLIC_KEY); comma-separate
+    # multiple keys during a key rotation. Empty = relay signatures ignored
+    # (mutations stay 401).
+    relay_signing_public_key: 'KhVqjHRomIZCykcVnxlCoZBUr932GqbaullQd4G/+Zs='
   serviceAccount:
     annotations: {}
 nodeAgent:


### PR DESCRIPTION
# Description

The `nudgebee-agent` chart already defaults the SaaS prod triple — `runner.relay_address: wss://relay.nudgebee.com/register` and `runner.nudgebee.endpoint: https://collector.nudgebee.com` — but left `runner.nudgebee.relay_signing_public_key: ''`.

With an empty relay key, the agent's relay-signature verifier is **disabled** (`relaysig.NewVerifier("")` → `Enabled()==false`). The relay signs every k8s request body, but the agent ignores the signature, so relay-signed **UI mutations fall through to the light-action allowlist** in `pkg/auth.Validate`. Since mutations are deliberately *not* light actions, every workload mutation is rejected:

```
auth: action "replace_workload" not in light-action allowlist
```

(also `delete_pod`, `create_workload`, `delete_workload`, `rollout_restart`, `replica_rightsizing`, …). **Reads keep working** because read primitives *are* light actions — the classic "reads fine, mutations 401" symptom.

Any agent installed against Nudgebee Cloud **without** the in-app install command — manual `helm install`, CI-driven installs — hits this, because only the UI install command injects the key (`--set-string runner.nudgebee.relay_signing_public_key=...` from the server's `SIGNING_PUBLIC_KEY`).

## Fix

Pair the key with the already-defaulted relay: default `relay_signing_public_key` to Nudgebee Cloud's relay **public** Ed25519 key, so a plain `helm install` against Cloud authorizes mutations out of the box.

- The value is a **public verification key** (no secret) — already served publicly at `/api/public/app_config`, and cross-verified against the prod cluster's `nudgebee` secret `SIGNING_PUBLIC_KEY`.
- Same SaaS-default posture as the relay/endpoint URLs the chart already ships.
- The UI install command still overrides it via `--set-string`.
- Self-hosted relays override it alongside `relay_address` (the comment now says so); comma-separate multiple keys during a rotation.
- No regression for self-hosted: a wrong/empty key both fall through to light-actions (reads OK, mutations 401) — identical observable behavior.

Chart version bumped 0.1.5 → 0.1.6 (RC releases derive their tag from `Chart.yaml` version).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Diagnosed live on the `iteration-prod` agent (and the tracked `nudgebee-prod-agent`): both connect to `wss://relay.nudgebee.com` with **no** `RELAY_SIGNING_PUBLIC_KEY` env → reproduces the rejection.
- [x] Confirmed prod relay-server signs (`SIGNING_PRIVATE_KEY` present, recent image) and the public key matches `/api/public/app_config`.
- [x] `helm lint` passes (only the expected missing-subchart-dependency warning).
- [x] Verified the `_helpers.tpl` guard `{{- if .Values.runner.nudgebee.relay_signing_public_key }}` now renders the `RELAY_SIGNING_PUBLIC_KEY` env (empty default previously skipped it — matching the broken live state).

## Review Notes → Risks & Counterarguments

- **Prod key in a public/OSS chart** — it's a public signature-verification key, already disclosed via `/api/public/app_config`, and consistent with the chart's existing `relay.nudgebee.com` / `collector.nudgebee.com` defaults.
- **Key rotation** — the verifier accepts comma-separated keys, so rotation publishes old+new; chart-default agents are no worse than today (no key at all).

## Rollout note (not in this PR)

`iteration-prod` and `nudgebee-prod-agent` pin chart versions, so they won't pick up the new default until upgraded. Immediate unblock for a pinned release:

```
helm upgrade <release> -n <ns> --reuse-values \
  --set-string runner.nudgebee.relay_signing_public_key=KhVqjHRomIZCykcVnxlCoZBUr932GqbaullQd4G/+Zs=
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)