### PR TITLE
chore(chart): add values.schema.json to catch typo'd/unknown top-level keys

### DIFF
--- a/charts/nudgebee-agent/values.schema.json
+++ b/charts/nudgebee-agent/values.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "nudgebee-agent",
+  "description": "Top-level values accepted by the nudgebee-agent chart. Rejects unknown top-level keys (e.g. typos, or keys copied from unrelated charts/docs) so a misconfigured value fails at `helm install`/`upgrade` time instead of silently no-oping.",
+  "type": "object",
+  "properties": {
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "enablePrometheusStack": { "type": "boolean" },
+    "automountServiceAccountToken": { "type": "boolean" },
+    "globalConfig": { "type": "object" },
+    "enableServiceMonitors": { "type": "boolean" },
+    "kubewatch": { "type": "object" },
+    "runnerServiceAccount": { "type": "object" },
+    "runner": { "type": "object" },
+    "nodeAgent": { "type": "object" },
+    "opencost": { "type": "object" },
+    "rsa": { "type": ["object", "null"] },
+    "openshift": { "type": "object" },
+    "opentelemetry-collector": { "type": "object" },
+    "clickhouse": { "type": "object" },
+    "alertmanager": { "type": "object" }
+  },
+  "additionalProperties": false
+}

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -61,7 +61,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-07-04T08-07-20_16e73b6bee276ad9e112b06f69d8a88f91e52ec1
+    tag: 2026-07-04T11-16-26_e1730394cb5e420b38fb79351f2a23ab46490ede
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.


### PR DESCRIPTION
## Summary

A customer values.yaml (`nudgebee-on-prem-test`) set a top-level `existingPrometheus.url` key that doesn't exist anywhere in this chart, so it silently no-oped instead of wiring up OpenCost's Prometheus endpoint. `PROMETHEUS_SERVER_ENDPOINT` stayed empty and the OpenCost pod crash-looped for days before the misconfiguration was traced back to that key.

This adds `charts/nudgebee-agent/values.schema.json` — Helm's native JSON-Schema values validation. It whitelists the chart's real top-level keys and sets `additionalProperties: false`, so `helm install`/`helm upgrade` now fails fast and locally with a clear error for any unrecognized top-level key, instead of silently ignoring it.

Nested subchart-owned trees (`opencost`, `opentelemetry-collector`, `clickhouse`, etc.) are left permissive (`type: object` only) since those are third-party chart values we don't want to have to keep re-syncing as upstream changes.

`.github/configs/ct.yaml` already has `validate-chart-schema: true`, so the existing `helm-dev-lint.yml` / `helm-prod-test.yml` CI workflows pick this up automatically — no workflow changes needed.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (chart upgrade requires user action)
- [ ] Documentation only
- [ ] CI / tooling

Note: this is non-breaking for any values.yaml that only uses documented keys. It will start rejecting values files that contain an *unrecognized* top-level key on their next upgrade to a chart version including this schema — surfacing a pre-existing misconfiguration rather than changing any rendered output.

## Chart version

- [x] No version bump needed (`version`/`appVersion` in `Chart.yaml` are set automatically by `.github/workflows/release.yaml`, per the comment at the top of that file)

## Test plan

- [x] Verified schema semantics with a local JSON-Schema validation pass (Python `jsonschema`, draft-07) since a Helm binary wasn't available in this environment:
  - Default `charts/nudgebee-agent/values.yaml` validates cleanly against the new schema.
  - Adding the exact `existingPrometheus.url` key from the incident is correctly rejected: `Additional properties are not allowed ('existingPrometheus' was unexpected)`.
- [ ] `helm lint charts/nudgebee-agent` / `ct lint` (should be exercised by CI on this PR)
- [ ] `helm template` output reviewed — unaffected, this change adds no templates

## Related issues

Follow-up from the `nudgebee-on-prem-test` OpenCost disconnection investigation (Slack thread, not a tracked GitHub issue).


---
_Generated by [Claude Code](https://claude.ai/code/session_01UGY1D7tdoA6foes12SRQrr)_