### PR TITLE
chore(chart): bump nudgebee-agent chart version to 0.1.10

### DIFF
--- a/charts/nudgebee-agent/Chart.yaml
+++ b/charts/nudgebee-agent/Chart.yaml
@@ -29,8 +29,8 @@ annotations:
 # these are set to the right value by .github/workflows/release.yaml
 # we use 0.0.1 as a placeholder for the version` because Helm wont allow `0.0.0` and we want to be able to run
 # `helm install` on development checkouts without updating this file. the version doesn't matter in that case anyway
-version: 0.1.9
-appVersion: 0.1.9
+version: 0.1.10
+appVersion: 0.1.10
 dependencies:
 - name: opencost
   version: 2.0.1

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -65,7 +65,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-07-14T03-38-04_fbc9436d684526a0b45488ac510a33e5168b5ae7
+    tag: 2026-07-14T09-20-14_17a3cbad58bd80c14dee85a158cc4ec2de19e09f
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.


### PR DESCRIPTION
## Why

`0.1.9` is already released (GitHub release `nudgebee-agent-0.1.9`, 2026-07-10), but `Chart.yaml` on `main` is still pinned to `0.1.9`. As a result, `release-rc.yml` has been cutting `0.1.9-rc-*` pre-releases *after* the final `0.1.9`, and a final `release.yml` run would collide with the already-published `0.1.9`.

Bump `version`/`appVersion` to **0.1.10** so a clean chart can be cut carrying the post-0.1.9 fixes — notably the SigNoz autocomplete `aggregateOperator` fix (#518), plus #516/#517.

## After merge

- `release-rc.yml` → cuts `0.1.10-rc-N` for validation.
- `release.yml` → publishes final `0.1.10` (pins the runner image to the newest build in the release's history).

Patch bump, consistent with the 0.1.6 → 0.1.7 → 0.1.8 → 0.1.9 cadence; #515 similarly bumped `version`+`appVersion` together.