### PR TITLE
fix(runner/signoz): default aggregateOperator=noop for autocomplete suggests

### DIFF
--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -65,7 +65,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-07-10T10-44-31_3d1cca8c6c01a5b06c317a24a1f77e1b9f83ff14
+    tag: 2026-07-14T03-38-04_fbc9436d684526a0b45488ac510a33e5168b5ae7
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/runner/pkg/observability/signoz/client.go
+++ b/runner/pkg/observability/signoz/client.go
@@ -7,7 +7,10 @@
 //
 // query_range forwards the action_params JSON as the request body. The
 // autocomplete suggests take their params as URL query string (Signoz serves
-// those endpoints via GET). All return the raw response; backend composes.
+// those endpoints via GET) and are defaulted to dataSource=logs and
+// aggregateOperator=noop when the caller omits them — Signoz (self-hosted
+// ≤ v0.51) rejects an empty aggregateOperator with "invalid operator:". All
+// return the raw response; backend composes.
 package signoz
 
 import (
@@ -53,11 +56,33 @@ func (c *Client) QueryRange(ctx context.Context, params any) (json.RawMessage, e
 }
 
 func (c *Client) LabelSuggest(ctx context.Context, params any) (json.RawMessage, error) {
-	return c.get(ctx, "/api/v3/autocomplete/attribute_keys", params)
+	return c.get(ctx, "/api/v3/autocomplete/attribute_keys", withAutocompleteDefaults(params))
 }
 
 func (c *Client) ValueSuggest(ctx context.Context, params any) (json.RawMessage, error) {
-	return c.get(ctx, "/api/v3/autocomplete/attribute_values", params)
+	return c.get(ctx, "/api/v3/autocomplete/attribute_values", withAutocompleteDefaults(params))
+}
+
+// withAutocompleteDefaults fills in the query params Signoz's autocomplete GET
+// endpoints require but that a caller may omit. Signoz (self-hosted ≤ v0.51)
+// returns HTTP 400 "invalid operator:" when aggregateOperator is empty, and
+// defaults the source to logs. Caller-supplied values are preserved. Mirrors
+// the legacy Python client, which injected aggregateOperator=noop for these
+// endpoints.
+func withAutocompleteDefaults(params any) map[string]any {
+	m := map[string]any{}
+	if params != nil {
+		if b, err := json.Marshal(params); err == nil {
+			_ = json.Unmarshal(b, &m)
+		}
+	}
+	if s, ok := m["dataSource"].(string); !ok || s == "" {
+		m["dataSource"] = "logs"
+	}
+	if s, ok := m["aggregateOperator"].(string); !ok || s == "" {
+		m["aggregateOperator"] = "noop"
+	}
+	return m
 }
 
 func (c *Client) post(ctx context.Context, path string, params any) (json.RawMessage, error) {

--- a/runner/pkg/observability/signoz/client.go
+++ b/runner/pkg/observability/signoz/client.go
@@ -71,7 +71,16 @@ func (c *Client) ValueSuggest(ctx context.Context, params any) (json.RawMessage,
 // endpoints.
 func withAutocompleteDefaults(params any) map[string]any {
 	m := map[string]any{}
-	if params != nil {
+	switch p := params.(type) {
+	case nil:
+		// no caller params
+	case map[string]any:
+		// Common case: dispatch already hands us a map — copy it (into a fresh
+		// map so we don't mutate the caller's) instead of round-tripping JSON.
+		for k, v := range p {
+			m[k] = v
+		}
+	default:
 		if b, err := json.Marshal(params); err == nil {
 			_ = json.Unmarshal(b, &m)
 		}

--- a/runner/pkg/observability/signoz/signoz_test.go
+++ b/runner/pkg/observability/signoz/signoz_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -142,6 +143,66 @@ func TestEachEndpoint_RoutesCorrectly(t *testing.T) {
 				t.Errorf("method = %q; want %q", method, c.method)
 			}
 		})
+	}
+}
+
+func TestAutocompleteSuggests_InjectRequiredDefaults(t *testing.T) {
+	// Signoz's autocomplete GET endpoints reject an empty aggregateOperator
+	// ("invalid operator:"). The client must default dataSource=logs and
+	// aggregateOperator=noop when the caller omits them.
+	cases := []struct {
+		name string
+		fn   func(c *Client) error
+	}{
+		{"label_suggest", func(c *Client) error {
+			_, err := c.LabelSuggest(context.Background(), map[string]any{})
+			return err
+		}},
+		{"value_suggest", func(c *Client) error {
+			_, err := c.ValueSuggest(context.Background(), map[string]any{"attributeKey": "k8s.pod.name"})
+			return err
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var q url.Values
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				q = r.URL.Query()
+				_, _ = w.Write([]byte(`{}`))
+			}))
+			defer srv.Close()
+			if err := tc.fn(New(srv.URL, nil)); err != nil {
+				t.Fatal(err)
+			}
+			if got := q.Get("aggregateOperator"); got != "noop" {
+				t.Errorf("aggregateOperator = %q; want noop", got)
+			}
+			if got := q.Get("dataSource"); got != "logs" {
+				t.Errorf("dataSource = %q; want logs", got)
+			}
+		})
+	}
+}
+
+func TestAutocompleteSuggests_PreserveCallerValues(t *testing.T) {
+	var q url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q = r.URL.Query()
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+	_, err := New(srv.URL, nil).LabelSuggest(context.Background(), map[string]any{
+		"dataSource":        "traces",
+		"aggregateOperator": "count",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := q.Get("dataSource"); got != "traces" {
+		t.Errorf("dataSource = %q; want traces (caller value preserved)", got)
+	}
+	if got := q.Get("aggregateOperator"); got != "count" {
+		t.Errorf("aggregateOperator = %q; want count (caller value preserved)", got)
 	}
 }
 


### PR DESCRIPTION
## Problem

`signoz_label_suggest` is failing at dispatch on the OSS agent:

```
dispatch: handler error  action_name=signoz_label_suggest
err="signoz /api/v3/autocomplete/attribute_keys: HTTP 400:
     {\"status\":\"error\",\"errorType\":\"bad_data\",\"error\":\"invalid operator: \"}"
```

SigNoz self-hosted (**v0.51**, our tested ceiling) serves `attribute_keys` /
`attribute_values` as **GET** and **requires a non-empty `aggregateOperator`**
query param. Verified live against the cluster SigNoz (`signoz-51-frontend…:3301`):

| Request | Result |
|---|---|
| `GET …/attribute_keys?dataSource=logs` (no operator) | **400** `invalid operator:` |
| `GET …/attribute_keys?dataSource=logs&aggregateOperator=noop` | **200 OK** |

The backend composers pass params without an operator — `QueryLabels` sends
`{"dataSource":"logs"}`, `QueryLabelValues` sends neither, and the LLM
log-query agent's `GetSupportedLabels` sends `{}` — and the client's `toQuery`
is a pure flatten, so the request goes out with an empty operator → 400.

## How legacy robusta worked

The legacy Python `SignozClient` injected `aggregateOperator=noop` in the
**client** for these endpoints (gated on SigNoz ≤ v0.51.0), rather than relying
on each caller. This restores that behaviour in the Go client.

## Change

- `LabelSuggest` / `ValueSuggest` now default `dataSource=logs` and
  `aggregateOperator=noop` when the caller omits them, via
  `withAutocompleteDefaults`. Caller-supplied values are preserved.
- Single chokepoint — fixes every current caller (including the empty-`{}`
  LLM path) and future ones, without touching backend call sites.

## Tests

- `TestAutocompleteSuggests_InjectRequiredDefaults` — label + value suggests
  emit `aggregateOperator=noop` and `dataSource=logs` from an empty/param-less call.
- `TestAutocompleteSuggests_PreserveCallerValues` — caller-supplied
  `dataSource`/`aggregateOperator` are not overridden.
- `gofmt`, `go vet`, full package suite green.