### PR TITLE
fix(chart): show chart version in install NOTES banner, not stale appVersion

### DIFF
--- a/charts/nudgebee-agent/templates/NOTES.txt
+++ b/charts/nudgebee-agent/templates/NOTES.txt
@@ -7,7 +7,7 @@
                   /____/                       
 ============================================================================
 
-Thank you for installing {{ .Chart.Name | title }} {{ .Chart.AppVersion }}
+Thank you for installing {{ .Chart.Name | title }} {{ .Chart.Version }}
 
 Visit the web UI at: https://app.nudgebee.com
 

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -61,7 +61,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-07-04T08-07-20_16e73b6bee276ad9e112b06f69d8a88f91e52ec1
+    tag: 2026-07-04T11-16-26_e1730394cb5e420b38fb79351f2a23ab46490ede
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.


### PR DESCRIPTION
# Description

After `helm upgrade` to chart version 0.1.5, the post-install NOTES banner still printed **"Thank you for installing Nudgebee-Agent 0.1.3"**.

Root cause: `charts/nudgebee-agent/templates/NOTES.txt` rendered `{{ .Chart.AppVersion }}`, but `appVersion` (0.1.3) lags the chart `version` (0.1.5) in `Chart.yaml` — they drift because a chart bump doesn't necessarily bump appVersion. The banner should reflect the chart version actually installed, so switch it to `{{ .Chart.Version }}`.

Fixes nudgebee/nudgebee-enterprise#33386

## Change
- `NOTES.txt`: `{{ .Chart.AppVersion }}` → `{{ .Chart.Version }}`.

## Testing
- `helm lint charts/nudgebee-agent` passes (only the expected missing-subchart-dependency warning).
- The banner now renders the chart `version` (0.1.5), which is what `helm upgrade` installed, and stays correct regardless of future appVersion drift.