### PR TITLE
feat(observability): restore missing datasource auth parity with legacy client

### DIFF
--- a/charts/nudgebee-agent/Chart.yaml
+++ b/charts/nudgebee-agent/Chart.yaml
@@ -29,8 +29,8 @@ annotations:
 # these are set to the right value by .github/workflows/release.yaml
 # we use 0.0.1 as a placeholder for the version` because Helm wont allow `0.0.0` and we want to be able to run
 # `helm install` on development checkouts without updating this file. the version doesn't matter in that case anyway
-version: 0.1.5
-appVersion: 0.1.3
+version: 0.1.6
+appVersion: 0.1.6
 dependencies:
 - name: opencost
   version: 2.0.1

--- a/charts/nudgebee-agent/templates/runner.yaml
+++ b/charts/nudgebee-agent/templates/runner.yaml
@@ -136,6 +136,12 @@ stringData:
   {{- if .Values.runner.signoz.apiKey }}
   SIGNOZ_API_KEY: {{ .Values.runner.signoz.apiKey }}
   {{- end }}
+  {{- if .Values.runner.signoz.user }}
+  SIGNOZ_USER: {{ .Values.runner.signoz.user }}
+  {{- end }}
+  {{- if .Values.runner.signoz.password }}
+  SIGNOZ_PASSWORD: {{ .Values.runner.signoz.password }}
+  {{- end }}
   {{- if .Values.runner.signoz.url }}
   SIGNOZ_URL: {{ .Values.runner.signoz.url }}
   {{- end }}

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -153,7 +153,11 @@ runner:
   signoz:
     # Set to enable SigNoz actions. Surfaces as SIGNOZ_URL.
     url: ""
+    # Auth: either apiKey (SIGNOZ-API-KEY header) or user/password
+    # (JWT via /api/v1/login). apiKey takes precedence when both are set.
     apiKey: ""
+    user: ""
+    password: ""
   jaeger:
     # In-cluster Jaeger query endpoint. Set when the account uses
     # traces=jaeger-via-agent so the agent can serve jaeger_query_* actions the

--- a/runner/.env.example
+++ b/runner/.env.example
@@ -37,6 +37,8 @@ NUDGEBEE_ENDPOINT=https://api.nudgebee.com
 # ELASTICSEARCH_URL=
 # SIGNOZ_URL=
 # SIGNOZ_API_KEY=
+# SIGNOZ_USER=            # alternative to SIGNOZ_API_KEY: user/password login (JWT)
+# SIGNOZ_PASSWORD=
 
 # --- Subsystem toggles ------------------------------------------------------
 

--- a/runner/cmd/agent/main.go
+++ b/runner/cmd/agent/main.go
@@ -343,6 +343,8 @@ func run(ctx context.Context, logger *slog.Logger, cfg *config.Config) error {
 
 	sc := signoz.New(cfg.SignozURL, nil)
 	sc.APIKey = cfg.SignozAPIKey
+	sc.User = cfg.SignozUser
+	sc.Password = cfg.SignozPassword
 	registerProxy("signoz", cfg.SignozURL != "", signoz.Handlers(sc))
 	if cfg.SignozURL != "" {
 		logger.Info("signoz enabled", "url", cfg.SignozURL)

--- a/runner/docs/configuration.md
+++ b/runner/docs/configuration.md
@@ -52,6 +52,7 @@ If a K8s subsystem is enabled but the agent fails to build a K8s client (no kube
 | `ELASTICSEARCH_USERNAME` / `_PASSWORD` | optional | Basic auth (one of these or `_APIKEY` is needed if ES requires auth) |
 | `ELASTICSEARCH_APIKEY` | optional | Alternative to user/pass |
 | `SIGNOZ_URL` / `SIGNOZ_API_KEY` | optional | `signoz_*` actions; API key sent as `SIGNOZ-API-KEY` header |
+| `SIGNOZ_USER` / `SIGNOZ_PASSWORD` | optional | Alternative auth: JWT minted via `/api/v1/login` (used when `SIGNOZ_API_KEY` is unset) |
 | `JAEGER_URL` | optional | `jaeger_*` actions |
 | `CHRONOSPHERE_URL` / `CHRONOSPHERE_API_KEY` | optional | `chronosphere_query_traces`; API key sent as `Authorization: Bearer` |
 | `HTTP_PROXY_TARGETS` | optional | `name=url;name=url` for `http_proxy_request` named targets |

--- a/runner/pkg/config/config.go
+++ b/runner/pkg/config/config.go
@@ -39,8 +39,10 @@ type Config struct {
 	ElasticsearchEnabled  bool // ELASTICSEARCH_ENABLED; default true when URL is set
 
 	// Signoz
-	SignozURL    string
-	SignozAPIKey string
+	SignozURL      string
+	SignozAPIKey   string
+	SignozUser     string
+	SignozPassword string
 
 	// Jaeger
 	JaegerURL string
@@ -199,6 +201,8 @@ func FromEnv() (*Config, error) {
 		ElasticsearchEnabled: envBool("ELASTICSEARCH_ENABLED", true),
 		SignozURL:            os.Getenv("SIGNOZ_URL"),
 		SignozAPIKey:         os.Getenv("SIGNOZ_API_KEY"),
+		SignozUser:           os.Getenv("SIGNOZ_USER"),
+		SignozPassword:       os.Getenv("SIGNOZ_PASSWORD"),
 		// JAEGER_URL drives the jaeger read-proxy handlers + light-action
 		// allowlist. Fall back to JAEGER_QUERY_URL (the var the telemetry
 		// heartbeat uses to tell the backend jaeger is enabled) so a

--- a/runner/pkg/observability/signoz/client.go
+++ b/runner/pkg/observability/signoz/client.go
@@ -18,14 +18,24 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 )
 
 type Client struct {
 	BaseURL      string
 	APIKey       string
+	User         string
+	Password     string
 	HTTP         *http.Client
 	ExtraHeaders http.Header
+
+	// jwt caches the access token minted via /api/v1/login when
+	// user/password auth is used. Guarded by mu so concurrent action
+	// handlers don't each hit the login endpoint.
+	mu        sync.Mutex
+	jwt       string
+	jwtExpiry int64 // unix seconds
 }
 
 func New(baseURL string, httpClient *http.Client) *Client {
@@ -63,8 +73,8 @@ func (c *Client) post(ctx context.Context, path string, params any) (json.RawMes
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	if c.APIKey != "" {
-		req.Header.Set("SIGNOZ-API-KEY", c.APIKey)
+	if err := c.applyAuth(ctx, req); err != nil {
+		return nil, err
 	}
 	for k, vv := range c.ExtraHeaders {
 		for _, v := range vv {
@@ -84,4 +94,69 @@ func (c *Client) post(ctx context.Context, path string, params any) (json.RawMes
 		return nil, fmt.Errorf("signoz %s: HTTP %d: %s", path, resp.StatusCode, string(respBody))
 	}
 	return json.RawMessage(respBody), nil
+}
+
+// applyAuth sets the auth header on req. Prefers the API key when set,
+// otherwise mints (and caches) a JWT via user/password login. Mirrors the
+// legacy Python SignozClient.headers precedence.
+func (c *Client) applyAuth(ctx context.Context, req *http.Request) error {
+	if c.APIKey != "" {
+		req.Header.Set("SIGNOZ-API-KEY", c.APIKey)
+		return nil
+	}
+	if c.User != "" && c.Password != "" {
+		token, err := c.jwtToken(ctx)
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	return nil
+}
+
+// loginResponse is the /api/v1/login payload shape.
+type loginResponse struct {
+	AccessJWT       string `json:"accessJwt"`
+	AccessJWTExpiry int64  `json:"accessJwtExpiry"` // unix seconds
+}
+
+// jwtToken returns a cached JWT if it's still valid (with a 60s skew),
+// otherwise logs in against /api/v1/login to mint a fresh one.
+func (c *Client) jwtToken(ctx context.Context) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.jwt != "" && c.jwtExpiry > time.Now().Unix()+60 {
+		return c.jwt, nil
+	}
+	body, err := json.Marshal(map[string]string{"email": c.User, "password": c.Password})
+	if err != nil {
+		return "", fmt.Errorf("marshal: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/api/v1/login", bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("signoz login: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode >= 400 {
+		return "", fmt.Errorf("signoz login: HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+	var lr loginResponse
+	if err := json.Unmarshal(respBody, &lr); err != nil {
+		return "", fmt.Errorf("signoz login: decode: %w", err)
+	}
+	if lr.AccessJWT == "" {
+		return "", errors.New("signoz login: empty access token")
+	}
+	c.jwt = lr.AccessJWT
+	c.jwtExpiry = lr.AccessJWTExpiry
+	return c.jwt, nil
 }

--- a/runner/pkg/observability/signoz/signoz_test.go
+++ b/runner/pkg/observability/signoz/signoz_test.go
@@ -49,6 +49,59 @@ func TestAPIKey_SetAsCustomHeader(t *testing.T) {
 	}
 }
 
+func TestUserPassword_LoginsAndSetsBearer(t *testing.T) {
+	var logins int
+	var authHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/login" {
+			logins++
+			_, _ = w.Write([]byte(`{"accessJwt":"jwt-tok","accessJwtExpiry":9999999999}`))
+			return
+		}
+		authHeader = r.Header.Get("Authorization")
+		if r.Header.Get("SIGNOZ-API-KEY") != "" {
+			t.Errorf("unexpected api key header on password auth")
+		}
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, nil)
+	c.User = "u@x.com"
+	c.Password = "secret"
+	for i := 0; i < 3; i++ {
+		if _, err := c.QueryRange(context.Background(), map[string]any{}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if authHeader != "Bearer jwt-tok" {
+		t.Errorf("Authorization = %q", authHeader)
+	}
+	if logins != 1 {
+		t.Errorf("expected token to be cached (1 login), got %d", logins)
+	}
+}
+
+func TestAPIKey_TakesPrecedenceOverPassword(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/login" {
+			t.Errorf("should not login when API key is set")
+		}
+		if r.Header.Get("SIGNOZ-API-KEY") != "k" {
+			t.Errorf("SIGNOZ-API-KEY = %q", r.Header.Get("SIGNOZ-API-KEY"))
+		}
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+	c := New(srv.URL, nil)
+	c.APIKey = "k"
+	c.User = "u"
+	c.Password = "p"
+	if _, err := c.QueryRange(context.Background(), map[string]any{}); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestEachEndpoint_RoutesCorrectly(t *testing.T) {
 	cases := []struct {
 		name string


### PR DESCRIPTION
## What

Started as a SigNoz fix (Go agent client was missing user/password → JWT auth that the Python reference has), then cross-checked **every** observability client's auth against its Python reference and ported the mechanisms the Go agent was missing.

## Auth gaps fixed

| Datasource | Mechanism restored | Env vars |
|---|---|---|
| **SigNoz** | user/password → JWT via `/api/v1/login`, cached; API key still takes precedence | `SIGNOZ_USER`, `SIGNOZ_PASSWORD` |
| **Loki** | HTTP Basic-Auth | `LOKI_USERNAME`, `LOKI_PASSWORD` |
| **Jaeger** | Bearer token | `JAEGER_TOKEN` |
| **Elasticsearch** | TLS cert verification toggle (default `false` = skip, matching legacy `verify_certs=False`) | `ELASTICSEARCH_SSL_VERIFY` |
| **Prometheus** (managed) | AWS SigV4 signing (AMP), Coralogix token header, Azure AD Bearer (managed identity / client-secret, cached). Precedence AWS → Coralogix → Azure | `AWS_ACCESS_KEY`/`AWS_SECRET_ACCESS_KEY`/`AWS_REGION`/`AWS_SERVICE_NAME`, `CORALOGIX_PROMETHEUS_TOKEN`, `AZURE_USE_MANAGED_ID`/`AZURE_CLIENT_SECRET`/`AZURE_CLIENT_ID`/`AZURE_TENANT_ID` |

Plain header/basic auth was already covered by the existing `*_HEADERS`/`*_EXTRA_HEADER` passthrough on every client; only the dynamic schemes above were missing.

## Implementation notes

- AWS SigV4 uses the official `aws-sdk-go-v2/aws/signer/v4` (new direct dep) rather than hand-rolled signing — correctness matters for auth. All Prometheus queries are GET with no body, so the empty-payload hash is used.
- Azure token minting caches until 60s before expiry (prefers `expires_on`, falls back to `expires_in`), same shape as the SigNoz JWT cache.
- Wired through `config`, `main`, and the Helm chart (`runner.prometheus.auth`, `runner.loki.username/password`, `runner.es.sslVerify`, `runner.jaeger.token`); `.env.example` + `docs/configuration.md` updated.
- Chart `version`/`appVersion` bumped to `0.1.6`.

## Not changed (verified as already-matching or out of scope)

- **Grafana proxy**: legacy `grafana_client.py` proxy path only does Basic + extra-header — Go already matches. (`GRAFANA_API_KEY` lives in a separate `silence_utils` feature, not this proxy.)
- ES API-key, ES basic auth, Chronosphere bearer, Loki/Prometheus extra headers: already present in Go.

## Tests

Unit tests for each new path: SigNoz JWT (cache + precedence), Loki basic auth, Jaeger bearer, Prometheus Coralogix header, AWS SigV4 (`AWS4-HMAC-SHA256` + credential scope), Azure token mint+cache, plus expiry parsing. `go build`, `go vet`, and full `go test ./...` pass; `helm template` renders all new env vars.