### PR TITLE
fix(runner): support chaining kubectl commands with && || ; in K8s CLI action

### DIFF
--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -61,7 +61,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-06-29T04-56-02_c5821d5110f76decc1b7952d8fcb6fb79aaca6cc
+    tag: 2026-07-04T08-07-20_16e73b6bee276ad9e112b06f69d8a88f91e52ec1
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/runner/pkg/kube/exec.go
+++ b/runner/pkg/kube/exec.go
@@ -100,35 +100,63 @@ var verbFlagsWithValue = map[string]struct{}{
 	"--client-key":            {},
 }
 
-// Run parses the command string, validates the verb against the allowlist,
-// and executes kubectl. Stdout, stderr, and exit code are returned together
-// — callers consume all three.
+// rejectedShellTokens are shell metacharacters we refuse rather than silently
+// mis-execute. kubectl is exec'd directly (no shell), so a pipe or redirect
+// would not do what the author expects — and worse, a pipe hands output to a
+// non-kubectl binary, escaping the per-command verb allowlist. Sequential
+// chaining (&&, ||, ;) IS supported (see runSegments); these are not.
+var rejectedShellTokens = map[string]struct{}{
+	"|": {}, "|&": {},
+	">": {}, ">>": {}, "<": {}, "<<": {}, "<<<": {},
+	"&": {}, "&>": {}, "&>>": {},
+}
+
+// segmentSeparators are the sequential list operators that may chain kubectl
+// commands. They map to shell short-circuit semantics in shouldRunSegment.
+var segmentSeparators = map[string]struct{}{
+	"&&": {}, "||": {}, ";": {},
+}
+
+// cmdSegment is one kubectl invocation within a chained command, together with
+// the operator that precedes it ("" for the first segment).
+type cmdSegment struct {
+	op   string   // "", "&&", "||", ";"
+	args []string // verb + args, leading "kubectl" already stripped
+}
+
+// Run parses the command string, validates the verb of every chained segment
+// against the allowlist, and executes kubectl. A command may chain multiple
+// invocations with &&, || and ; (matching shell short-circuit semantics);
+// pipes and redirects are rejected. Stdout, stderr, and exit code are returned
+// together — callers consume all three.
 func (k *KubectlExecutor) Run(ctx context.Context, command string) (map[string]any, error) {
 	if command == "" {
 		return nil, errors.New("kubectl: command is required")
 	}
-	args, err := shlex.Split(command)
+	tokens, err := shlex.Split(command)
 	if err != nil {
 		return nil, fmt.Errorf("kubectl: parse command: %w", err)
 	}
 
-	// Strip a leading "kubectl" if the caller included it.
-	if len(args) > 0 && args[0] == "kubectl" {
-		args = args[1:]
-	}
-	if len(args) == 0 {
-		return nil, errors.New("kubectl: empty command after stripping prefix")
+	// Reject pipes/redirects up front. shlex yields these as standalone tokens,
+	// so an operator quoted inside an argument (e.g. a label value) is untouched.
+	for _, t := range tokens {
+		if _, bad := rejectedShellTokens[t]; bad {
+			return nil, fmt.Errorf("kubectl: shell operator %q is not supported; chain commands with && , || or ; (no pipes or redirects)", t)
+		}
 	}
 
-	// Resolve the verb past any leading global flags so `kubectl -n ns get
-	// pods` validates as "get", not "-n".
-	verb := firstVerb(args)
-	if verb == "" {
-		return nil, errors.New("kubectl: no verb found (only flags supplied)")
+	segments, err := splitSegments(tokens)
+	if err != nil {
+		return nil, err
 	}
-	if !k.AllowWrite {
-		if _, ok := allowedKubectlVerbs[verb]; !ok {
-			return nil, fmt.Errorf("kubectl: verb %q not in read-only allowlist; enable runner.enableWritePermissions for writes, or route mutating actions through pkg/mutate", verb)
+
+	// Validate every segment BEFORE running any, so a chain such as
+	// `get pods && delete pod foo` is rejected atomically — the read-only verb
+	// allowlist must hold for each command, not merely the first one.
+	for _, seg := range segments {
+		if err := k.validateSegment(seg.args); err != nil {
+			return nil, err
 		}
 	}
 
@@ -136,35 +164,120 @@ func (k *KubectlExecutor) Run(ctx context.Context, command string) (map[string]a
 	if bin == "" {
 		bin = "kubectl"
 	}
+	return k.runSegments(ctx, bin, segments)
+}
 
-	var stdout, stderr bytes.Buffer
-	// args are validated upstream against a read-verb allowlist
-	// (pkg/kube/dynamic.go) before reaching this shell-out.
-	cmd := exec.CommandContext(ctx, bin, args...) //nolint:gosec // verb-allowlist enforced
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	runErr := cmd.Run()
+// splitSegments partitions shlex tokens into command segments on the sequential
+// operators && || ; . A leading "kubectl" is stripped from each segment. Empty
+// segments (a leading/trailing/doubled operator) are an error.
+func splitSegments(tokens []string) ([]cmdSegment, error) {
+	var segments []cmdSegment
+	op := "" // operator preceding the segment currently being accumulated
+	var cur []string
 
-	// ProcessState is nil if the process never started (e.g. kubectl not
-	// on PATH); the real-exec-failure branch below turns that into an error.
-	exitCode := -1
-	if cmd.ProcessState != nil {
-		exitCode = cmd.ProcessState.ExitCode()
+	flush := func(nextOp string) error {
+		args := cur
+		if len(args) > 0 && args[0] == "kubectl" {
+			args = args[1:]
+		}
+		if len(args) == 0 {
+			return errors.New("kubectl: empty command segment; && , || and ; each need a command on both sides")
+		}
+		segments = append(segments, cmdSegment{op: op, args: args})
+		op = nextOp
+		cur = nil
+		return nil
 	}
-	out := map[string]any{
+
+	for _, t := range tokens {
+		if _, isSep := segmentSeparators[t]; isSep {
+			if err := flush(t); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		cur = append(cur, t)
+	}
+	if err := flush(""); err != nil {
+		return nil, err
+	}
+	return segments, nil
+}
+
+// validateSegment resolves the verb past leading global flags and enforces the
+// read-only allowlist when write mode is off.
+func (k *KubectlExecutor) validateSegment(args []string) error {
+	verb := firstVerb(args)
+	if verb == "" {
+		return errors.New("kubectl: no verb found (only flags supplied)")
+	}
+	if !k.AllowWrite {
+		if _, ok := allowedKubectlVerbs[verb]; !ok {
+			return fmt.Errorf("kubectl: verb %q not in read-only allowlist; enable runner.enableWritePermissions for writes, or route mutating actions through pkg/mutate", verb)
+		}
+	}
+	return nil
+}
+
+// shouldRunSegment applies shell short-circuit semantics: a segment after && runs
+// only when the previous command succeeded, after || only when it failed, and
+// after ; always. &&/|| are equal-precedence and left-associative, so evaluating
+// left-to-right against the carried exit code reproduces bash for mixed chains.
+func shouldRunSegment(op string, prevExit int) bool {
+	switch op {
+	case "&&":
+		return prevExit == 0
+	case "||":
+		return prevExit != 0
+	default: // ";" — unconditional
+		return true
+	}
+}
+
+// runSegments executes segments in order, honoring &&/||/; short-circuiting, and
+// aggregates their output. exit_code is the status of the last command that
+// actually ran (skipped segments carry the prior status forward, as in a shell).
+func (k *KubectlExecutor) runSegments(ctx context.Context, bin string, segments []cmdSegment) (map[string]any, error) {
+	var stdout, stderr bytes.Buffer
+	exitCode := 0 // status carried between segments for &&/|| short-circuit
+
+	for i, seg := range segments {
+		if i > 0 && !shouldRunSegment(seg.op, exitCode) {
+			continue
+		}
+
+		// Verb allowlist enforced per segment in validateSegment above.
+		cmd := exec.CommandContext(ctx, bin, seg.args...) //nolint:gosec // verb-allowlist enforced per segment
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		runErr := cmd.Run()
+
+		// ProcessState is nil if the process never started (e.g. kubectl not on
+		// PATH); the real-exec-failure branch below turns that into an error.
+		if cmd.ProcessState != nil {
+			exitCode = cmd.ProcessState.ExitCode()
+		} else {
+			exitCode = -1
+		}
+
+		if runErr != nil {
+			// kubectl returns non-zero for cases the caller may want to inspect
+			// (e.g. "not found"); surface those as data via exit_code. A real
+			// exec failure (binary missing) is a hard error and stops the chain.
+			var exitErr *exec.ExitError
+			if !errors.As(runErr, &exitErr) {
+				return map[string]any{
+					"stdout":    stdout.String(),
+					"stderr":    stderr.String(),
+					"exit_code": exitCode,
+				}, fmt.Errorf("kubectl exec: %w", runErr)
+			}
+		}
+	}
+
+	return map[string]any{
 		"stdout":    stdout.String(),
 		"stderr":    stderr.String(),
 		"exit_code": exitCode,
-	}
-	// kubectl returns non-zero for cases the caller may want to inspect
-	// (e.g. "not found"); surface as data, not Go error.
-	if runErr != nil {
-		// Real exec failure (e.g. binary not found) is a hard error.
-		var exitErr *exec.ExitError
-		if errors.As(runErr, &exitErr) {
-			return out, nil
-		}
-		return out, fmt.Errorf("kubectl exec: %w", runErr)
-	}
-	return out, nil
+	}, nil
 }

--- a/runner/pkg/kube/exec.go
+++ b/runner/pkg/kube/exec.go
@@ -181,6 +181,15 @@ func splitSegments(tokens []string) ([]cmdSegment, error) {
 			args = args[1:]
 		}
 		if len(args) == 0 {
+			// A trailing ";" is a valid shell no-op ("kubectl get pods ;") — drop it.
+			if op == ";" && nextOp == "" {
+				return nil
+			}
+			// Nothing but a prefix: an empty command or a bare "kubectl".
+			if op == "" && nextOp == "" {
+				return errors.New("kubectl: empty command after stripping prefix")
+			}
+			// A leading, trailing, or doubled && / || is genuinely malformed.
 			return errors.New("kubectl: empty command segment; && , || and ; each need a command on both sides")
 		}
 		segments = append(segments, cmdSegment{op: op, args: args})
@@ -234,14 +243,29 @@ func shouldRunSegment(op string, prevExit int) bool {
 	}
 }
 
+// execResult packages the aggregated stdout/stderr and the running exit code
+// into the map shape the action handler consumes.
+func execResult(stdout, stderr *bytes.Buffer, exitCode int) map[string]any {
+	return map[string]any{
+		"stdout":    stdout.String(),
+		"stderr":    stderr.String(),
+		"exit_code": exitCode,
+	}
+}
+
 // runSegments executes segments in order, honoring &&/||/; short-circuiting, and
 // aggregates their output. exit_code is the status of the last command that
 // actually ran (skipped segments carry the prior status forward, as in a shell).
+// A cancelled or timed-out context stops the chain and propagates its error.
 func (k *KubectlExecutor) runSegments(ctx context.Context, bin string, segments []cmdSegment) (map[string]any, error) {
 	var stdout, stderr bytes.Buffer
 	exitCode := 0 // status carried between segments for &&/|| short-circuit
 
 	for i, seg := range segments {
+		// Don't start another kubectl once the context is done (deadline/cancel).
+		if err := ctx.Err(); err != nil {
+			return execResult(&stdout, &stderr, exitCode), err
+		}
 		if i > 0 && !shouldRunSegment(seg.op, exitCode) {
 			continue
 		}
@@ -260,24 +284,24 @@ func (k *KubectlExecutor) runSegments(ctx context.Context, bin string, segments 
 			exitCode = -1
 		}
 
+		// A cancelled/timed-out context kills the process, so cmd.Run returns an
+		// ExitError that must NOT be mistaken for a normal non-zero kubectl exit
+		// (which we'd otherwise surface as data or, on the last segment, as
+		// success). Propagate the context error and stop the chain.
+		if err := ctx.Err(); err != nil {
+			return execResult(&stdout, &stderr, exitCode), err
+		}
+
 		if runErr != nil {
 			// kubectl returns non-zero for cases the caller may want to inspect
 			// (e.g. "not found"); surface those as data via exit_code. A real
 			// exec failure (binary missing) is a hard error and stops the chain.
 			var exitErr *exec.ExitError
 			if !errors.As(runErr, &exitErr) {
-				return map[string]any{
-					"stdout":    stdout.String(),
-					"stderr":    stderr.String(),
-					"exit_code": exitCode,
-				}, fmt.Errorf("kubectl exec: %w", runErr)
+				return execResult(&stdout, &stderr, exitCode), fmt.Errorf("kubectl exec: %w", runErr)
 			}
 		}
 	}
 
-	return map[string]any{
-		"stdout":    stdout.String(),
-		"stderr":    stderr.String(),
-		"exit_code": exitCode,
-	}, nil
+	return execResult(&stdout, &stderr, exitCode), nil
 }

--- a/runner/pkg/kube/exec_test.go
+++ b/runner/pkg/kube/exec_test.go
@@ -295,6 +295,38 @@ func TestKubectl_RejectsPipesAndRedirects(t *testing.T) {
 	}
 }
 
+func TestKubectl_Chained_AcceptsTrailingSemicolon(t *testing.T) {
+	// A trailing ";" is a valid shell no-op and must not be rejected.
+	bin, counter := fakeKubectl(t, 0)
+	k := &KubectlExecutor{BinaryPath: bin}
+	out, err := k.Run(context.Background(), "kubectl get pods ;")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out["exit_code"] != 0 {
+		t.Errorf("exit_code = %v; want 0", out["exit_code"])
+	}
+	if n := callCount(t, counter); n != 1 {
+		t.Errorf("segments executed = %d; want 1", n)
+	}
+}
+
+func TestKubectl_Chained_RespectsCancelledContext(t *testing.T) {
+	// A done context stops the chain before any kubectl runs and propagates the
+	// context error rather than reporting success.
+	bin, counter := fakeKubectl(t, 0)
+	k := &KubectlExecutor{BinaryPath: bin}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := k.Run(ctx, "kubectl get pods && kubectl get svc")
+	if err == nil {
+		t.Error("expected a context error")
+	}
+	if n := callCount(t, counter); n != 0 {
+		t.Errorf("no segment should run under a cancelled context; got %d", n)
+	}
+}
+
 func TestKubectl_RejectsEmptySegments(t *testing.T) {
 	k := &KubectlExecutor{BinaryPath: "/usr/bin/true"}
 	for _, cmd := range []string{

--- a/runner/pkg/kube/exec_test.go
+++ b/runner/pkg/kube/exec_test.go
@@ -2,6 +2,9 @@ package kube
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -133,5 +136,175 @@ func TestKubectl_StripsLeadingKubectl(t *testing.T) {
 	}
 	if out["exit_code"] != 0 {
 		t.Errorf("got exit_code %v", out["exit_code"])
+	}
+}
+
+// fakeKubectl writes a stand-in kubectl script that logs each invocation's args
+// to a counter file and exits with the given code. Returns the binary path and
+// the counter path so tests can assert how many segments actually executed.
+func fakeKubectl(t *testing.T, exitCode int) (bin, counter string) {
+	t.Helper()
+	dir := t.TempDir()
+	counter = filepath.Join(dir, "calls.log")
+	bin = filepath.Join(dir, "kubectl.sh")
+	script := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$*\" >> %q\nexit %d\n", counter, exitCode)
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return bin, counter
+}
+
+func callCount(t *testing.T, counter string) int {
+	t.Helper()
+	data, err := os.ReadFile(counter)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0
+		}
+		t.Fatal(err)
+	}
+	s := strings.TrimSpace(string(data))
+	if s == "" {
+		return 0
+	}
+	return len(strings.Split(s, "\n"))
+}
+
+func TestKubectl_ChainedCommands_Issue33447(t *testing.T) {
+	// Regression for #33447: two valid kubectl commands joined with && used to
+	// collapse into one invocation (the second command's tokens became NAME args
+	// of the first), yielding "name cannot be provided when a selector is
+	// specified". Both segments must now run as separate kubectl processes.
+	bin, counter := fakeKubectl(t, 0)
+	k := &KubectlExecutor{BinaryPath: bin}
+	cmd := "kubectl get pods -n default --field-selector status.phase=Failed -o wide && " +
+		"kubectl get pods -n default --field-selector status.phase=Succeeded -o wide"
+	out, err := k.Run(context.Background(), cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out["exit_code"] != 0 {
+		t.Errorf("exit_code = %v; want 0", out["exit_code"])
+	}
+	if n := callCount(t, counter); n != 2 {
+		t.Errorf("segments executed = %d; want 2", n)
+	}
+}
+
+func TestKubectl_Chained_AcceptsSequentialOperators(t *testing.T) {
+	bin, _ := fakeKubectl(t, 0)
+	k := &KubectlExecutor{BinaryPath: bin}
+	for _, cmd := range []string{
+		"kubectl get pods && kubectl get svc",
+		"kubectl get pods ; kubectl top nodes",
+		"kubectl get pods || describe deployment foo",
+		"get pods && get svc && top nodes",
+	} {
+		if _, err := k.Run(context.Background(), cmd); err != nil {
+			t.Errorf("%s: unexpected error: %v", cmd, err)
+		}
+	}
+}
+
+func TestKubectl_Chained_ValidatesEverySegment(t *testing.T) {
+	// The read-only allowlist must hold for EACH chained command, not just the
+	// first — otherwise `get && delete` would bypass it. The whole chain is
+	// rejected before anything executes.
+	bin, counter := fakeKubectl(t, 0)
+	k := &KubectlExecutor{BinaryPath: bin}
+	for _, cmd := range []string{
+		"kubectl get pods && kubectl delete pod foo",
+		"kubectl get pods ; kubectl scale deploy foo --replicas=0",
+		"kubectl delete pod foo || kubectl get pods", // mutating verb in the FIRST segment
+	} {
+		_, err := k.Run(context.Background(), cmd)
+		if err == nil {
+			t.Errorf("%s: expected rejection (mutating verb in a segment)", cmd)
+		}
+	}
+	if n := callCount(t, counter); n != 0 {
+		t.Errorf("no segment should have executed on rejection; got %d", n)
+	}
+}
+
+func TestKubectl_Chained_ShortCircuit(t *testing.T) {
+	tests := []struct {
+		name      string
+		exitCode  int
+		command   string
+		wantCalls int
+		wantExit  int
+	}{
+		{"&& stops on failure", 1, "get pods && get svc", 1, 1},
+		{"&& continues on success", 0, "get pods && get svc", 2, 0},
+		{"|| skips on success", 0, "get pods || get svc", 1, 0},
+		{"|| runs on failure", 1, "get pods || get svc", 2, 1},
+		{"; always runs both", 1, "get pods ; get svc", 2, 1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bin, counter := fakeKubectl(t, tc.exitCode)
+			k := &KubectlExecutor{BinaryPath: bin}
+			out, err := k.Run(context.Background(), tc.command)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if n := callCount(t, counter); n != tc.wantCalls {
+				t.Errorf("segments executed = %d; want %d", n, tc.wantCalls)
+			}
+			if out["exit_code"] != tc.wantExit {
+				t.Errorf("exit_code = %v; want %d", out["exit_code"], tc.wantExit)
+			}
+		})
+	}
+}
+
+func TestKubectl_Chained_AllowWrite_PermitsMutations(t *testing.T) {
+	bin, counter := fakeKubectl(t, 0)
+	k := &KubectlExecutor{BinaryPath: bin, AllowWrite: true}
+	out, err := k.Run(context.Background(), "kubectl delete pod a && kubectl delete pod b")
+	if err != nil {
+		t.Fatalf("unexpected error with AllowWrite: %v", err)
+	}
+	if out["exit_code"] != 0 {
+		t.Errorf("exit_code = %v; want 0", out["exit_code"])
+	}
+	if n := callCount(t, counter); n != 2 {
+		t.Errorf("segments executed = %d; want 2", n)
+	}
+}
+
+func TestKubectl_RejectsPipesAndRedirects(t *testing.T) {
+	bin, counter := fakeKubectl(t, 0)
+	k := &KubectlExecutor{BinaryPath: bin}
+	for _, cmd := range []string{
+		"kubectl get pods | grep Running",
+		"kubectl get pods > out.txt",
+		"kubectl get pods >> out.txt",
+		"kubectl logs foo & ",
+	} {
+		_, err := k.Run(context.Background(), cmd)
+		if err == nil {
+			t.Errorf("%s: expected rejection (pipe/redirect)", cmd)
+		} else if !strings.Contains(err.Error(), "not supported") {
+			t.Errorf("%s: error %q should explain the operator is unsupported", cmd, err.Error())
+		}
+	}
+	if n := callCount(t, counter); n != 0 {
+		t.Errorf("no segment should have executed; got %d", n)
+	}
+}
+
+func TestKubectl_RejectsEmptySegments(t *testing.T) {
+	k := &KubectlExecutor{BinaryPath: "/usr/bin/true"}
+	for _, cmd := range []string{
+		"kubectl get pods &&",
+		"&& kubectl get pods",
+		"kubectl get pods ; ; kubectl get svc",
+		"kubectl get pods || || kubectl get svc",
+	} {
+		if _, err := k.Run(context.Background(), cmd); err == nil {
+			t.Errorf("%s: expected rejection (empty command segment)", cmd)
+		}
 	}
 }


### PR DESCRIPTION
# Description

The **K8s CLI action** (`kubectl_command_executor`) fails when two valid kubectl commands are joined with `&&`. Reported in **nudgebee/nudgebee-enterprise#33447** (runbook template "Clean Up Evicted and Failed Pods"):

```
kubectl get pods -n <ns> --field-selector status.phase=Failed -o wide && kubectl get pods -n <ns> --field-selector status.phase=Succeeded -o wide
```
```
error: name cannot be provided when a selector is specified
```

**Root cause:** `KubectlExecutor.Run` tokenized the command with `shlex.Split` and exec'd a **single** kubectl with no shell (`exec.CommandContext(ctx, "kubectl", args...)`). `shlex` treats `&&` as an ordinary word, so every token from `&&` onward (`&&`, `kubectl`, `get`, `pods`, …) became **positional NAME arguments** of the first `kubectl get pods`. With `--field-selector` also set, kubectl emits exactly `name cannot be provided when a selector is specified`. Only the *first* verb was ever allowlist-checked.

## What changed

`runner/pkg/kube/exec.go`:
- Split the command into **segments** on the sequential operators `&&`, `||`, `;` and run each as its own kubectl process, with shell **short-circuit** semantics (`&&` runs on success, `||` on failure, `;` always). `&&`/`||` are equal-precedence, left-associative, so evaluating left-to-right against the carried exit code reproduces bash for mixed chains. stdout/stderr are aggregated; `exit_code` is the last executed command's status.
- **Every segment's verb is validated against the read-only allowlist *before any segment runs*** — so `get pods && delete pod foo` is rejected atomically, not after executing the read half. The per-command allowlist guarantee is preserved for each command, not just the first.
- **Pipes and redirects are rejected** with a clear error. Without a shell we can't pipe anyway, and piping to a non-kubectl binary (`grep`, `awk`) would escape the verb allowlist — out of scope by design.
- Single (unchained) commands are unchanged: one segment, same behavior as before.

`runner/pkg/kube/exec_test.go`: the exact reported command, per-segment allowlist enforcement (0 executions on rejection), all five short-circuit cases, `AllowWrite` chained mutations, pipe/redirect rejection, empty-segment rejection.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] `go test ./pkg/kube/` — all pass (existing + new)
- [x] `go vet ./pkg/kube/` and `gofmt` — clean
- [ ] golangci-lint — blocked locally by a go1.25-vs-module-go1.26.3 toolchain mismatch; relies on CI to lint

## Review Notes → Risks & Counterarguments

- **Security is the crux.** The read-only allowlist previously only checked the first verb. This change validates *every* chained segment up front and refuses to execute any if one fails validation. If you review one thing, review `validateSegment` being called for all segments before `runSegments`, and `TestKubectl_Chained_ValidatesEverySegment`.
- **Pipes/redirects unsupported.** Rejected rather than shelled out, to keep the "kubectl-only, verb-allowlisted" model. If users need `| grep`, that's a separate, larger decision (would need a shell + full-string verb parsing).
- **Glued operators** (`a&&b` with no surrounding spaces) are *not* split — `shlex` yields them as one token. Standard usage has spaces around operators (as in the report). Noted as a known minor limitation rather than adding a raw-string pre-parser that would fight shlex quoting.
- **Cross-repo issue:** the fix lives here (`k8s-agent`) but the issue is on `nudgebee-enterprise`, so GitHub won't auto-close it — please close nudgebee/nudgebee-enterprise#33447 manually on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)