### PR TITLE
feat(signoz): report Signoz server version in telemetry

### DIFF
--- a/runner/cmd/agent/main.go
+++ b/runner/cmd/agent/main.go
@@ -1256,7 +1256,13 @@ func probeLogsProvider(ctx context.Context, cfg *config.Config) (provider, url s
 	case cfg.SignozURL != "":
 		// Signoz health endpoint: /api/v1/health.
 		ok = httpProbe(ctx, httpClient, cfg.SignozURL+"/api/v1/health")
-		return "signoz", cfg.SignozURL, ok, map[string]any{}
+		providerCfg = map[string]any{}
+		// Report the Signoz server version so the backend/UI can surface it
+		// and gate version-specific behaviour. /api/v1/version is unauthed.
+		if v := fetchSignozVersion(ctx, httpClient, cfg.SignozURL); v != "" {
+			providerCfg["version"] = v
+		}
+		return "signoz", cfg.SignozURL, ok, providerCfg
 	case cfg.LokiURL != "":
 		// LOKI_URL points at the loki gateway, whose nginx only proxies the
 		// `/loki/...` API paths — the backend `/ready` is not exposed there and
@@ -1287,6 +1293,31 @@ func probeClickhouse(ctx context.Context, c *http.Client, host, port string) boo
 		return false
 	}
 	return httpProbe(ctx, c, fmt.Sprintf("http://%s:%s/ping", host, port))
+}
+
+// fetchSignozVersion GETs Signoz's /api/v1/version and returns the reported
+// server version (e.g. "v0.51.0"), or "" on any error. Unauthenticated —
+// the endpoint is public. Best-effort: a failure just omits the version.
+func fetchSignozVersion(ctx context.Context, c *http.Client, baseURL string) string {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(baseURL, "/")+"/api/v1/version", nil) //nolint:gosec // operator-provided URL
+	if err != nil {
+		return ""
+	}
+	resp, err := c.Do(req) //nolint:gosec // operator-provided URL
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return ""
+	}
+	var v struct {
+		Version string `json:"version"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
+		return ""
+	}
+	return v.Version
 }
 
 // httpProbe is a copy of telemetry.httpHealth — kept here to avoid exporting

--- a/runner/cmd/agent/signozver_test.go
+++ b/runner/cmd/agent/signozver_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestFetchSignozVersion(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		body   string
+		want   string
+	}{
+		{"ok", http.StatusOK, `{"version":"v0.51.0","ee":"Y","setupCompleted":true}`, "v0.51.0"},
+		{"empty version field", http.StatusOK, `{"ee":"Y"}`, ""},
+		{"non-200", http.StatusInternalServerError, `boom`, ""},
+		{"bad json", http.StatusOK, `not json`, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/api/v1/version" {
+					t.Errorf("unexpected path %q", r.URL.Path)
+				}
+				if r.Method != http.MethodGet {
+					t.Errorf("expected GET, got %s", r.Method)
+				}
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer srv.Close()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			got := fetchSignozVersion(ctx, srv.Client(), srv.URL)
+			if got != tt.want {
+				t.Errorf("fetchSignozVersion = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// A dead endpoint must yield "" rather than blocking or panicking.
+func TestFetchSignozVersion_Unreachable(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if got := fetchSignozVersion(ctx, &http.Client{Timeout: time.Second}, "http://127.0.0.1:1"); got != "" {
+		t.Errorf("expected empty version for unreachable host, got %q", got)
+	}
+}


### PR DESCRIPTION
## What
Adds the Signoz **server version** to the telemetry payload the agent posts to `/v1/k8s/telemetry`.

Today the telemetry poster reports the logs provider (`signoz`), its URL, and connection status, but `log_provider_config` for Signoz is an empty `{}`. This wires the version into that map:

```json
"log_provider_config": { "version": "v0.51.0" }
```

## How
- New helper `fetchSignozVersion` — GETs the **unauthenticated** `/api/v1/version` and parses `{"version": "..."}`.
- `probeLogsProvider`'s Signoz branch now populates `log_provider_config["version"]` when available.
- **Best-effort**: probed each telemetry tick alongside the existing health probe; any failure (unreachable, non-200, malformed body) just omits the version and leaves `log_provider_config` unchanged — telemetry never fails on it.

## Testing
- Unit test `TestFetchSignozVersion` (httptest): ok / empty-version / non-200 / bad-json / unreachable.
- Verified end-to-end against a live Signoz (v0.51.0) via a local telemetry sink — the real agent POST carried `log_provider_config: {"version": "v0.51.0"}`.

## Notes
- Independent of #516 (autocomplete GET fix); touches only `cmd/agent`.
- Only the Signoz provider is wired here; the same slot exists for other providers if we want to extend later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)