### PR TITLE
fix(chronosphere): traces endpoint 404 + auto-enable traces + report trace URL

### DIFF
--- a/charts/nudgebee-agent/Chart.yaml
+++ b/charts/nudgebee-agent/Chart.yaml
@@ -29,8 +29,8 @@ annotations:
 # these are set to the right value by .github/workflows/release.yaml
 # we use 0.0.1 as a placeholder for the version` because Helm wont allow `0.0.0` and we want to be able to run
 # `helm install` on development checkouts without updating this file. the version doesn't matter in that case anyway
-version: 0.1.8
-appVersion: 0.1.8
+version: 0.1.9
+appVersion: 0.1.9
 dependencies:
 - name: opencost
   version: 2.0.1

--- a/charts/nudgebee-agent/templates/runner.yaml
+++ b/charts/nudgebee-agent/templates/runner.yaml
@@ -195,6 +195,12 @@ stringData:
   {{- end }}
   {{- if .Values.runner.chronosphere.url }}
   CHRONOSPHERE_URL: {{ .Values.runner.chronosphere.url | quote }}
+  {{- if .Values.runner.chronosphere.tracesEnabled }}
+  CHRONOSPHERE_TRACES_ENABLED: "true"
+  {{- end }}
+  {{- if .Values.runner.chronosphere.tracesUrl }}
+  CHRONOSPHERE_TRACES_URL: {{ .Values.runner.chronosphere.tracesUrl | quote }}
+  {{- end }}
   {{- end }}
   {{- if .Values.runner.chronosphere.apiKey }}
   CHRONOSPHERE_API_KEY: {{ .Values.runner.chronosphere.apiKey | quote }}

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -65,11 +65,11 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-07-09T11-31-19_a8e27effd8f5ccfc4f8a5fc80e901e62a405f0b4
+    tag: 2026-07-09T12-54-36_10e2c3944495656eea7955fa063091cfe99866eb
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.
-  profilerImage: "ghcr.io/nudgebee/application-profiler-{}:dc5fd6d"
+  profilerImage: "ghcr.io/nudgebee/application-profiler-{}:e50de43"
   imagePullPolicy: IfNotPresent
   # Expose net/http/pprof on the runner HTTP listener (surfaces as
   # PPROF_ENABLED). Off by default — the endpoints are unauthenticated;
@@ -245,7 +245,7 @@ nodeAgent:
   image:
     repository: ghcr.io/nudgebee/node-agent
     pullPolicy: IfNotPresent
-    tag: 0.1.0
+    tag: 0.1.1
   resources:
     requests:
       cpu: "100m"

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -199,10 +199,18 @@ runner:
     # Optional Bearer token for the Jaeger query API. Surfaces as JAEGER_TOKEN.
     token: ""
   chronosphere:
-    # Chronosphere trace API endpoint. Surfaces as CHRONOSPHERE_URL. Empty →
-    # chronosphere_query_traces returns "not configured".
+    # Chronosphere endpoint for trace queries. Surfaces as CHRONOSPHERE_URL.
+    # Empty → chronosphere_query_traces returns "not configured".
     url: ""
     apiKey: ""
+    # Report Chronosphere as the traces provider (surfaces as
+    # CHRONOSPHERE_TRACES_ENABLED). Defaults on when `url` is set, so
+    # configuring the block "just works" for the Traces status; set false to
+    # keep the query action but not surface Chronosphere traces.
+    tracesEnabled: true
+    # Optional explicit traces URL (CHRONOSPHERE_TRACES_URL). When empty the
+    # agent falls back to prometheus_url if it points at chronosphere.io.
+    tracesUrl: ""
   pinot:
     # Apache Pinot broker endpoint. Surfaces as PINOT_URL. Empty →
     # pinot_* actions return "not configured".

--- a/runner/cmd/agent/main.go
+++ b/runner/cmd/agent/main.go
@@ -1006,6 +1006,7 @@ func run(ctx context.Context, logger *slog.Logger, cfg *config.Config) error {
 					JaegerQueryURL:             jaegerQueryURL,
 					ChronosphereTracesEnabled:  chronosphereEnabled,
 					ChronosphereTracesURL:      chronosphereURL,
+					ChronosphereURL:            cfg.ChronosphereURL,
 					ClickHouseStatus:           clickhouseStatus,
 					AgentURL:                   agentURL,
 					GrafanaEnabled:             grafanaURL != "" && httpProbe(probeCtx, probeClient, grafanaURL+"/api/health"),

--- a/runner/pkg/observability/chronosphere/chronosphere_test.go
+++ b/runner/pkg/observability/chronosphere/chronosphere_test.go
@@ -26,7 +26,7 @@ func TestQueryTraces_PostsBodyAndAuth(t *testing.T) {
 	if _, err := c.QueryTraces(context.Background(), map[string]any{"service": "frontend"}); err != nil {
 		t.Fatal(err)
 	}
-	if path != "/api/unstable/data/traces/searches" {
+	if path != "/api/v1/data/traces" {
 		t.Errorf("path = %q", path)
 	}
 	if auth != "Bearer tk-1" {

--- a/runner/pkg/observability/chronosphere/client.go
+++ b/runner/pkg/observability/chronosphere/client.go
@@ -2,9 +2,12 @@
 // search API.
 //
 // Action surface:
-//   - chronosphere_query_traces : POST /api/unstable/data/traces/searches
+//   - chronosphere_query_traces : POST /api/v1/data/traces
 //
-// The action_params is forwarded as the JSON body unchanged.
+// The action_params is forwarded as the JSON body unchanged. The backend
+// composes the ListTraces request body (query_type, tag_filters, time range),
+// matching the legacy agent which posts to the same /api/v1/data/traces path.
+// (The earlier /api/unstable/data/traces/searches path 404s on Chronosphere.)
 package chronosphere
 
 import (
@@ -45,7 +48,7 @@ func (c *Client) QueryTraces(ctx context.Context, params any) (json.RawMessage, 
 		return nil, fmt.Errorf("marshal: %w", err)
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
-		c.BaseURL+"/api/unstable/data/traces/searches", bytes.NewReader(body))
+		c.BaseURL+"/api/v1/data/traces", bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}

--- a/runner/pkg/telemetry/service.go
+++ b/runner/pkg/telemetry/service.go
@@ -138,6 +138,7 @@ type Datasources struct {
 	JaegerQueryURL            string // JAEGER_QUERY_URL
 	ChronosphereTracesEnabled bool   // CHRONOSPHERE_TRACES_ENABLED
 	ChronosphereTracesURL     string // CHRONOSPHERE_TRACES_URL
+	ChronosphereURL           string // CHRONOSPHERE_URL (query endpoint; reported as the traces URL when no explicit traces URL)
 	// ClickHouseStatus is the `clickhouse_status` flag — used only as the
 	// fallback for tracesEnabled when no other provider matches.
 	ClickHouseStatus bool
@@ -406,6 +407,15 @@ func traceURL(ds Datasources) string {
 	}
 	if isJaegerEnabled(ds) {
 		return ds.JaegerQueryURL
+	}
+	// For Chronosphere, report a real endpoint so the UI shows the trace
+	// backend instead of a "localhost" placeholder: explicit traces URL first,
+	// then the query endpoint (CHRONOSPHERE_URL).
+	if isChronosphereEnabled(ds) {
+		if ds.ChronosphereTracesURL != "" {
+			return ds.ChronosphereTracesURL
+		}
+		return ds.ChronosphereURL
 	}
 	return ""
 }

--- a/runner/pkg/telemetry/service_test.go
+++ b/runner/pkg/telemetry/service_test.go
@@ -208,15 +208,21 @@ func TestProbe_TraceProviderSelection(t *testing.T) {
 			url:      "bq.dataset.traces",
 		},
 		{
-			name:     "chronosphere via explicit URL",
+			name:     "chronosphere reports explicit traces URL",
 			ds:       Datasources{ChronosphereTracesEnabled: true, ChronosphereTracesURL: "https://traces.example.io"},
 			provider: "chronosphere",
 			enabled:  true,
-			// get_trace_url falls through to "" when neither TRACE_TABLE nor jaeger
-			url: "",
+			url:      "https://traces.example.io",
 		},
 		{
-			name:     "chronosphere inferred from prometheus URL",
+			name:     "chronosphere falls back to CHRONOSPHERE_URL for the traces URL",
+			ds:       Datasources{ChronosphereTracesEnabled: true, PrometheusURL: "https://abc.chronosphere.io/api/prom", ChronosphereURL: "https://abc.chronosphere.io"},
+			provider: "chronosphere",
+			enabled:  true,
+			url:      "https://abc.chronosphere.io",
+		},
+		{
+			name:     "chronosphere inferred from prometheus URL, no chronosphere URL → empty",
 			ds:       Datasources{ChronosphereTracesEnabled: true, PrometheusURL: "https://abc.chronosphere.io/api/prom"},
 			provider: "chronosphere",
 			enabled:  true,


### PR DESCRIPTION
Makes Chronosphere traces work end-to-end for a customer whose Traces view showed **No Data Available** despite the provider being detected correctly.

## 1. Wrong trace endpoint (the functional bug)
The Go client POSTed to `/api/unstable/data/traces/searches`, which Chronosphere **404s**. The correct path (legacy agent's, and the one the backend builds the `ListTraces` body for) is `/api/v1/data/traces`.

Verified live against the customer's Chronosphere:
```
POST /api/unstable/data/traces/searches           → 404 "No endpoint found"
POST /api/v1/data/traces  {query_type,start,end}  → 200 with real traces
```

## 2. Chart: auto-enable the traces provider
The Traces **status** reads `CHRONOSPHERE_TRACES_ENABLED`, which the chart never wired — so it needed a raw `additional_env_vars` workaround even though `runner.chronosphere.url` was set. Now setting `runner.chronosphere.url` also emits `CHRONOSPHERE_TRACES_ENABLED=true` (new `runner.chronosphere.tracesEnabled`, default true) plus optional `CHRONOSPHERE_TRACES_URL`.

## 3. Report the trace endpoint instead of `localhost`
For the Chronosphere provider the agent reported an empty traces URL, so the health panel showed a `localhost` placeholder. `traceURL()` now returns the explicit traces URL (or `CHRONOSPHERE_URL`).

## Tests
Unit tests updated/added (endpoint path, traceURL for chronosphere). `go build`, `go vet`, full `go test ./...`, gofmt, and `helm template` all pass. Live end-to-end query returns real trace data. Chart bumped to **0.1.9**.