### PR TITLE
fix(scanners): own copied pull-secrets at create time so they GC with the Job

### DIFF
--- a/runner/pkg/scanners/primitives.go
+++ b/runner/pkg/scanners/primitives.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
@@ -100,8 +101,16 @@ func (r *Runner) handleScheduleJob(ctx context.Context, params map[string]any) (
 		if err := r.resumeJob(ctx, created.Name); err != nil {
 			// Couldn't release the Job; delete it so we don't leave a suspended Job
 			// idling forever (its owned pull-secret copies are GC'd along with it).
-			_ = r.Client.BatchV1().Jobs(r.Namespace).Delete(ctx, created.Name,
-				metav1.DeleteOptions{PropagationPolicy: ptr.To(metav1.DeletePropagationBackground)})
+			// resumeJob most often fails because ctx was cancelled/timed out, so the
+			// cleanup Delete must run on a detached (but still bounded) context —
+			// reusing ctx would make the Delete fail immediately and leak the Job.
+			cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
+			defer cancel()
+			if delErr := r.Client.BatchV1().Jobs(r.Namespace).Delete(cleanupCtx, created.Name,
+				metav1.DeleteOptions{PropagationPolicy: ptr.To(metav1.DeletePropagationBackground)}); delErr != nil {
+				slog.Error("schedule_k8s_job: failed to delete suspended job after resume failure; it will idle until manual cleanup",
+					"job_name", created.Name, "error", delErr)
+			}
 			return nil, fmt.Errorf("schedule_k8s_job: resume suspended job: %w", err)
 		}
 	}

--- a/runner/pkg/scanners/primitives.go
+++ b/runner/pkg/scanners/primitives.go
@@ -14,6 +14,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 )
 
 // schedule_k8s_job
@@ -68,23 +70,41 @@ func (r *Runner) handleScheduleJob(ctx context.Context, params map[string]any) (
 	// Opt-in: make the target workload's image-pull credentials available so the
 	// Job can pull a private image. Gated by AutoCopyPullSecrets — when off, the
 	// field is ignored and no credentials are read or copied.
-	var copiedPullSecrets []*corev1.Secret
+	//
+	// Ordering matters: the copies must be owned by the Job (so they are GC'd with
+	// it), but the ownerReference needs the Job's UID, and the agent has `create`
+	// but not `update` on secrets — so it can't attach the reference after the
+	// fact. We therefore create the Job SUSPENDED (its pod won't start, so it
+	// can't try to pull before the credentials exist), reference the not-yet-
+	// created copies on the pod, create those copies owned by the Job, then resume
+	// it.
+	var pendingPullSecrets []*corev1.Secret
 	if r.AutoCopyPullSecrets && spec.ImagePullSecretsFrom != nil {
-		copiedPullSecrets = r.resolveAndCopyPullSecrets(ctx, *spec.ImagePullSecretsFrom, jobName)
-		for _, s := range copiedPullSecrets {
+		pendingPullSecrets = r.resolvePullSecrets(ctx, *spec.ImagePullSecretsFrom, jobName)
+		for _, s := range pendingPullSecrets {
 			job.Spec.Template.Spec.ImagePullSecrets = append(
 				job.Spec.Template.Spec.ImagePullSecrets, corev1.LocalObjectReference{Name: s.Name})
+		}
+		if len(pendingPullSecrets) > 0 {
+			job.Spec.Suspend = ptr.To(true)
 		}
 	}
 
 	created, err := r.Client.BatchV1().Jobs(r.Namespace).Create(ctx, job, metav1.CreateOptions{})
 	if err != nil {
-		// Don't leak the copied credentials if the Job never came up to own them.
-		r.deleteCopiedSecrets(ctx, copiedPullSecrets)
 		return nil, fmt.Errorf("schedule_k8s_job: create: %w", err)
 	}
-	// GC the copies with the Job (ownerReference; Job TTL cleans both up).
-	r.ownReferencedSecrets(ctx, copiedPullSecrets, created)
+
+	if len(pendingPullSecrets) > 0 {
+		r.createOwnedSecrets(ctx, pendingPullSecrets, created)
+		if err := r.resumeJob(ctx, created.Name); err != nil {
+			// Couldn't release the Job; delete it so we don't leave a suspended Job
+			// idling forever (its owned pull-secret copies are GC'd along with it).
+			_ = r.Client.BatchV1().Jobs(r.Namespace).Delete(ctx, created.Name,
+				metav1.DeleteOptions{PropagationPolicy: ptr.To(metav1.DeletePropagationBackground)})
+			return nil, fmt.Errorf("schedule_k8s_job: resume suspended job: %w", err)
+		}
+	}
 
 	slog.Info("schedule_k8s_job: created",
 		"job_name", created.Name,
@@ -103,6 +123,16 @@ func (r *Runner) handleScheduleJob(ctx context.Context, params map[string]any) (
 		"job_name": created.Name,
 		"job_uuid": jobUUID,
 	}, nil
+}
+
+// resumeJob clears spec.suspend so the Job controller starts the Job's pod. Used
+// after the Job's copied pull secrets have been created. A strategic-merge patch
+// (rather than a read-modify-update) avoids clobbering any concurrent status
+// write and needs only `patch` on jobs, which the agent has.
+func (r *Runner) resumeJob(ctx context.Context, jobName string) error {
+	_, err := r.Client.BatchV1().Jobs(r.Namespace).Patch(
+		ctx, jobName, types.StrategicMergePatchType, []byte(`{"spec":{"suspend":false}}`), metav1.PatchOptions{})
+	return err
 }
 
 // wait_for_k8s_job

--- a/runner/pkg/scanners/pullsecrets.go
+++ b/runner/pkg/scanners/pullsecrets.go
@@ -11,7 +11,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 )
 
 // copiedPullSecretLabel marks Secrets the agent copied for an image scan, so a
@@ -19,16 +18,18 @@ import (
 // is identifiable for a sweep.
 const copiedPullSecretLabel = "nudgebee.com/copied-pull-secret"
 
-// resolveAndCopyPullSecrets makes the image-pull credentials of pod `ref`
-// available in the scanner namespace so a scan Job can pull that workload's
-// (private) image. It returns the names of the copied Secrets, all living in
-// r.Namespace. Best-effort: a secret that can't be read/copied is logged and
+// resolvePullSecrets reads the effective image-pull credentials of pod `ref` and
+// returns Secret objects (in r.Namespace) ready to be created — it does NOT
+// create them. Creation is deferred to createOwnedSecrets so each copy is
+// stamped with an ownerReference to the scan Job at creation time; the agent has
+// `create` but not `update` on secrets, so the reference can't be attached
+// afterwards. Best-effort: a source secret that can't be read is logged and
 // skipped rather than failing the whole scan.
 //
 // The "effective" pull secrets of a pod are its pod-level imagePullSecrets plus
 // its ServiceAccount's imagePullSecrets — both are consulted by the kubelet, so
 // both are needed to reproduce the pull.
-func (r *Runner) resolveAndCopyPullSecrets(ctx context.Context, ref PodRef, jobName string) []*corev1.Secret {
+func (r *Runner) resolvePullSecrets(ctx context.Context, ref PodRef, jobName string) []*corev1.Secret {
 	pod, err := r.Client.CoreV1().Pods(ref.Namespace).Get(ctx, ref.Name, metav1.GetOptions{})
 	if err != nil {
 		slog.Warn("image scan: cannot read target pod for pull secrets; scan may fail to pull a private image",
@@ -58,7 +59,7 @@ func (r *Runner) resolveAndCopyPullSecrets(ctx context.Context, ref PodRef, jobN
 			"namespace", ref.Namespace, "service_account", saName, "error", err)
 	}
 
-	copied := make([]*corev1.Secret, 0, len(names))
+	out := make([]*corev1.Secret, 0, len(names))
 	for name := range names {
 		src, err := r.Client.CoreV1().Secrets(ref.Namespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
@@ -70,10 +71,9 @@ func (r *Runner) resolveAndCopyPullSecrets(ctx context.Context, ref PodRef, jobN
 		if src.Type != corev1.SecretTypeDockerConfigJson && src.Type != corev1.SecretTypeDockercfg {
 			continue
 		}
-		dstName := copiedSecretName(jobName, ref.Namespace, name)
-		dst := &corev1.Secret{
+		out = append(out, &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      dstName,
+				Name:      copiedSecretName(jobName, ref.Namespace, name),
 				Namespace: r.Namespace,
 				Labels: map[string]string{
 					managedByLabel:        managedByValue,
@@ -82,55 +82,34 @@ func (r *Runner) resolveAndCopyPullSecrets(ctx context.Context, ref PodRef, jobN
 			},
 			Type: src.Type,
 			Data: src.Data,
-		}
-		created, err := r.Client.CoreV1().Secrets(r.Namespace).Create(ctx, dst, metav1.CreateOptions{})
-		if err != nil {
-			if apierrors.IsAlreadyExists(err) {
-				// Deterministic name → a prior attempt for this same Job. Reuse it.
-				if existing, getErr := r.Client.CoreV1().Secrets(r.Namespace).Get(ctx, dstName, metav1.GetOptions{}); getErr == nil {
-					copied = append(copied, existing)
-				}
-			} else {
-				slog.Warn("image scan: cannot copy pull secret into scanner namespace",
-					"secret", dstName, "scanner_namespace", r.Namespace, "error", err)
-			}
-			continue
-		}
-		copied = append(copied, created)
+		})
 	}
-	return copied
+	return out
 }
 
-// ownReferencedSecrets points the copied Secrets at the Job so they are
-// garbage-collected when the Job's TTL deletes it. The Job UID is only known
-// after creation, hence this post-create step. Same namespace, so the
-// ownerReference is valid. Operates on the objects returned by the copy step
-// (their ResourceVersion is current), so no extra Get is needed. Best-effort: a
-// failed update only risks a short-lived orphan that namespace cleanup removes.
-func (r *Runner) ownReferencedSecrets(ctx context.Context, secrets []*corev1.Secret, job *batchv1.Job) {
+// createOwnedSecrets creates the resolved pull-secret copies in the scanner
+// namespace, each owned by the scan Job so Kubernetes garbage-collects them when
+// the Job is deleted (by its TTL or the reaper). The ownerReference is stamped
+// at creation time by design: the agent has `create` on secrets but not
+// `update`/`delete`, so it cannot attach the reference (or clean the copy up)
+// after the fact. BlockOwnerDeletion is deliberately left unset — it would
+// require `update` on the Job's finalizers subresource, which the agent lacks,
+// and it is unnecessary for garbage collection. Best-effort: a copy that fails
+// to create is logged; the pod's pull for that registry fails while other
+// registries/layers still scan. AlreadyExists (a retry with the same Job name)
+// is treated as success.
+func (r *Runner) createOwnedSecrets(ctx context.Context, secrets []*corev1.Secret, job *batchv1.Job) {
 	owner := metav1.OwnerReference{
-		APIVersion:         "batch/v1",
-		Kind:               "Job",
-		Name:               job.Name,
-		UID:                job.UID,
-		BlockOwnerDeletion: ptr.To(true),
+		APIVersion: "batch/v1",
+		Kind:       "Job",
+		Name:       job.Name,
+		UID:        job.UID,
 	}
 	for _, s := range secrets {
 		s.OwnerReferences = append(s.OwnerReferences, owner)
-		if _, err := r.Client.CoreV1().Secrets(r.Namespace).Update(ctx, s, metav1.UpdateOptions{}); err != nil {
-			slog.Warn("image scan: cannot set ownerReference on copied pull secret (will rely on sweep)",
-				"secret", s.Name, "error", err)
-		}
-	}
-}
-
-// deleteCopiedSecrets removes copied Secrets, used when Job creation fails so we
-// don't leak credentials. Best-effort.
-func (r *Runner) deleteCopiedSecrets(ctx context.Context, secrets []*corev1.Secret) {
-	for _, s := range secrets {
-		if err := r.Client.CoreV1().Secrets(r.Namespace).Delete(ctx, s.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-			slog.Warn("image scan: cannot delete copied pull secret after job-create failure",
-				"secret", s.Name, "error", err)
+		if _, err := r.Client.CoreV1().Secrets(r.Namespace).Create(ctx, s, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+			slog.Warn("image scan: cannot create copied pull secret in scanner namespace",
+				"secret", s.Name, "scanner_namespace", r.Namespace, "error", err)
 		}
 	}
 }

--- a/runner/pkg/scanners/pullsecrets_test.go
+++ b/runner/pkg/scanners/pullsecrets_test.go
@@ -86,6 +86,12 @@ func TestAutoCopyPullSecrets_CopiesRegistrySecretsAndAttaches(t *testing.T) {
 	if got := len(jobs.Items[0].Spec.Template.Spec.ImagePullSecrets); got != 2 {
 		t.Errorf("job imagePullSecrets = %d; want 2", got)
 	}
+	// The Job is created suspended (so its pod can't pull before the copied
+	// credentials exist) and must be resumed once they do — it must not be left
+	// suspended, or the scan never runs.
+	if s := jobs.Items[0].Spec.Suspend; s != nil && *s {
+		t.Errorf("job left suspended after schedule; resume did not run")
+	}
 }
 
 func TestAutoCopyPullSecrets_DisabledIgnoresField(t *testing.T) {


### PR DESCRIPTION
# Description

Copied image-pull secrets (`imgps-*`) were leaking: they accumulate in the scanner namespace and never get cleaned up.

## Root cause

The copy flow created each Secret **without** an ownerReference, then tried to attach one via a post-create Secret `Update` (`ownReferencedSecrets`). But the runner ServiceAccount has `create` on secrets and **not** `update`/`delete`. Additionally, the ownerReference set `BlockOwnerDeletion: true`, which the GC admission plugin only allows if the caller has `update` on the owner's `finalizers` subresource (`jobs/finalizers`) — which the agent also lacks. So the `Update` was rejected (403) and, being best-effort, silently dropped. Result: every copied secret was orphaned with no ownerReference, so neither the Job's TTL nor the reaper ever garbage-collected it.

(Confirmed on a live cluster: `kubectl auth can-i update secrets` → no, `update jobs/finalizers` → no; observed `imgps-*` secrets with empty ownerReferences.)

## Fix

Stamp the ownerReference at Secret **create** time (needs only `create`, which the agent has). Since the reference needs the Job UID and the pod must not pull before its credentials exist:

1. Resolve the pull secrets (read source, build the copy objects — don't create).
2. Create the Job **suspended**, referencing the not-yet-created copies on its pod.
3. Create the copies **owned by the Job**.
4. Resume the Job (`patch spec.suspend=false` — `patch` on jobs is already granted).

`BlockOwnerDeletion` is dropped (unnecessary for GC, and avoids the `jobs/finalizers` requirement). If resume fails, the Job is deleted so its owned copies GC with it instead of lingering.

**No RBAC/chart change, and no expansion of the agent's secret permissions** (a customer-deployed agent stays at `create`-only on secrets).

## Testing

- Unit test (`TestAutoCopyPullSecrets_CopiesRegistrySecretsAndAttaches`): asserts each copy is Job-owned and the Job is not left suspended.
- Integration test against a real apiserver (`TestPrimitives_RealAPIServer/ScheduleJob_AutoCopyPullSecrets`): confirms the copy is owned by the Job end to end. Both pass; `go build ./...`, `go vet`, `gofmt` clean.

## Notes

- Non-pull-secret scans are unchanged: the Job is only suspended when there are pending copies to create.
- Pairs with the api-server manual-scan tenant fix and the `SCANNER_AUTO_COPY_PULL_SECRETS` enablement (separate PRs) that make private-image scans work in the first place.