### PR TITLE
fix(legacy-parity): wire prometheus_additional_labels + loud unconfigured-datasource logs

### DIFF
--- a/charts/nudgebee-agent/Chart.yaml
+++ b/charts/nudgebee-agent/Chart.yaml
@@ -29,8 +29,8 @@ annotations:
 # these are set to the right value by .github/workflows/release.yaml
 # we use 0.0.1 as a placeholder for the version` because Helm wont allow `0.0.0` and we want to be able to run
 # `helm install` on development checkouts without updating this file. the version doesn't matter in that case anyway
-version: 0.1.7
-appVersion: 0.1.7
+version: 0.1.8
+appVersion: 0.1.8
 dependencies:
 - name: opencost
   version: 2.0.1

--- a/charts/nudgebee-agent/templates/runner.yaml
+++ b/charts/nudgebee-agent/templates/runner.yaml
@@ -101,7 +101,7 @@ stringData:
   PROMETHEUS_HEADERS: {{ .Values.globalConfig.prometheus_headers | quote }}
   {{- end }}
   {{- with .Values.globalConfig.prometheus_additional_labels }}
-  {{- $p := list }}{{ range $k, $v := . }}{{ $p = append $p (printf "%s=%s" $k $v) }}{{ end }}
+  {{- $p := list }}{{ range $k, $v := . }}{{ $p = append $p (printf "%s=%v" $k $v) }}{{ end }}
   PROMETHEUS_ADDITIONAL_LABELS: {{ join "," $p | quote }}
   {{- end }}
   {{- with .Values.runner.prometheus.auth }}

--- a/charts/nudgebee-agent/templates/runner.yaml
+++ b/charts/nudgebee-agent/templates/runner.yaml
@@ -100,6 +100,10 @@ stringData:
   {{- if .Values.globalConfig.prometheus_headers }}
   PROMETHEUS_HEADERS: {{ .Values.globalConfig.prometheus_headers | quote }}
   {{- end }}
+  {{- with .Values.globalConfig.prometheus_additional_labels }}
+  {{- $p := list }}{{ range $k, $v := . }}{{ $p = append $p (printf "%s=%s" $k $v) }}{{ end }}
+  PROMETHEUS_ADDITIONAL_LABELS: {{ join "," $p | quote }}
+  {{- end }}
   {{- with .Values.runner.prometheus.auth }}
   {{- if .coralogixToken }}
   CORALOGIX_PROMETHEUS_TOKEN: {{ .coralogixToken | quote }}

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -65,7 +65,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-07-08T10-06-14_f2d9b536e5ebb3fa0b470241b64b01c6534c6bba
+    tag: 2026-07-08T12-07-17_760acd19456f642a6af7c95b2df8e071bad809fc
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -10,6 +10,10 @@ globalConfig:
   prometheus_url: ""
   # Optional headers (comma-separated "Header: value" pairs). Surfaces as PROMETHEUS_HEADERS.
   prometheus_headers: ""
+  # Optional labels appended to every PromQL query (legacy multi-cluster parity).
+  # A YAML map, e.g. {k8s_cluster: aws-prod}. Surfaces as PROMETHEUS_ADDITIONAL_LABELS
+  # in the "key=value,key=value" form the runner expects.
+  prometheus_additional_labels: {}
 enableServiceMonitors: true
 # parameters for the nudgebee forwarder deployment
 kubewatch:

--- a/runner/cmd/agent/main.go
+++ b/runner/cmd/agent/main.go
@@ -329,7 +329,7 @@ func run(ctx context.Context, logger *slog.Logger, cfg *config.Config) error {
 		// migrating from the legacy agent (which read prometheus_url from the
 		// Robusta global_config ConfigMap) by only bumping the image tag on the
 		// old chart, which never sets the PROMETHEUS_URL env the Go agent reads.
-		logger.Warn("prometheus disabled: PROMETHEUS_URL not set and none autodiscovered — prometheus_* actions, rightsizing, service-map, and the Prometheus health badge are unavailable")
+		logger.Warn("prometheus disabled: PROMETHEUS_URL not set and none autodiscovered; prometheus_* actions, rightsizing, service-map, and the Prometheus health badge are unavailable")
 	}
 
 	// Service map needs the same Prometheus client (queries Coroot eBPF

--- a/runner/cmd/agent/main.go
+++ b/runner/cmd/agent/main.go
@@ -323,6 +323,13 @@ func run(ctx context.Context, logger *slog.Logger, cfg *config.Config) error {
 		lightActions["slo_generator"] = struct{}{}
 
 		logger.Info("prometheus compat enrichers enabled", "actions", 4)
+	} else {
+		// Loud, explicit signal so a missing URL is obvious in the logs rather
+		// than inferred from the absence of "prometheus enabled". Common cause:
+		// migrating from the legacy agent (which read prometheus_url from the
+		// Robusta global_config ConfigMap) by only bumping the image tag on the
+		// old chart, which never sets the PROMETHEUS_URL env the Go agent reads.
+		logger.Warn("prometheus disabled: PROMETHEUS_URL not set and none autodiscovered — prometheus_* actions, rightsizing, service-map, and the Prometheus health badge are unavailable")
 	}
 
 	// Service map needs the same Prometheus client (queries Coroot eBPF
@@ -379,6 +386,17 @@ func run(ctx context.Context, logger *slog.Logger, cfg *config.Config) error {
 	registerProxy("signoz", cfg.SignozURL != "", signoz.Handlers(sc))
 	if cfg.SignozURL != "" {
 		logger.Info("signoz enabled", "url", cfg.SignozURL)
+	}
+
+	// Log which single logs provider will be reported to the UI and why —
+	// selection is priority-ordered (pinot → es → signoz → loki), so a
+	// configured provider can be masked by a higher-priority one (e.g. a stray
+	// ELASTICSEARCH_URL hiding SigNoz). Making the winner explicit turns that
+	// class of "I configured X but see Y" into a one-line grep.
+	if provider, url := selectedLogsProvider(cfg); provider != "" {
+		logger.Info("logs provider selected", "provider", provider, "url", url)
+	} else {
+		logger.Info("logs provider: none configured")
 	}
 
 	jc := jaeger.New(cfg.JaegerURL, nil)
@@ -1189,6 +1207,24 @@ func queryNodeAgentCount(ctx context.Context, c *prometheus.Client, logger *slog
 		return 0
 	}
 	return len(resp.Data.Result)
+}
+
+// selectedLogsProvider returns the provider (and its URL) that probeLogsProvider
+// would pick, without the network probe — for a startup log. Precedence must
+// stay in sync with probeLogsProvider: pinot → ES → signoz → loki.
+func selectedLogsProvider(cfg *config.Config) (provider, url string) {
+	switch {
+	case cfg.PinotURL != "":
+		return "pinot", cfg.PinotURL
+	case cfg.ElasticsearchEnabled && cfg.ElasticsearchURL != "":
+		return "ES", cfg.ElasticsearchURL
+	case cfg.SignozURL != "":
+		return "signoz", cfg.SignozURL
+	case cfg.LokiURL != "":
+		return "loki", cfg.LokiURL
+	default:
+		return "", ""
+	}
 }
 
 // probeLogsProvider

--- a/runner/cmd/agent/probe_test.go
+++ b/runner/cmd/agent/probe_test.go
@@ -159,3 +159,29 @@ func TestPrometheusConnected_FailuresReportDisconnected(t *testing.T) {
 		t.Error("expected connected=false for empty base URL")
 	}
 }
+
+// selectedLogsProvider must match probeLogsProvider's precedence
+// (pinot → ES → signoz → loki), including that a stray ES URL only wins when
+// ES is enabled.
+func TestSelectedLogsProvider_Precedence(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  config.Config
+		want string
+	}{
+		{"none", config.Config{}, ""},
+		{"loki only", config.Config{LokiURL: "http://loki"}, "loki"},
+		{"signoz over loki", config.Config{SignozURL: "http://sz", LokiURL: "http://loki"}, "signoz"},
+		{"es disabled → signoz wins", config.Config{ElasticsearchURL: "http://es", ElasticsearchEnabled: false, SignozURL: "http://sz"}, "signoz"},
+		{"es enabled beats signoz", config.Config{ElasticsearchURL: "http://es", ElasticsearchEnabled: true, SignozURL: "http://sz"}, "ES"},
+		{"pinot wins all", config.Config{PinotURL: "http://pinot", ElasticsearchURL: "http://es", ElasticsearchEnabled: true}, "pinot"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, _ := selectedLogsProvider(&tc.cfg)
+			if got != tc.want {
+				t.Errorf("selectedLogsProvider = %q; want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why

Diagnosing a customer migrating from the legacy (Robusta) agent to the Go agent surfaced two gaps that made a simple misconfig take far too long to find. The customer bumped only `runner.image.tag` to the Go image on their **legacy chart**, which routes `globalConfig.prometheus_url` into the Robusta `global_config` ConfigMap (what the Python agent read) — never into the `PROMETHEUS_URL` env var the Go agent reads. Result: SigNoz Connected, Prometheus Disconnected, with correct values and a valid token.

## What

**1. Chart: wire `globalConfig.prometheus_additional_labels`.**
The Go agent reads `PROMETHEUS_ADDITIONAL_LABELS` (`main.go`), but the chart only wired `prometheus_url` / `prometheus_headers` — so the legacy multi-cluster label map (e.g. `{k8s_cluster: aws-otr-eks-staging}`) was silently dropped even on a clean migration. Now converted from the YAML map to the `key=value,key=value` form the runner parses. Verified via `helm template`:
```
PROMETHEUS_ADDITIONAL_LABELS: "k8s_cluster=aws-otr-eks-staging"
```

**2. Agent: make "not configured" loud instead of silent.**
- `WARN prometheus disabled: PROMETHEUS_URL not set and none autodiscovered …` — names the common cause (image-tag-only migration on a chart that never sets the env). Previously this was only inferable from the *absence* of a `prometheus enabled` line.
- `INFO logs provider selected provider=… url=…` — logs-provider selection is priority-ordered (pinot → ES → signoz → loki), so a configured provider can be masked by a higher-priority one (a stray `ELASTICSEARCH_URL` hiding SigNoz). Making the winner explicit turns "I configured X but see Y" into a one-line grep.

## Tests
- `TestSelectedLogsProvider_Precedence` — keeps the startup summary in sync with the prober (incl. stray-ES-doesn't-mask-SigNoz).
- `helm template` renders the label env only when the map is set (empty map → nothing).
- `go build`, `go vet`, `go test ./...`, gofmt all pass.

Chart bumped to **0.1.8**.

## Note
This helps future migrations onto the new chart. The immediate customer is on the **legacy chart** and needs to move to the new chart (or set the env explicitly) — a chart migration, not an image-tag bump. That process gap is called out for follow-up.