### PR TITLE
security: bump bundled kubectl v1.32.1 -> v1.32.13

### DIFF
--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -65,7 +65,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-07-08T12-07-17_760acd19456f642a6af7c95b2df8e071bad809fc
+    tag: 2026-07-09T11-31-19_a8e27effd8f5ccfc4f8a5fc80e901e62a405f0b4
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -27,7 +27,7 @@ RUN go build \
 # build pipeline should pull the arm64 variant. Currently we only build amd64
 # images (.github/workflows/build-image.yaml).
 FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b AS kubectl
-ARG KUBECTL_VERSION=v1.32.1
+ARG KUBECTL_VERSION=v1.32.13
 RUN apk add --no-cache curl ca-certificates && \
 	curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
 	chmod +x /usr/local/bin/kubectl


### PR DESCRIPTION
## Summary

All 57 fixable CVEs in the `nudgebee-agent` image — including the Go stdlib **CRITICAL** (CVE-2025-68121) and the `golang.org/x/net` / `moby/spdystream` HIGHs — live in the **bundled `/usr/local/bin/kubectl`** binary, not the runner code (the runner is already on go 1.26.3 with patched modules). Trivy confirms all 57 findings have `PkgPath: usr/local/bin/kubectl`.

kubectl `v1.32.1` was built with go 1.23.4; `v1.32.13` (latest v1.32 patch) is built with a patched go 1.24.x and scans clean.

## Why this is safe

- **Same minor (v1.32)** — no change to Kubernetes cluster compatibility. The pin comment cautions bumping *alongside supported Kubernetes versions*; that concern is about minor versions. This is a patch bump within the already-supported minor.
- k8s backports Go toolchain security fixes into patch releases, so the patch alone clears the stdlib + x/net CVEs.

## Verification

`trivy rootfs --ignore-unfixed --severity CRITICAL,HIGH,MEDIUM` on the downloaded `v1.32.13` binary → **0 findings** (v1.32.1 → 57).

Part of the nudgebee image-hardening effort (nudgebee/nudgebee#578).