### PR TITLE
fix(runner/signoz): use GET for autocomplete label/value suggests

### DIFF
--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -19,7 +19,7 @@ enableServiceMonitors: true
 kubewatch:
   image:
     repository: ghcr.io/nudgebee/kubewatch
-    tag: 2.14.1-nb.1
+    tag: 2.14.1-nb.2
   imagePullPolicy: IfNotPresent
   pprof: true
   resources:
@@ -65,7 +65,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-07-09T12-54-36_10e2c3944495656eea7955fa063091cfe99866eb
+    tag: 2026-07-10T10-44-31_3d1cca8c6c01a5b06c317a24a1f77e1b9f83ff14
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/runner/pkg/observability/signoz/client.go
+++ b/runner/pkg/observability/signoz/client.go
@@ -2,11 +2,12 @@
 //
 // Action surface:
 //   - signoz_query_range   : POST /api/v3/query_range
-//   - signoz_label_suggest : POST /api/v3/autocomplete/attribute_keys
-//   - signoz_value_suggest : POST /api/v3/autocomplete/attribute_values
+//   - signoz_label_suggest : GET  /api/v3/autocomplete/attribute_keys
+//   - signoz_value_suggest : GET  /api/v3/autocomplete/attribute_values
 //
-// All three forward the action_params JSON as the request body and return
-// the raw response. Signoz's body shapes are passthrough; backend composes.
+// query_range forwards the action_params JSON as the request body. The
+// autocomplete suggests take their params as URL query string (Signoz serves
+// those endpoints via GET). All return the raw response; backend composes.
 package signoz
 
 import (
@@ -17,6 +18,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -50,11 +53,11 @@ func (c *Client) QueryRange(ctx context.Context, params any) (json.RawMessage, e
 }
 
 func (c *Client) LabelSuggest(ctx context.Context, params any) (json.RawMessage, error) {
-	return c.post(ctx, "/api/v3/autocomplete/attribute_keys", params)
+	return c.get(ctx, "/api/v3/autocomplete/attribute_keys", params)
 }
 
 func (c *Client) ValueSuggest(ctx context.Context, params any) (json.RawMessage, error) {
-	return c.post(ctx, "/api/v3/autocomplete/attribute_values", params)
+	return c.get(ctx, "/api/v3/autocomplete/attribute_values", params)
 }
 
 func (c *Client) post(ctx context.Context, path string, params any) (json.RawMessage, error) {
@@ -73,6 +76,27 @@ func (c *Client) post(ctx context.Context, path string, params any) (json.RawMes
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	return c.do(ctx, req, path)
+}
+
+func (c *Client) get(ctx context.Context, path string, params any) (json.RawMessage, error) {
+	if c.BaseURL == "" {
+		return nil, errors.New("signoz: base URL not configured")
+	}
+	reqURL := c.BaseURL + path
+	if q := toQuery(params); len(q) > 0 {
+		reqURL += "?" + q.Encode()
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	return c.do(ctx, req, path)
+}
+
+// do applies auth + extra headers, sends the request, and returns the raw body
+// or an error for any non-2xx/3xx status. Shared by post and get.
+func (c *Client) do(ctx context.Context, req *http.Request, path string) (json.RawMessage, error) {
 	if err := c.applyAuth(ctx, req); err != nil {
 		return nil, err
 	}
@@ -94,6 +118,45 @@ func (c *Client) post(ctx context.Context, path string, params any) (json.RawMes
 		return nil, fmt.Errorf("signoz %s: HTTP %d: %s", path, resp.StatusCode, string(respBody))
 	}
 	return json.RawMessage(respBody), nil
+}
+
+// toQuery flattens a JSON-object params payload into URL query values so the
+// autocomplete GET endpoints receive dataSource/aggregateOperator/searchText/etc.
+// Nested arrays/objects are JSON-encoded; scalars are stringified.
+func toQuery(params any) url.Values {
+	if params == nil {
+		return nil
+	}
+	b, err := json.Marshal(params)
+	if err != nil {
+		return nil
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil
+	}
+	q := url.Values{}
+	for k, v := range m {
+		switch val := v.(type) {
+		case nil:
+			// skip nulls
+		case string:
+			q.Set(k, val)
+		case bool:
+			q.Set(k, strconv.FormatBool(val))
+		case float64:
+			if val == float64(int64(val)) {
+				q.Set(k, strconv.FormatInt(int64(val), 10))
+			} else {
+				q.Set(k, strconv.FormatFloat(val, 'f', -1, 64))
+			}
+		default:
+			if jb, err := json.Marshal(val); err == nil {
+				q.Set(k, string(jb))
+			}
+		}
+	}
+	return q
 }
 
 // applyAuth sets the auth header on req. Prefers the API key when set,

--- a/runner/pkg/observability/signoz/signoz_test.go
+++ b/runner/pkg/observability/signoz/signoz_test.go
@@ -104,28 +104,30 @@ func TestAPIKey_TakesPrecedenceOverPassword(t *testing.T) {
 
 func TestEachEndpoint_RoutesCorrectly(t *testing.T) {
 	cases := []struct {
-		name string
-		path string
-		fn   func(c *Client) error
+		name   string
+		path   string
+		method string
+		fn     func(c *Client) error
 	}{
-		{"query_range", "/api/v3/query_range", func(c *Client) error {
+		{"query_range", "/api/v3/query_range", http.MethodPost, func(c *Client) error {
 			_, err := c.QueryRange(context.Background(), map[string]any{})
 			return err
 		}},
-		{"label_suggest", "/api/v3/autocomplete/attribute_keys", func(c *Client) error {
+		{"label_suggest", "/api/v3/autocomplete/attribute_keys", http.MethodGet, func(c *Client) error {
 			_, err := c.LabelSuggest(context.Background(), map[string]any{})
 			return err
 		}},
-		{"value_suggest", "/api/v3/autocomplete/attribute_values", func(c *Client) error {
+		{"value_suggest", "/api/v3/autocomplete/attribute_values", http.MethodGet, func(c *Client) error {
 			_, err := c.ValueSuggest(context.Background(), map[string]any{})
 			return err
 		}},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			var path string
+			var path, method string
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				path = r.URL.Path
+				method = r.Method
 				_, _ = w.Write([]byte(`{}`))
 			}))
 			defer srv.Close()
@@ -135,6 +137,9 @@ func TestEachEndpoint_RoutesCorrectly(t *testing.T) {
 			}
 			if path != c.path {
 				t.Errorf("path = %q; want %q", path, c.path)
+			}
+			if method != c.method {
+				t.Errorf("method = %q; want %q", method, c.method)
 			}
 		})
 	}


### PR DESCRIPTION
signoz_label_suggest and signoz_value_suggest issued POST to /api/v3/autocomplete/attribute_{keys,values}, but Signoz serves those endpoints via GET — so they return HTTP 404 and log-search label/value autocomplete never populates.

Switch both to GET with the action_params flattened into the URL query string (dataSource/aggregateOperator/searchText/limit/...). Add a get helper and factor the shared auth/send/read into do so post is unchanged; query_range stays POST. Extend the routing test to assert HTTP method.

<!-- Thanks for opening a PR! Please fill in the sections below. -->

## Summary

<!-- What does this PR change and why? -->

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (chart upgrade requires user action)
- [ ] Documentation only
- [ ] CI / tooling

## Chart version

- [ ] I bumped `version` in `charts/nudgebee-agent/Chart.yaml` (required for user-visible changes)
- [ ] No version bump needed (docs/CI only)

## Test plan

<!-- How did you verify this works? -->

- [ ] `helm lint charts/nudgebee-agent` passes
- [ ] `ct lint --config .github/configs/ct.yaml` passes
- [ ] `helm template` output reviewed
- [ ] Installed on a real/kind cluster and verified the change

## Related issues

<!-- Closes #123, refs #456 -->
