### PR TITLE
feat(observability): datasource auth parity + logs-provider & Prometheus health fixes

### DIFF
--- a/charts/nudgebee-agent/Chart.yaml
+++ b/charts/nudgebee-agent/Chart.yaml
@@ -29,8 +29,8 @@ annotations:
 # these are set to the right value by .github/workflows/release.yaml
 # we use 0.0.1 as a placeholder for the version` because Helm wont allow `0.0.0` and we want to be able to run
 # `helm install` on development checkouts without updating this file. the version doesn't matter in that case anyway
-version: 0.1.6
-appVersion: 0.1.6
+version: 0.1.7
+appVersion: 0.1.7
 dependencies:
 - name: opencost
   version: 2.0.1

--- a/charts/nudgebee-agent/templates/runner.yaml
+++ b/charts/nudgebee-agent/templates/runner.yaml
@@ -100,6 +100,34 @@ stringData:
   {{- if .Values.globalConfig.prometheus_headers }}
   PROMETHEUS_HEADERS: {{ .Values.globalConfig.prometheus_headers | quote }}
   {{- end }}
+  {{- with .Values.runner.prometheus.auth }}
+  {{- if .coralogixToken }}
+  CORALOGIX_PROMETHEUS_TOKEN: {{ .coralogixToken | quote }}
+  {{- end }}
+  {{- if .awsAccessKey }}
+  AWS_ACCESS_KEY: {{ .awsAccessKey | quote }}
+  AWS_SECRET_ACCESS_KEY: {{ .awsSecretAccessKey | quote }}
+  {{- if .awsRegion }}
+  AWS_REGION: {{ .awsRegion | quote }}
+  {{- end }}
+  {{- if .awsServiceName }}
+  AWS_SERVICE_NAME: {{ .awsServiceName | quote }}
+  {{- end }}
+  {{- end }}
+  {{- if or .azureUseManagedId .azureClientSecret }}
+  {{- if .azureUseManagedId }}
+  AZURE_USE_MANAGED_ID: {{ .azureUseManagedId | quote }}
+  {{- end }}
+  {{- if .azureClientSecret }}
+  AZURE_CLIENT_SECRET: {{ .azureClientSecret | quote }}
+  {{- end }}
+  AZURE_CLIENT_ID: {{ .azureClientId | quote }}
+  AZURE_TENANT_ID: {{ .azureTenantId | quote }}
+  {{- if .azureResource }}
+  AZURE_RESOURCE: {{ .azureResource | quote }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
   {{- if .Values.runner.grafana.password }}
   GRAFANA_PASSWORD: {{ .Values.runner.grafana.password | quote }}
   {{- end }}
@@ -118,6 +146,12 @@ stringData:
   {{- if .Values.runner.loki.headers }}
   LOKI_EXTRA_HEADER: {{ .Values.runner.loki.headers }}
   {{- end }}
+  {{- if .Values.runner.loki.username }}
+  LOKI_USERNAME: {{ .Values.runner.loki.username | quote }}
+  {{- end }}
+  {{- if .Values.runner.loki.password }}
+  LOKI_PASSWORD: {{ .Values.runner.loki.password | quote }}
+  {{- end }}
   {{- if .Values.runner.es.url }}
   ELASTICSEARCH_URL: {{ .Values.runner.es.url }}
   {{- end }}
@@ -133,6 +167,9 @@ stringData:
   {{- if not .Values.runner.es.enabled }}
   ELASTICSEARCH_ENABLED: {{ .Values.runner.es.enabled | quote }}
   {{- end }}
+  {{- if .Values.runner.es.sslVerify }}
+  ELASTICSEARCH_SSL_VERIFY: {{ .Values.runner.es.sslVerify | quote }}
+  {{- end }}
   {{- if .Values.runner.signoz.apiKey }}
   SIGNOZ_API_KEY: {{ .Values.runner.signoz.apiKey }}
   {{- end }}
@@ -147,6 +184,9 @@ stringData:
   {{- end }}
   {{- if .Values.runner.jaeger.queryUrl }}
   JAEGER_QUERY_URL: {{ .Values.runner.jaeger.queryUrl | quote }}
+  {{- end }}
+  {{- if .Values.runner.jaeger.token }}
+  JAEGER_TOKEN: {{ .Values.runner.jaeger.token | quote }}
   {{- end }}
   {{- if .Values.runner.chronosphere.url }}
   CHRONOSPHERE_URL: {{ .Values.runner.chronosphere.url | quote }}

--- a/charts/nudgebee-agent/templates/runner.yaml
+++ b/charts/nudgebee-agent/templates/runner.yaml
@@ -164,9 +164,10 @@ stringData:
   {{- if .Values.runner.es.apiKey }}
   ELASTICSEARCH_APIKEY: {{ .Values.runner.es.apiKey }}
   {{- end }}
-  {{- if not .Values.runner.es.enabled }}
+  # Always emit the explicit opt-in so the agent never falls back to a default:
+  # ES is the logs provider only when es.enabled is true, matching the prod
+  # chart. A bare es.url does NOT enable ES.
   ELASTICSEARCH_ENABLED: {{ .Values.runner.es.enabled | quote }}
-  {{- end }}
   {{- if .Values.runner.es.sslVerify }}
   ELASTICSEARCH_SSL_VERIFY: {{ .Values.runner.es.sslVerify | quote }}
   {{- end }}

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -167,13 +167,13 @@ runner:
     username: ""
     password: ""
   es:
-    # Set to enable Elasticsearch actions. Surfaces as ELASTICSEARCH_URL.
+    # ES as the logs provider is OPT-IN: set enabled: true AND url. Defaults off
+    # (matching the prod chart) so a stray/leftover `url` never auto-selects ES
+    # and masks an explicitly-configured provider like SigNoz. Surfaces as
+    # ELASTICSEARCH_ENABLED / ELASTICSEARCH_URL.
+    enabled: false
     url: ""
     apiKey: ""
-    # Gate ES as a logs provider independent of the URL. Set false to keep a
-    # configured `url` from overriding another logs provider (e.g. Loki) while
-    # still exposing the ES query actions. Surfaces as ELASTICSEARCH_ENABLED.
-    enabled: true
     # Verify the ES server's TLS certificate (https URLs only). Defaults off to
     # match the legacy client. Surfaces as ELASTICSEARCH_SSL_VERIFY.
     sslVerify: false

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -139,9 +139,33 @@ runner:
   relay_address: wss://relay.nudgebee.com/register
   clickhouse_enabled: true
   clickhouse_secret: ""
+  prometheus:
+    # Managed-provider auth for Prometheus-compatible backends. Leave empty
+    # for in-cluster Prometheus / plain-header auth (use globalConfig.
+    # prometheus_headers for a static Authorization header). Precedence:
+    # AWS → Coralogix → Azure.
+    auth:
+      # Coralogix: surfaces as CORALOGIX_PROMETHEUS_TOKEN (sent as `token` header).
+      coralogixToken: ""
+      # AWS SigV4 (Amazon Managed Prometheus). accessKey+secretAccessKey required
+      # together; serviceName defaults to "aps".
+      awsAccessKey: ""
+      awsSecretAccessKey: ""
+      awsRegion: ""
+      awsServiceName: ""
+      # Azure AD (Azure Monitor managed Prometheus). Set azureUseManagedId
+      # (any non-empty value) OR azureClientSecret; clientId + tenantId required.
+      azureUseManagedId: ""
+      azureClientId: ""
+      azureClientSecret: ""
+      azureTenantId: ""
+      azureResource: ""
   loki:
     url: ""
     headers: ""
+    # Optional HTTP Basic-Auth. Surfaces as LOKI_USERNAME / LOKI_PASSWORD.
+    username: ""
+    password: ""
   es:
     # Set to enable Elasticsearch actions. Surfaces as ELASTICSEARCH_URL.
     url: ""
@@ -150,6 +174,9 @@ runner:
     # configured `url` from overriding another logs provider (e.g. Loki) while
     # still exposing the ES query actions. Surfaces as ELASTICSEARCH_ENABLED.
     enabled: true
+    # Verify the ES server's TLS certificate (https URLs only). Defaults off to
+    # match the legacy client. Surfaces as ELASTICSEARCH_SSL_VERIFY.
+    sslVerify: false
   signoz:
     # Set to enable SigNoz actions. Surfaces as SIGNOZ_URL.
     url: ""
@@ -165,6 +192,8 @@ runner:
     # it for JAEGER_URL). When empty, jaeger_query_* return a clear
     # "not configured" error instead of failing auth.
     queryUrl: ""
+    # Optional Bearer token for the Jaeger query API. Surfaces as JAEGER_TOKEN.
+    token: ""
   chronosphere:
     # Chronosphere trace API endpoint. Surfaces as CHRONOSPHERE_URL. Empty →
     # chronosphere_query_traces returns "not configured".

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -61,7 +61,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-07-04T11-16-26_e1730394cb5e420b38fb79351f2a23ab46490ede
+    tag: 2026-07-08T10-06-14_f2d9b536e5ebb3fa0b470241b64b01c6534c6bba
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/runner/.env.example
+++ b/runner/.env.example
@@ -33,12 +33,21 @@ NUDGEBEE_ENDPOINT=https://api.nudgebee.com
 # --- Observability (optional but typical) -----------------------------------
 
 # PROMETHEUS_URL=http://prometheus.monitoring.svc:9090
+# PROMETHEUS_HEADERS=Authorization: Bearer xxx   # static header auth (basic/bearer)
+# Managed Prometheus auth (pick one; precedence AWS → Coralogix → Azure):
+#   AWS SigV4 (Amazon Managed Prometheus): AWS_ACCESS_KEY / AWS_SECRET_ACCESS_KEY / AWS_REGION [/ AWS_SERVICE_NAME=aps]
+#   Coralogix: CORALOGIX_PROMETHEUS_TOKEN
+#   Azure AD:  AZURE_USE_MANAGED_ID=true or AZURE_CLIENT_SECRET, plus AZURE_CLIENT_ID / AZURE_TENANT_ID
 # LOKI_URL=http://loki.logging.svc:3100
+# LOKI_USERNAME=          # optional Loki HTTP Basic-Auth
+# LOKI_PASSWORD=
 # ELASTICSEARCH_URL=
+# ELASTICSEARCH_SSL_VERIFY=false   # verify ES TLS cert (https only); default false
 # SIGNOZ_URL=
 # SIGNOZ_API_KEY=
 # SIGNOZ_USER=            # alternative to SIGNOZ_API_KEY: user/password login (JWT)
 # SIGNOZ_PASSWORD=
+# JAEGER_TOKEN=           # optional Bearer token for the Jaeger query API
 
 # --- Subsystem toggles ------------------------------------------------------
 

--- a/runner/cmd/agent/main.go
+++ b/runner/cmd/agent/main.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -255,6 +256,32 @@ func run(ctx context.Context, logger *slog.Logger, cfg *config.Config) error {
 	if cfg.PrometheusURL != "" {
 		promClient = prometheus.New(cfg.PrometheusURL, nil)
 		promClient.ExtraHeaders = config.ParseHeaders(cfg.PrometheusHeaders)
+		// Managed-provider auth, same precedence as the legacy
+		// generate_prometheus_config: AWS SigV4 → Coralogix token → Azure AD.
+		// Plain header/basic auth stays in PROMETHEUS_HEADERS above.
+		switch {
+		case cfg.AWSAccessKey != "":
+			promClient.Auth = prometheus.NewAWSAuth(cfg.AWSAccessKey, cfg.AWSSecretAccessKey, cfg.AWSRegion, cfg.AWSServiceName)
+			logger.Info("prometheus auth: AWS SigV4", "service", cfg.AWSServiceName, "region", cfg.AWSRegion)
+		case cfg.CoralogixPrometheusToken != "":
+			promClient.Auth = prometheus.NewCoralogixAuth(cfg.CoralogixPrometheusToken)
+			logger.Info("prometheus auth: Coralogix token")
+		case cfg.AzureUseManagedID != "" || cfg.AzureClientSecret != "":
+			if a := prometheus.NewAzureAuth(prometheus.AzureAuthConfig{
+				UseManagedID:     cfg.AzureUseManagedID,
+				ClientID:         cfg.AzureClientID,
+				ClientSecret:     cfg.AzureClientSecret,
+				TenantID:         cfg.AzureTenantID,
+				Resource:         cfg.AzureResource,
+				MetadataEndpoint: cfg.AzureMetadataEndpoint,
+				TokenEndpoint:    cfg.AzureTokenEndpoint,
+			}, nil); a != nil {
+				promClient.Auth = a
+				logger.Info("prometheus auth: Azure AD")
+			} else {
+				logger.Warn("prometheus Azure auth requested but AZURE_CLIENT_ID/AZURE_TENANT_ID incomplete — ignoring")
+			}
+		}
 		ph := prometheus.Handlers(promClient)
 		maps.Copy(handlers, ph)
 		for name := range ph {
@@ -313,6 +340,8 @@ func run(ctx context.Context, logger *slog.Logger, cfg *config.Config) error {
 	if cfg.LokiURL != "" {
 		lc := loki.New(cfg.LokiURL, nil)
 		lc.ExtraHeaders = config.ParseHeaders(cfg.LokiHeaders)
+		lc.Username = cfg.LokiUsername
+		lc.Password = cfg.LokiPassword
 		lh := loki.Handlers(lc)
 		maps.Copy(handlers, lh)
 		for name := range lh {
@@ -332,7 +361,9 @@ func run(ctx context.Context, logger *slog.Logger, cfg *config.Config) error {
 	}
 
 	esEnabled := cfg.ElasticsearchEnabled && cfg.ElasticsearchURL != ""
-	ec := elasticsearch.New(cfg.ElasticsearchURL, nil)
+	// Legacy ES client defaults verify_certs=False; skip TLS verification
+	// unless ELASTICSEARCH_SSL_VERIFY is set. Only affects https URLs.
+	ec := elasticsearch.New(cfg.ElasticsearchURL, esHTTPClient(cfg.ElasticsearchSSLVerify))
 	ec.Username = cfg.ElasticsearchUser
 	ec.Password = cfg.ElasticsearchPassword
 	ec.APIKey = cfg.ElasticsearchAPIKey
@@ -351,6 +382,7 @@ func run(ctx context.Context, logger *slog.Logger, cfg *config.Config) error {
 	}
 
 	jc := jaeger.New(cfg.JaegerURL, nil)
+	jc.Token = cfg.JaegerToken
 	registerProxy("jaeger", cfg.JaegerURL != "", jaeger.Handlers(jc))
 	if cfg.JaegerURL != "" {
 		logger.Info("jaeger enabled", "url", cfg.JaegerURL)
@@ -1213,6 +1245,22 @@ func httpProbe(ctx context.Context, c *http.Client, url string, headers ...map[s
 	}
 	defer func() { _ = resp.Body.Close() }()
 	return resp.StatusCode >= 200 && resp.StatusCode < 300
+}
+
+// esHTTPClient returns the HTTP client the ES query client uses. When
+// sslVerify is false (the legacy default), it disables TLS certificate
+// verification to match the legacy client's verify_certs=False. For plain
+// http URLs the TLS config is inert.
+func esHTTPClient(sslVerify bool) *http.Client {
+	if sslVerify {
+		return nil // nil → elasticsearch.New builds a default verifying client
+	}
+	return &http.Client{
+		Timeout: 60 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // legacy parity: ELASTICSEARCH_SSL_VERIFY defaults false
+		},
+	}
 }
 
 // esAuthHeader builds the Authorization header for ES probes from the

--- a/runner/cmd/agent/main.go
+++ b/runner/cmd/agent/main.go
@@ -979,6 +979,7 @@ func run(ctx context.Context, logger *slog.Logger, cfg *config.Config) error {
 					LogsProviderURL:            logsURL,
 					LogsProviderStatus:         logsOK,
 					LogProviderConfig:          logCfg,
+					PrometheusConnected:        prometheusConnected(probeCtx, promClient, logger),
 					NodeAgentCount:             queryNodeAgentCount(probeCtx, promClient, logger),
 					PrometheusRetentionTime:    telemetry.PrometheusRetention(probeCtx, promClient, logger),
 					PrometheusAdditionalLabels: promExtraLabels,
@@ -1127,6 +1128,33 @@ func (a *grafanaAdapter) HandlePrometheus(ctx context.Context, r *dispatch.Grafa
 		Body:          r.Body,
 		Header:        r.Header,
 	})
+}
+
+// prometheusConnected reports whether the agent can actually query Prometheus,
+// using the authenticated prometheus client (which carries PROMETHEUS_HEADERS).
+// It runs a trivial `vector(1)` query instead of GET /-/healthy so query-only
+// backends that don't serve the Prometheus admin/health endpoints and require
+// auth — Chronosphere, Thanos Query, Grafana Mimir, Amazon Managed Prometheus —
+// are reported Connected when metric queries work. Returns false on any error
+// so a broken backend shows Disconnected rather than panicking the tick.
+func prometheusConnected(ctx context.Context, c *prometheus.Client, logger *slog.Logger) bool {
+	if c == nil || c.BaseURL == "" {
+		return false
+	}
+	cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	raw, err := c.Query(cctx, "vector(1)", "", "")
+	if err != nil {
+		logger.Debug("prometheus health query failed", "err", err)
+		return false
+	}
+	var resp struct {
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return false
+	}
+	return resp.Status == "success"
 }
 
 // queryNodeAgentCount

--- a/runner/cmd/agent/main.go
+++ b/runner/cmd/agent/main.go
@@ -1255,11 +1255,13 @@ func esHTTPClient(sslVerify bool) *http.Client {
 	if sslVerify {
 		return nil // nil → elasticsearch.New builds a default verifying client
 	}
+	// Clone DefaultTransport so we keep its connection pooling, keep-alives,
+	// dial timeouts, and HTTP/2 support — only TLS verification is relaxed.
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // legacy parity: ELASTICSEARCH_SSL_VERIFY defaults false
 	return &http.Client{
-		Timeout: 60 * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // legacy parity: ELASTICSEARCH_SSL_VERIFY defaults false
-		},
+		Timeout:   60 * time.Second,
+		Transport: transport,
 	}
 }
 

--- a/runner/cmd/agent/probe_test.go
+++ b/runner/cmd/agent/probe_test.go
@@ -3,11 +3,13 @@ package main
 import (
 	"context"
 	"encoding/base64"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/nudgebee/nudgebee-agent/pkg/config"
+	"github.com/nudgebee/nudgebee-agent/pkg/observability/prometheus"
 )
 
 // ELASTICSEARCH_ENABLED=false must keep a configured ELASTICSEARCH_URL from
@@ -38,6 +40,36 @@ func TestProbeLogsProvider_ESDisabledFallsThroughToLoki(t *testing.T) {
 	}
 	if !ok {
 		t.Fatal("ok = false, want true (buildinfo path should be reachable)")
+	}
+}
+
+// Regression: a leftover ES URL (e.g. the prod chart's default
+// monitoring.svc URL carried into a values file) must NOT hijack logs-provider
+// selection when ES isn't explicitly enabled — SigNoz, which the operator did
+// configure, must win. Mirrors the customer scenario that motivated defaulting
+// ELASTICSEARCH_ENABLED to false.
+func TestProbeLogsProvider_StrayESURLDoesNotMaskSignoz(t *testing.T) {
+	signoz := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/health" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer signoz.Close()
+
+	cfg := &config.Config{
+		// Stray/leftover ES URL, ES not enabled (the new default).
+		ElasticsearchURL:     "https://elasticsearch-es-internal-http.monitoring.svc:9200",
+		ElasticsearchEnabled: false,
+		SignozURL:            signoz.URL,
+	}
+	provider, url, ok, _ := probeLogsProvider(context.Background(), cfg)
+	if provider != "signoz" {
+		t.Fatalf("provider = %q, want signoz (stray ES URL must not mask SigNoz)", provider)
+	}
+	if url != signoz.URL || !ok {
+		t.Fatalf("url=%q ok=%v; want %q true", url, ok, signoz.URL)
 	}
 }
 
@@ -72,5 +104,58 @@ func TestProbeLogsProvider_ESProbeSendsAuth(t *testing.T) {
 	want := "Basic " + base64.StdEncoding.EncodeToString([]byte("admin:pw"))
 	if gotAuth != want {
 		t.Fatalf("Authorization = %q, want %q", gotAuth, want)
+	}
+}
+
+// prometheusConnected must report a Chronosphere-style backend as connected:
+// it only serves /api/v1/query (not /-/healthy) and requires the bearer token.
+// This is the exact case the old /-/healthy probe reported Disconnected.
+func TestPrometheusConnected_ChronosphereStyleBackend(t *testing.T) {
+	var queried bool
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		// Chronosphere doesn't serve the Prometheus admin/health endpoints.
+		if r.URL.Path == "/-/healthy" || r.URL.Path == "/api/v1/status/flags" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if r.URL.Path == "/api/v1/query" && gotAuth == "Bearer tok" {
+			queried = true
+			_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[]}}`))
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c := prometheus.New(srv.URL, nil)
+	c.ExtraHeaders = config.ParseHeaders("Authorization: Bearer tok")
+	if !prometheusConnected(context.Background(), c, slog.Default()) {
+		t.Error("expected connected=true for query-only backend serving /api/v1/query")
+	}
+	if !queried {
+		t.Error("health check should hit /api/v1/query")
+	}
+	if gotAuth != "Bearer tok" {
+		t.Errorf("Authorization = %q; want Bearer tok (auth must be sent)", gotAuth)
+	}
+}
+
+func TestPrometheusConnected_FailuresReportDisconnected(t *testing.T) {
+	// Backend that rejects everything → not connected.
+	down := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer down.Close()
+	if prometheusConnected(context.Background(), prometheus.New(down.URL, nil), slog.Default()) {
+		t.Error("expected connected=false when backend returns 500")
+	}
+	// Nil / unconfigured client → not connected, no panic.
+	if prometheusConnected(context.Background(), nil, slog.Default()) {
+		t.Error("expected connected=false for nil client")
+	}
+	if prometheusConnected(context.Background(), prometheus.New("", nil), slog.Default()) {
+		t.Error("expected connected=false for empty base URL")
 	}
 }

--- a/runner/docs/configuration.md
+++ b/runner/docs/configuration.md
@@ -45,15 +45,21 @@ If a K8s subsystem is enabled but the agent fails to build a K8s client (no kube
 | Variable | Required | Description |
 |---|---|---|
 | `PROMETHEUS_URL` | recommended | Enables `prometheus_*` actions and `service_map` |
-| `PROMETHEUS_HEADERS` | optional | Comma-separated `Header: value` pairs (e.g. `X-Scope-OrgID: tenant-1`) |
+| `PROMETHEUS_HEADERS` | optional | Comma-separated `Header: value` pairs (e.g. `X-Scope-OrgID: tenant-1`); use for static basic/bearer auth |
+| `AWS_ACCESS_KEY` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION` | optional | Managed Prometheus: sign requests with AWS SigV4. `AWS_SERVICE_NAME` defaults to `aps` |
+| `CORALOGIX_PROMETHEUS_TOKEN` | optional | Managed Prometheus: sent as `token` header |
+| `AZURE_USE_MANAGED_ID` / `AZURE_CLIENT_SECRET` (+ `AZURE_CLIENT_ID` / `AZURE_TENANT_ID`) | optional | Managed Prometheus: Azure AD Bearer token (managed identity or client-secret). Precedence: AWS → Coralogix → Azure |
 | `LOKI_URL` | optional | Enables `loki_*` actions |
 | `LOKI_EXTRA_HEADER` | optional | Same format as PROMETHEUS_HEADERS |
+| `LOKI_USERNAME` / `LOKI_PASSWORD` | optional | Loki HTTP Basic-Auth |
 | `ELASTICSEARCH_URL` | optional | Enables `query_es*` actions |
 | `ELASTICSEARCH_USERNAME` / `_PASSWORD` | optional | Basic auth (one of these or `_APIKEY` is needed if ES requires auth) |
 | `ELASTICSEARCH_APIKEY` | optional | Alternative to user/pass |
+| `ELASTICSEARCH_SSL_VERIFY` | optional | Verify the ES server TLS cert (https only). Default `false` (skip verify), matching the legacy client |
 | `SIGNOZ_URL` / `SIGNOZ_API_KEY` | optional | `signoz_*` actions; API key sent as `SIGNOZ-API-KEY` header |
 | `SIGNOZ_USER` / `SIGNOZ_PASSWORD` | optional | Alternative auth: JWT minted via `/api/v1/login` (used when `SIGNOZ_API_KEY` is unset) |
 | `JAEGER_URL` | optional | `jaeger_*` actions |
+| `JAEGER_TOKEN` | optional | Bearer token for the Jaeger query API |
 | `CHRONOSPHERE_URL` / `CHRONOSPHERE_API_KEY` | optional | `chronosphere_query_traces`; API key sent as `Authorization: Bearer` |
 | `HTTP_PROXY_TARGETS` | optional | `name=url;name=url` for `http_proxy_request` named targets |
 

--- a/runner/go.mod
+++ b/runner/go.mod
@@ -3,6 +3,7 @@ module github.com/nudgebee/nudgebee-agent
 go 1.26.3
 
 require (
+	github.com/aws/aws-sdk-go-v2 v1.42.1
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
@@ -24,6 +25,7 @@ require (
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
+	github.com/aws/smithy-go v1.27.3 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/runner/go.sum
+++ b/runner/go.sum
@@ -12,6 +12,10 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
+github.com/aws/aws-sdk-go-v2 v1.42.1 h1:9eOTgu1z/dVtYpNZ3/8/XbbaX0x/BqE3HUzAzs6K0ek=
+github.com/aws/aws-sdk-go-v2 v1.42.1/go.mod h1:5pKeft2eJj+gElQ38Jqg4ibCqh+/AK33/0X3hip7IjM=
+github.com/aws/smithy-go v1.27.3 h1:F3Zb497UhhskkfpJmfkXswyo+t0sh9OTBnIHjogWbVY=
+github.com/aws/smithy-go v1.27.3/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=

--- a/runner/pkg/config/config.go
+++ b/runner/pkg/config/config.go
@@ -231,11 +231,14 @@ func FromEnv() (*Config, error) {
 		ElasticsearchUser:        os.Getenv("ELASTICSEARCH_USERNAME"),
 		ElasticsearchPassword:    os.Getenv("ELASTICSEARCH_PASSWORD"),
 		ElasticsearchAPIKey:      os.Getenv("ELASTICSEARCH_APIKEY"),
-		// ELASTICSEARCH_ENABLED gates ES as a logs provider independent of the
-		// URL: operators set it false to keep a stray ELASTICSEARCH_URL from
-		// overriding a working provider (e.g. Loki). Unset → enabled when a URL
-		// is present, preserving legacy URL-presence behaviour.
-		ElasticsearchEnabled: envBool("ELASTICSEARCH_ENABLED", true),
+		// ELASTICSEARCH_ENABLED is the explicit opt-in for ES as the logs
+		// provider, defaulting false to match the legacy agent
+		// (env_vars.ELASTICSEARCH_ENABLED = load_bool(..., False)) and the prod
+		// chart (runner.es.enabled: false). ES must be turned on deliberately —
+		// a bare ELASTICSEARCH_URL (e.g. the prod chart's default
+		// monitoring.svc URL carried into a values file) must NOT auto-select
+		// ES and mask an explicitly-configured provider like SigNoz.
+		ElasticsearchEnabled: envBool("ELASTICSEARCH_ENABLED", false),
 		// ELASTICSEARCH_SSL_VERIFY defaults false — the legacy client passes
 		// verify_certs=False by default, so we skip cert verification unless
 		// the operator opts in. Only affects https URLs.

--- a/runner/pkg/config/config.go
+++ b/runner/pkg/config/config.go
@@ -30,13 +30,32 @@ type Config struct {
 	PrometheusHeaders string // raw "Header: value" string, parsed into http.Header
 	LokiURL           string
 	LokiHeaders       string
+	LokiUsername      string // optional Basic-Auth (LOKI_USERNAME)
+	LokiPassword      string // optional Basic-Auth (LOKI_PASSWORD)
+
+	// Prometheus managed-provider auth (mirrors the legacy prometrix configs).
+	// Coralogix uses a `token` header; AWS signs each request with SigV4;
+	// Azure mints a Bearer token via managed identity or client-secret.
+	CoralogixPrometheusToken string
+	AWSAccessKey             string
+	AWSSecretAccessKey       string
+	AWSServiceName           string // default "aps" (Amazon Managed Prometheus)
+	AWSRegion                string
+	AzureUseManagedID        string
+	AzureClientSecret        string
+	AzureClientID            string
+	AzureTenantID            string
+	AzureResource            string
+	AzureMetadataEndpoint    string
+	AzureTokenEndpoint       string
 
 	// Elasticsearch
-	ElasticsearchURL      string
-	ElasticsearchUser     string
-	ElasticsearchPassword string
-	ElasticsearchAPIKey   string
-	ElasticsearchEnabled  bool // ELASTICSEARCH_ENABLED; default true when URL is set
+	ElasticsearchURL       string
+	ElasticsearchUser      string
+	ElasticsearchPassword  string
+	ElasticsearchAPIKey    string
+	ElasticsearchEnabled   bool // ELASTICSEARCH_ENABLED; default true when URL is set
+	ElasticsearchSSLVerify bool // ELASTICSEARCH_SSL_VERIFY; default false (skip cert verify) to match legacy
 
 	// Signoz
 	SignozURL      string
@@ -45,7 +64,8 @@ type Config struct {
 	SignozPassword string
 
 	// Jaeger
-	JaegerURL string
+	JaegerURL   string
+	JaegerToken string // optional Bearer token (JAEGER_TOKEN)
 
 	// Chronosphere
 	ChronosphereURL    string
@@ -190,15 +210,36 @@ func FromEnv() (*Config, error) {
 		PrometheusHeaders:     os.Getenv("PROMETHEUS_HEADERS"), // matches runner.yaml secret
 		LokiURL:               os.Getenv("LOKI_URL"),
 		LokiHeaders:           os.Getenv("LOKI_EXTRA_HEADER"), // matches runner.yaml secret
-		ElasticsearchURL:      os.Getenv("ELASTICSEARCH_URL"),
-		ElasticsearchUser:     os.Getenv("ELASTICSEARCH_USERNAME"),
-		ElasticsearchPassword: os.Getenv("ELASTICSEARCH_PASSWORD"),
-		ElasticsearchAPIKey:   os.Getenv("ELASTICSEARCH_APIKEY"),
+		LokiUsername:          os.Getenv("LOKI_USERNAME"),
+		LokiPassword:          os.Getenv("LOKI_PASSWORD"),
+		// Prometheus managed-provider auth. Defaults mirror the legacy
+		// prometrix env handling (utils.py): AWS service defaults to "aps",
+		// Azure resource/endpoints have the same fallbacks.
+		CoralogixPrometheusToken: os.Getenv("CORALOGIX_PROMETHEUS_TOKEN"),
+		AWSAccessKey:             os.Getenv("AWS_ACCESS_KEY"),
+		AWSSecretAccessKey:       os.Getenv("AWS_SECRET_ACCESS_KEY"),
+		AWSServiceName:           cmp(os.Getenv("AWS_SERVICE_NAME"), "aps"),
+		AWSRegion:                os.Getenv("AWS_REGION"),
+		AzureUseManagedID:        os.Getenv("AZURE_USE_MANAGED_ID"),
+		AzureClientSecret:        os.Getenv("AZURE_CLIENT_SECRET"),
+		AzureClientID:            os.Getenv("AZURE_CLIENT_ID"),
+		AzureTenantID:            os.Getenv("AZURE_TENANT_ID"),
+		AzureResource:            cmp(os.Getenv("AZURE_RESOURCE"), "https://prometheus.monitor.azure.com"),
+		AzureMetadataEndpoint:    cmp(os.Getenv("AZURE_METADATA_ENDPOINT"), "http://169.254.169.254/metadata/identity/oauth2/token"),
+		AzureTokenEndpoint:       os.Getenv("AZURE_TOKEN_ENDPOINT"),
+		ElasticsearchURL:         os.Getenv("ELASTICSEARCH_URL"),
+		ElasticsearchUser:        os.Getenv("ELASTICSEARCH_USERNAME"),
+		ElasticsearchPassword:    os.Getenv("ELASTICSEARCH_PASSWORD"),
+		ElasticsearchAPIKey:      os.Getenv("ELASTICSEARCH_APIKEY"),
 		// ELASTICSEARCH_ENABLED gates ES as a logs provider independent of the
 		// URL: operators set it false to keep a stray ELASTICSEARCH_URL from
 		// overriding a working provider (e.g. Loki). Unset → enabled when a URL
 		// is present, preserving legacy URL-presence behaviour.
 		ElasticsearchEnabled: envBool("ELASTICSEARCH_ENABLED", true),
+		// ELASTICSEARCH_SSL_VERIFY defaults false — the legacy client passes
+		// verify_certs=False by default, so we skip cert verification unless
+		// the operator opts in. Only affects https URLs.
+		ElasticsearchSSLVerify: envBool("ELASTICSEARCH_SSL_VERIFY", false),
 		SignozURL:            os.Getenv("SIGNOZ_URL"),
 		SignozAPIKey:         os.Getenv("SIGNOZ_API_KEY"),
 		SignozUser:           os.Getenv("SIGNOZ_USER"),
@@ -210,6 +251,7 @@ func FromEnv() (*Config, error) {
 		// backend dispatching jaeger_query_* while the agent rejects them as
 		// "not in light-action allowlist".
 		JaegerURL:          cmp(os.Getenv("JAEGER_URL"), os.Getenv("JAEGER_QUERY_URL")),
+		JaegerToken:        os.Getenv("JAEGER_TOKEN"),
 		ChronosphereURL:    os.Getenv("CHRONOSPHERE_URL"),
 		ChronosphereAPIKey: os.Getenv("CHRONOSPHERE_API_KEY"),
 		PinotURL:           os.Getenv("PINOT_URL"),
@@ -255,6 +297,11 @@ func FromEnv() (*Config, error) {
 		ClickHousePassword:         os.Getenv("CLICKHOUSE_PASSWORD"),
 		ClickHouseDB:               cmp(os.Getenv("CLICKHOUSE_DB"), "default"),
 		ClickHouseSSL:              envBool("CLICKHOUSE_SSL_ENABLED", false),
+	}
+	// Azure token endpoint defaults to the tenant-scoped login URL, mirroring
+	// the legacy f-string default (utils.py).
+	if c.AzureTokenEndpoint == "" {
+		c.AzureTokenEndpoint = "https://login.microsoftonline.com/" + c.AzureTenantID + "/oauth2/token"
 	}
 	if c.RelayURL == "" {
 		return nil, errors.New("WEBSOCKET_RELAY_ADDRESS not set")

--- a/runner/pkg/config/config.go
+++ b/runner/pkg/config/config.go
@@ -240,10 +240,10 @@ func FromEnv() (*Config, error) {
 		// verify_certs=False by default, so we skip cert verification unless
 		// the operator opts in. Only affects https URLs.
 		ElasticsearchSSLVerify: envBool("ELASTICSEARCH_SSL_VERIFY", false),
-		SignozURL:            os.Getenv("SIGNOZ_URL"),
-		SignozAPIKey:         os.Getenv("SIGNOZ_API_KEY"),
-		SignozUser:           os.Getenv("SIGNOZ_USER"),
-		SignozPassword:       os.Getenv("SIGNOZ_PASSWORD"),
+		SignozURL:              os.Getenv("SIGNOZ_URL"),
+		SignozAPIKey:           os.Getenv("SIGNOZ_API_KEY"),
+		SignozUser:             os.Getenv("SIGNOZ_USER"),
+		SignozPassword:         os.Getenv("SIGNOZ_PASSWORD"),
 		// JAEGER_URL drives the jaeger read-proxy handlers + light-action
 		// allowlist. Fall back to JAEGER_QUERY_URL (the var the telemetry
 		// heartbeat uses to tell the backend jaeger is enabled) so a

--- a/runner/pkg/config/config_test.go
+++ b/runner/pkg/config/config_test.go
@@ -50,6 +50,12 @@ func TestFromEnv_ReadsAllFields(t *testing.T) {
 		LokiURL:           "http://loki:3100",
 		LokiHeaders:       "X-Scope-OrgID: t1",
 		HTTPListenAddr:    ":7000",
+		// Managed-provider auth defaults, applied even when the env vars are
+		// unset (mirrors the legacy prometrix defaults).
+		AWSServiceName:        "aps",
+		AzureResource:         "https://prometheus.monitor.azure.com",
+		AzureMetadataEndpoint: "http://169.254.169.254/metadata/identity/oauth2/token",
+		AzureTokenEndpoint:    "https://login.microsoftonline.com//oauth2/token",
 		// ES enable defaults on when ELASTICSEARCH_ENABLED is unset.
 		ElasticsearchEnabled: true,
 		// K8s subsystems default-on (drop-in compatible with the legacy runner);

--- a/runner/pkg/config/config_test.go
+++ b/runner/pkg/config/config_test.go
@@ -56,8 +56,9 @@ func TestFromEnv_ReadsAllFields(t *testing.T) {
 		AzureResource:         "https://prometheus.monitor.azure.com",
 		AzureMetadataEndpoint: "http://169.254.169.254/metadata/identity/oauth2/token",
 		AzureTokenEndpoint:    "https://login.microsoftonline.com//oauth2/token",
-		// ES enable defaults on when ELASTICSEARCH_ENABLED is unset.
-		ElasticsearchEnabled: true,
+		// ES is opt-in: defaults off when ELASTICSEARCH_ENABLED is unset, so a
+		// bare ELASTICSEARCH_URL doesn't auto-select ES (matches prod/legacy).
+		ElasticsearchEnabled: false,
 		// K8s subsystems default-on (drop-in compatible with the legacy runner);
 		// operators opt out per-subsystem via DISCOVERY_ENABLED=false etc.
 		DiscoveryEnabled:   true,

--- a/runner/pkg/observability/jaeger/client.go
+++ b/runner/pkg/observability/jaeger/client.go
@@ -24,6 +24,7 @@ type Client struct {
 	BaseURL      string
 	HTTP         *http.Client
 	ExtraHeaders http.Header
+	Token        string // optional Bearer token (JAEGER_TOKEN)
 }
 
 func New(baseURL string, httpClient *http.Client) *Client {
@@ -110,6 +111,9 @@ func (c *Client) get(ctx context.Context, path string, params url.Values) (json.
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
 		return nil, err
+	}
+	if c.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.Token)
 	}
 	for k, vv := range c.ExtraHeaders {
 		for _, v := range vv {

--- a/runner/pkg/observability/jaeger/jaeger_test.go
+++ b/runner/pkg/observability/jaeger/jaeger_test.go
@@ -174,3 +174,34 @@ func TestHandlers_TraceByID_Roundtrip(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestToken_SetsBearer(t *testing.T) {
+	var auth string
+	c, srv := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		auth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	})
+	defer srv.Close()
+	c.Token = "tok123"
+	if _, err := c.Services(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if auth != "Bearer tok123" {
+		t.Errorf("Authorization = %q", auth)
+	}
+}
+
+func TestToken_AbsentWhenUnset(t *testing.T) {
+	var auth string
+	c, srv := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		auth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	})
+	defer srv.Close()
+	if _, err := c.Services(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if auth != "" {
+		t.Errorf("unexpected Authorization = %q", auth)
+	}
+}

--- a/runner/pkg/observability/loki/client.go
+++ b/runner/pkg/observability/loki/client.go
@@ -27,6 +27,8 @@ type Client struct {
 	BaseURL      string
 	HTTP         *http.Client
 	ExtraHeaders http.Header
+	Username     string // optional Basic-Auth (LOKI_USERNAME)
+	Password     string // optional Basic-Auth (LOKI_PASSWORD)
 }
 
 func New(baseURL string, httpClient *http.Client) *Client {
@@ -134,6 +136,10 @@ func (c *Client) get(ctx context.Context, path string, params url.Values) (json.
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
 		return nil, err
+	}
+	// LOKI_USERNAME/LOKI_PASSWORD → Basic-Auth header (legacy get_headers).
+	if c.Username != "" && c.Password != "" {
+		req.SetBasicAuth(c.Username, c.Password)
 	}
 	for k, vv := range c.ExtraHeaders {
 		for _, v := range vv {

--- a/runner/pkg/observability/loki/loki_test.go
+++ b/runner/pkg/observability/loki/loki_test.go
@@ -167,3 +167,39 @@ func TestStrSlice_Variants(t *testing.T) {
 }
 
 func contains(haystack, needle string) bool { return strings.Contains(haystack, needle) }
+
+func TestBasicAuth_SetWhenConfigured(t *testing.T) {
+	var user, pass string
+	var ok bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, pass, ok = r.BasicAuth()
+		_, _ = w.Write([]byte(`{"status":"success"}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, &http.Client{Timeout: 5 * time.Second})
+	c.Username = "u"
+	c.Password = "p"
+	if _, err := c.Query(context.Background(), `{job="x"}`, "", ""); err != nil {
+		t.Fatal(err)
+	}
+	if !ok || user != "u" || pass != "p" {
+		t.Errorf("basic auth = %q/%q ok=%v", user, pass, ok)
+	}
+}
+
+func TestBasicAuth_AbsentWhenUnset(t *testing.T) {
+	var hadAuth bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _, hadAuth = r.BasicAuth()
+		_, _ = w.Write([]byte(`{"status":"success"}`))
+	}))
+	defer srv.Close()
+	c := New(srv.URL, &http.Client{Timeout: 5 * time.Second})
+	if _, err := c.Query(context.Background(), `{job="x"}`, "", ""); err != nil {
+		t.Fatal(err)
+	}
+	if hadAuth {
+		t.Error("unexpected basic auth header when username/password unset")
+	}
+}

--- a/runner/pkg/observability/prometheus/auth.go
+++ b/runner/pkg/observability/prometheus/auth.go
@@ -151,11 +151,13 @@ func (a *azureAuth) bearer(ctx context.Context) (string, error) {
 }
 
 // azureTokenResponse matches both the IMDS and the client-credentials shapes.
-// Azure returns the numeric fields as JSON strings in these endpoints.
+// The expiry fields come back as JSON strings from IMDS but as JSON numbers
+// from the client-credentials (v2) endpoint, so use json.Number, which
+// unmarshals from either.
 type azureTokenResponse struct {
-	AccessToken string `json:"access_token"`
-	ExpiresIn   string `json:"expires_in"`
-	ExpiresOn   string `json:"expires_on"` // unix seconds (absolute)
+	AccessToken string      `json:"access_token"`
+	ExpiresIn   json.Number `json:"expires_in"`
+	ExpiresOn   json.Number `json:"expires_on"` // unix seconds (absolute)
 }
 
 func (a *azureAuth) requestToken(ctx context.Context) (string, time.Time, error) {
@@ -212,10 +214,10 @@ func (a *azureAuth) requestToken(ctx context.Context) (string, time.Time, error)
 // the absolute expires_on and falling back to now+expires_in. A short default
 // keeps us from caching indefinitely if neither field parses.
 func azureExpiry(tr azureTokenResponse) time.Time {
-	if secs, err := strconv.ParseInt(tr.ExpiresOn, 10, 64); err == nil && secs > 0 {
+	if secs, err := strconv.ParseInt(tr.ExpiresOn.String(), 10, 64); err == nil && secs > 0 {
 		return time.Unix(secs, 0)
 	}
-	if secs, err := strconv.ParseInt(tr.ExpiresIn, 10, 64); err == nil && secs > 0 {
+	if secs, err := strconv.ParseInt(tr.ExpiresIn.String(), 10, 64); err == nil && secs > 0 {
 		return time.Now().Add(time.Duration(secs) * time.Second)
 	}
 	return time.Now().Add(5 * time.Minute)

--- a/runner/pkg/observability/prometheus/auth.go
+++ b/runner/pkg/observability/prometheus/auth.go
@@ -1,0 +1,222 @@
+package prometheus
+
+// Managed-provider auth for Prometheus-compatible backends, mirroring the
+// legacy prometrix PrometheusAuthorization logic:
+//
+//   - Coralogix : a static `token` header (CoralogixPrometheusConfig).
+//   - AWS       : SigV4 request signing for Amazon Managed Prometheus (AMP).
+//   - Azure     : a Bearer token minted via managed identity or client-secret,
+//     cached until shortly before it expires.
+//
+// The plain header/basic cases are already covered by Client.ExtraHeaders
+// (PROMETHEUS_HEADERS), so only these three dynamic schemes live here.
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+)
+
+// Authorizer applies provider-specific auth to an outgoing request just
+// before it is sent. Implementations must be safe for concurrent use.
+type Authorizer interface {
+	Apply(ctx context.Context, req *http.Request) error
+}
+
+// --- Coralogix -------------------------------------------------------------
+
+type coralogixAuth struct{ token string }
+
+// NewCoralogixAuth returns an Authorizer that sends the Coralogix
+// `token` header (matches PrometheusAuthorization.get_authorization_headers).
+func NewCoralogixAuth(token string) Authorizer { return &coralogixAuth{token: token} }
+
+func (a *coralogixAuth) Apply(_ context.Context, req *http.Request) error {
+	req.Header.Set("token", a.token)
+	return nil
+}
+
+// --- AWS SigV4 -------------------------------------------------------------
+
+// emptyPayloadHash is SHA-256 of the empty string — every Prometheus query
+// the agent issues is a GET with no body.
+var emptyPayloadHash = func() string {
+	sum := sha256.Sum256(nil)
+	return hex.EncodeToString(sum[:])
+}()
+
+type awsAuth struct {
+	creds   aws.Credentials
+	region  string
+	service string
+	signer  *v4.Signer
+}
+
+// NewAWSAuth returns an Authorizer that signs each request with AWS SigV4,
+// as the legacy AWSPrometheusConnect does via botocore. service defaults to
+// "aps" (Amazon Managed Prometheus) when empty.
+func NewAWSAuth(accessKey, secretKey, region, service string) Authorizer {
+	if service == "" {
+		service = "aps"
+	}
+	return &awsAuth{
+		creds:   aws.Credentials{AccessKeyID: accessKey, SecretAccessKey: secretKey},
+		region:  region,
+		service: service,
+		signer:  v4.NewSigner(),
+	}
+}
+
+func (a *awsAuth) Apply(ctx context.Context, req *http.Request) error {
+	// GET requests carry the query in the URL and no body, so the empty
+	// payload hash is correct for every call site.
+	return a.signer.SignHTTP(ctx, a.creds, req, emptyPayloadHash, a.service, a.region, time.Now())
+}
+
+// --- Azure -----------------------------------------------------------------
+
+// AzureAuthConfig carries the managed-identity / client-secret settings.
+// Endpoints and resource have defaults applied by config.FromEnv.
+type AzureAuthConfig struct {
+	UseManagedID     string
+	ClientID         string
+	ClientSecret     string
+	TenantID         string
+	Resource         string
+	MetadataEndpoint string
+	TokenEndpoint    string
+}
+
+// authorized reports whether the config has enough to mint a token — mirrors
+// PrometheusAuthorization.azure_authorization.
+func (c AzureAuthConfig) authorized() bool {
+	return c.ClientID != "" && c.TenantID != "" && (c.ClientSecret != "" || c.UseManagedID != "")
+}
+
+type azureAuth struct {
+	cfg  AzureAuthConfig
+	http *http.Client
+
+	mu     sync.Mutex
+	token  string
+	expiry time.Time
+}
+
+// NewAzureAuth returns an Authorizer that mints and caches an Azure AD bearer
+// token. Returns nil if the config isn't complete enough to authorize, so the
+// caller can fall through to no auth.
+func NewAzureAuth(cfg AzureAuthConfig, httpClient *http.Client) Authorizer {
+	if !cfg.authorized() {
+		return nil
+	}
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 30 * time.Second}
+	}
+	return &azureAuth{cfg: cfg, http: httpClient}
+}
+
+func (a *azureAuth) Apply(ctx context.Context, req *http.Request) error {
+	tok, err := a.bearer(ctx)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+tok)
+	return nil
+}
+
+func (a *azureAuth) bearer(ctx context.Context) (string, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.token != "" && time.Now().Add(60*time.Second).Before(a.expiry) {
+		return a.token, nil
+	}
+	tok, exp, err := a.requestToken(ctx)
+	if err != nil {
+		return "", err
+	}
+	a.token, a.expiry = tok, exp
+	return tok, nil
+}
+
+// azureTokenResponse matches both the IMDS and the client-credentials shapes.
+// Azure returns the numeric fields as JSON strings in these endpoints.
+type azureTokenResponse struct {
+	AccessToken string `json:"access_token"`
+	ExpiresIn   string `json:"expires_in"`
+	ExpiresOn   string `json:"expires_on"` // unix seconds (absolute)
+}
+
+func (a *azureAuth) requestToken(ctx context.Context) (string, time.Time, error) {
+	var req *http.Request
+	var err error
+	if a.cfg.UseManagedID != "" {
+		// IMDS managed-identity flow: GET with query params + Metadata header.
+		q := url.Values{}
+		q.Set("api-version", "2018-02-01")
+		q.Set("client_id", a.cfg.ClientID)
+		q.Set("resource", a.cfg.Resource)
+		u := a.cfg.MetadataEndpoint + "?" + q.Encode()
+		req, err = http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+		if err != nil {
+			return "", time.Time{}, err
+		}
+		req.Header.Set("Metadata", "true")
+	} else {
+		// Client-credentials flow: form POST to the token endpoint.
+		form := url.Values{}
+		form.Set("grant_type", "client_credentials")
+		form.Set("client_id", a.cfg.ClientID)
+		form.Set("client_secret", a.cfg.ClientSecret)
+		form.Set("resource", a.cfg.Resource)
+		req, err = http.NewRequestWithContext(ctx, http.MethodPost, a.cfg.TokenEndpoint, strings.NewReader(form.Encode()))
+		if err != nil {
+			return "", time.Time{}, err
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	}
+	resp, err := a.http.Do(req)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("azure token: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	if resp.StatusCode >= 400 {
+		return "", time.Time{}, fmt.Errorf("azure token: HTTP %d: %s", resp.StatusCode, string(body))
+	}
+	var tr azureTokenResponse
+	if err := json.Unmarshal(body, &tr); err != nil {
+		return "", time.Time{}, fmt.Errorf("azure token: decode: %w", err)
+	}
+	if tr.AccessToken == "" {
+		return "", time.Time{}, fmt.Errorf("azure token: empty access_token")
+	}
+	return tr.AccessToken, azureExpiry(tr), nil
+}
+
+// azureExpiry derives an absolute expiry from the token response, preferring
+// the absolute expires_on and falling back to now+expires_in. A short default
+// keeps us from caching indefinitely if neither field parses.
+func azureExpiry(tr azureTokenResponse) time.Time {
+	if secs, err := strconv.ParseInt(tr.ExpiresOn, 10, 64); err == nil && secs > 0 {
+		return time.Unix(secs, 0)
+	}
+	if secs, err := strconv.ParseInt(tr.ExpiresIn, 10, 64); err == nil && secs > 0 {
+		return time.Now().Add(time.Duration(secs) * time.Second)
+	}
+	return time.Now().Add(5 * time.Minute)
+}

--- a/runner/pkg/observability/prometheus/auth.go
+++ b/runner/pkg/observability/prometheus/auth.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -214,10 +213,10 @@ func (a *azureAuth) requestToken(ctx context.Context) (string, time.Time, error)
 // the absolute expires_on and falling back to now+expires_in. A short default
 // keeps us from caching indefinitely if neither field parses.
 func azureExpiry(tr azureTokenResponse) time.Time {
-	if secs, err := strconv.ParseInt(tr.ExpiresOn.String(), 10, 64); err == nil && secs > 0 {
+	if secs, err := tr.ExpiresOn.Int64(); err == nil && secs > 0 {
 		return time.Unix(secs, 0)
 	}
-	if secs, err := strconv.ParseInt(tr.ExpiresIn.String(), 10, 64); err == nil && secs > 0 {
+	if secs, err := tr.ExpiresIn.Int64(); err == nil && secs > 0 {
 		return time.Now().Add(time.Duration(secs) * time.Second)
 	}
 	return time.Now().Add(5 * time.Minute)

--- a/runner/pkg/observability/prometheus/auth_test.go
+++ b/runner/pkg/observability/prometheus/auth_test.go
@@ -1,0 +1,127 @@
+package prometheus
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCoralogixAuth_SetsTokenHeader(t *testing.T) {
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("token")
+		_, _ = w.Write([]byte(`{"status":"success"}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, &http.Client{Timeout: 5 * time.Second})
+	c.Auth = NewCoralogixAuth("cx-token")
+	if _, err := c.Query(context.Background(), "up", "", ""); err != nil {
+		t.Fatal(err)
+	}
+	if got != "cx-token" {
+		t.Errorf("token header = %q", got)
+	}
+}
+
+func TestAWSAuth_SignsRequest(t *testing.T) {
+	var auth, amzDate string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth = r.Header.Get("Authorization")
+		amzDate = r.Header.Get("X-Amz-Date")
+		_, _ = w.Write([]byte(`{"status":"success"}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, &http.Client{Timeout: 5 * time.Second})
+	c.Auth = NewAWSAuth("AKIDEXAMPLE", "secret", "us-east-1", "aps")
+	if _, err := c.Query(context.Background(), "up", "", ""); err != nil {
+		t.Fatal(err)
+	}
+	// SigV4 stamps an Authorization header with the algorithm + credential
+	// scope (service "aps", region "us-east-1") and an X-Amz-Date.
+	if !strings.HasPrefix(auth, "AWS4-HMAC-SHA256 ") {
+		t.Errorf("Authorization not SigV4: %q", auth)
+	}
+	if !strings.Contains(auth, "/us-east-1/aps/aws4_request") {
+		t.Errorf("credential scope missing service/region: %q", auth)
+	}
+	if amzDate == "" {
+		t.Error("X-Amz-Date not set")
+	}
+}
+
+func TestAWSAuth_DefaultsServiceToAPS(t *testing.T) {
+	var auth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+	c := New(srv.URL, &http.Client{Timeout: 5 * time.Second})
+	c.Auth = NewAWSAuth("AKIDEXAMPLE", "secret", "eu-west-1", "")
+	if _, err := c.Query(context.Background(), "up", "", ""); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(auth, "/eu-west-1/aps/aws4_request") {
+		t.Errorf("expected default service aps: %q", auth)
+	}
+}
+
+func TestAzureAuth_MintsAndCachesBearer(t *testing.T) {
+	var tokenCalls int
+	var seenBearer string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/oauth2/token") {
+			tokenCalls++
+			_, _ = w.Write([]byte(`{"access_token":"az-tok","expires_in":"3600"}`))
+			return
+		}
+		seenBearer = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"status":"success"}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, &http.Client{Timeout: 5 * time.Second})
+	c.Auth = NewAzureAuth(AzureAuthConfig{
+		ClientID:      "cid",
+		ClientSecret:  "csecret",
+		TenantID:      "tid",
+		Resource:      "https://prometheus.monitor.azure.com",
+		TokenEndpoint: srv.URL + "/tenant/oauth2/token",
+	}, &http.Client{Timeout: 5 * time.Second})
+
+	for i := 0; i < 3; i++ {
+		if _, err := c.Query(context.Background(), "up", "", ""); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if seenBearer != "Bearer az-tok" {
+		t.Errorf("Authorization = %q", seenBearer)
+	}
+	if tokenCalls != 1 {
+		t.Errorf("expected token cached (1 mint), got %d", tokenCalls)
+	}
+}
+
+func TestNewAzureAuth_NilWhenIncomplete(t *testing.T) {
+	// Missing tenant + no managed id / secret → not authorized.
+	if a := NewAzureAuth(AzureAuthConfig{ClientID: "cid"}, nil); a != nil {
+		t.Error("expected nil authorizer for incomplete Azure config")
+	}
+}
+
+func TestAzureExpiry_PrefersExpiresOn(t *testing.T) {
+	got := azureExpiry(azureTokenResponse{ExpiresOn: "1700000000"})
+	if got.Unix() != 1700000000 {
+		t.Errorf("expiry = %d", got.Unix())
+	}
+	// Falls back to now+expires_in when expires_on absent.
+	got = azureExpiry(azureTokenResponse{ExpiresIn: "120"})
+	if d := time.Until(got); d < 100*time.Second || d > 140*time.Second {
+		t.Errorf("expires_in fallback out of range: %v", d)
+	}
+}

--- a/runner/pkg/observability/prometheus/auth_test.go
+++ b/runner/pkg/observability/prometheus/auth_test.go
@@ -107,6 +107,35 @@ func TestAzureAuth_MintsAndCachesBearer(t *testing.T) {
 	}
 }
 
+func TestAzureAuth_AcceptsNumericExpiry(t *testing.T) {
+	// The client-credentials (v2) endpoint returns expires_in as a JSON
+	// number, not a string — the response must still decode.
+	var seenBearer string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/oauth2/token") {
+			_, _ = w.Write([]byte(`{"access_token":"az-num","expires_in":3600,"expires_on":1700000000}`))
+			return
+		}
+		seenBearer = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"status":"success"}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, &http.Client{Timeout: 5 * time.Second})
+	c.Auth = NewAzureAuth(AzureAuthConfig{
+		ClientID:      "cid",
+		ClientSecret:  "csecret",
+		TenantID:      "tid",
+		TokenEndpoint: srv.URL + "/tenant/oauth2/token",
+	}, &http.Client{Timeout: 5 * time.Second})
+	if _, err := c.Query(context.Background(), "up", "", ""); err != nil {
+		t.Fatal(err)
+	}
+	if seenBearer != "Bearer az-num" {
+		t.Errorf("Authorization = %q", seenBearer)
+	}
+}
+
 func TestNewAzureAuth_NilWhenIncomplete(t *testing.T) {
 	// Missing tenant + no managed id / secret → not authorized.
 	if a := NewAzureAuth(AzureAuthConfig{ClientID: "cid"}, nil); a != nil {

--- a/runner/pkg/observability/prometheus/client.go
+++ b/runner/pkg/observability/prometheus/client.go
@@ -38,6 +38,11 @@ type Client struct {
 	// (Cortex/Mimir multi-tenant) and any auth headers the operator
 	// configures via the runner secret today (LOKI_EXTRA_HEADER pattern).
 	ExtraHeaders http.Header
+
+	// Auth applies a managed-provider auth scheme (AWS SigV4 / Azure AD /
+	// Coralogix) to each request. Nil when the backend uses plain headers
+	// or no auth. See auth.go.
+	Auth Authorizer
 }
 
 // New returns a Client. Pass an empty BaseURL to disable Prometheus access
@@ -181,6 +186,13 @@ func (c *Client) get(ctx context.Context, path string, params url.Values) (json.
 	for k, vv := range c.ExtraHeaders {
 		for _, v := range vv {
 			req.Header.Add(k, v)
+		}
+	}
+	// Auth is applied last so provider signing (AWS SigV4) covers the final
+	// header set, including any ExtraHeaders above.
+	if c.Auth != nil {
+		if err := c.Auth.Apply(ctx, req); err != nil {
+			return nil, fmt.Errorf("prometheus auth: %w", err)
 		}
 	}
 

--- a/runner/pkg/telemetry/service.go
+++ b/runner/pkg/telemetry/service.go
@@ -118,6 +118,16 @@ type Datasources struct {
 	LogsProviderStatus bool
 	LogProviderConfig  map[string]any
 
+	// PrometheusConnected is the caller-computed connectivity result: an
+	// authenticated `vector(1)` query via the prometheus client (which carries
+	// PROMETHEUS_HEADERS). Computed by the caller — like NodeAgentCount — so it
+	// reflects "can we actually query metrics?" rather than "does GET /-/healthy
+	// return 2xx?". Query-only backends (Chronosphere, Thanos Query, Grafana
+	// Mimir, Amazon Managed Prometheus) don't serve the Prometheus /-/healthy
+	// admin endpoint and require auth, so the old unauthenticated /-/healthy
+	// probe reported them Disconnected even when queries worked.
+	PrometheusConnected bool
+
 	// Prometheus retention from `flags.retentionTime` (utils.get_prometheus_flags).
 	PrometheusRetentionTime    string
 	PrometheusAdditionalLabels map[string]string
@@ -297,12 +307,12 @@ func (s *Service) postOnce(ctx context.Context) error {
 //
 // Probes implemented in-package:
 //
-//	Prometheus  /-/healthy   (utils.get_prometheus_connect.check_prometheus_connection)
 //	AlertManager /-/healthy  (silence_utils.get_alertmanager_silences_connection)
 //	OpenCost    /healthz
 //
 // Inputs the caller pre-computes (see Datasources):
 //
+//	PrometheusConnected   — authenticated `vector(1)` query via prometheus client
 //	NodeAgentCount        — Prometheus query, mirrors lines 246-264
 //	LogsProviderStatus    — loki/es/signoz health, mirrors lines 204-242
 //	GrafanaEnabled        — grafana_client.health(), mirrors lines 284-293
@@ -329,13 +339,12 @@ func (s *Service) probe(ctx context.Context, ds Datasources) ActivityStats {
 		AgentURL:                   ds.AgentURL,
 	}
 
-	// Prometheus + AlertManager: HTTP /-/healthy. A fuller connection
-	// check with prometrix is possible; we rely on /-/healthy because
-	// it's the same shape kube-prometheus-stack ships, and a working
-	// /-/healthy implies the rest.
-	if ds.PrometheusURL != "" {
-		out.PrometheusConnection = httpHealth(ctx, s.HTTP, ds.PrometheusURL+"/-/healthy")
-	}
+	// Prometheus: connectivity is computed by the caller via an authenticated
+	// query (see Datasources.PrometheusConnected) so query-only backends that
+	// don't serve /-/healthy (Chronosphere/Thanos/Mimir/AMP) report correctly.
+	out.PrometheusConnection = ds.PrometheusConnected
+	// AlertManager: HTTP /-/healthy — the endpoint kube-prometheus-stack ships,
+	// no auth needed for in-cluster AlertManager.
 	if ds.AlertManagerURL != "" {
 		out.AlertManagerConnection = httpHealth(ctx, s.HTTP, ds.AlertManagerURL+"/-/healthy")
 	}

--- a/runner/pkg/telemetry/service_test.go
+++ b/runner/pkg/telemetry/service_test.go
@@ -17,9 +17,8 @@ import (
 // and verifies the service POSTs the expected wire shape to /v1/k8s/telemetry —
 // keys the collector reads plus the URLs the UI
 // shows. Confirms:
-//   - in-package probes (Prometheus /-/healthy, AlertManager /-/healthy) flip
-//     *Connection bools correctly
-//   - caller-provided LogsProviderStatus / NodeAgentCount round-trip
+//   - AlertManager /-/healthy in-package probe flips its Connection bool
+//   - caller-provided PrometheusConnected / LogsProviderStatus / NodeAgentCount round-trip
 //   - Authorization header is bare base64 (no "Basic " prefix)
 //   - URL set + probe down → Connection=false but URL still emitted
 //   - traceProvider mirrors get_trace_provider() default ("otel_clickhouse")
@@ -61,12 +60,13 @@ func TestService_PostsActivityStatsWithProbedStatus(t *testing.T) {
 		Logger:       slog.Default(),
 		Datasources: func() Datasources {
 			return Datasources{
-				PrometheusURL:      prom.URL,
-				AlertManagerURL:    am.URL,
-				LogsProvider:       "loki",
-				LogsProviderURL:    "http://loki.svc:3100",
-				LogsProviderStatus: true,
-				NodeAgentCount:     3,
+				PrometheusURL:       prom.URL,
+				PrometheusConnected: true, // caller-computed (authenticated query)
+				AlertManagerURL:     am.URL,
+				LogsProvider:        "loki",
+				LogsProviderURL:     "http://loki.svc:3100",
+				LogsProviderStatus:  true,
+				NodeAgentCount:      3,
 			}
 		},
 		LightActions: func() []string { return []string{"prometheus_enricher"} },
@@ -253,6 +253,28 @@ func TestProbe_TraceProviderSelection(t *testing.T) {
 				t.Errorf("traceURL = %q; want %q", got, tc.url)
 			}
 		})
+	}
+}
+
+// TestProbe_PrometheusConnectionFromCaller verifies PrometheusConnection is
+// driven by the caller-computed PrometheusConnected flag, NOT an in-package
+// /-/healthy probe. This is what lets query-only backends (Chronosphere/Thanos/
+// Mimir/AMP) — which don't serve /-/healthy and require auth — report Connected.
+func TestProbe_PrometheusConnectionFromCaller(t *testing.T) {
+	// A server that 404s everything, standing in for Chronosphere (no /-/healthy).
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(404)
+	}))
+	defer backend.Close()
+	s := &Service{HTTP: &http.Client{Timeout: time.Second}, Logger: slog.Default()}
+
+	// Connected=true flows through even though /-/healthy would 404.
+	if got := s.probe(context.Background(), Datasources{PrometheusURL: backend.URL, PrometheusConnected: true}); !got.PrometheusConnection {
+		t.Error("PrometheusConnection should be true when caller reports connected")
+	}
+	// Connected=false → Disconnected, even with a URL set.
+	if got := s.probe(context.Background(), Datasources{PrometheusURL: backend.URL, PrometheusConnected: false}); got.PrometheusConnection {
+		t.Error("PrometheusConnection should be false when caller reports not connected")
 	}
 }
 


### PR DESCRIPTION
Follow-up to #509. Started as auth parity across observability clients, then two customer-driven correctness fixes were added (all discovered investigating a Chronosphere + SigNoz customer on the Go agent).

## 1. Datasource auth parity

Ported the auth mechanisms the Go agent was missing vs the Python reference:

| Datasource | Restored | Env vars |
|---|---|---|
| **Loki** | HTTP Basic-Auth | `LOKI_USERNAME`, `LOKI_PASSWORD` |
| **Jaeger** | Bearer token | `JAEGER_TOKEN` |
| **Elasticsearch** | TLS verify toggle (default false, legacy parity) | `ELASTICSEARCH_SSL_VERIFY` |
| **Prometheus** (managed) | AWS SigV4, Coralogix token, Azure AD Bearer (precedence AWS→Coralogix→Azure) | `AWS_*`, `CORALOGIX_PROMETHEUS_TOKEN`, `AZURE_*` |

AWS SigV4 uses the official `aws-sdk-go-v2/aws/signer/v4`. Azure token minting caches until 60s before expiry and accepts both string and numeric `expires_in`/`expires_on` (`json.Number`).

## 2. Logs provider: Elasticsearch is now opt-in (⚠️ breaking)

**Bug:** the Go rewrite flipped `ELASTICSEARCH_ENABLED`'s default from **false** (legacy `load_bool(..., False)`; prod chart `runner.es.enabled: false`) to **true**, and selected the logs provider by URL presence instead of the explicit enable flag. The prod chart also shipped a default `es.url` (`…elasticsearch-es-internal-http.monitoring.svc:9200`) that was inert there — but carried into a Go-agent values file it now auto-selected ES and **masked an explicitly-configured SigNoz**.

**Fix:** restore the opt-in contract — `ELASTICSEARCH_ENABLED` defaults false; chart defaults `runner.es.enabled: false` and always emits the flag, so a bare `es.url` never enables ES.

**Breaking:** deployments that enabled ES via `es.url` alone must now also set `runner.es.enabled: true`.

## 3. Prometheus health reported via authenticated query

**Bug:** the telemetry probe set `prometheusConnection` from an unauthenticated `GET {PROMETHEUS_URL}/-/healthy`. Query-only backends that don't serve that admin endpoint and require auth — Chronosphere, Thanos Query, Grafana Mimir, Amazon Managed Prometheus — returned 404/401, so the UI showed Prometheus **Disconnected** even though metric queries worked.

**Fix:** connectivity is computed in the caller via an authenticated `vector(1)` query through the prometheus client (which carries `PROMETHEUS_HEADERS`) and passed in as `Datasources.PrometheusConnected`. Works for in-cluster Prometheus and query-only backends alike.

## Not changed (verified matching / out of scope)
- Grafana proxy (already matches legacy: Basic + extra-header)
- ES API-key / basic auth, Chronosphere bearer, Loki/Prometheus extra headers — already present

## Tests
Unit tests for every path: Loki basic, Jaeger bearer, Prometheus Coralogix/AWS-SigV4/Azure(+numeric expiry), ES opt-in (stray URL must not mask SigNoz), and Prometheus authenticated-health (Chronosphere-style backend serving only `/api/v1/query`). `go build`, `go vet`, full `go test ./...`, gofmt, and `helm template` all pass.

Chart `version`/`appVersion` bumped to `0.1.7`.