### PR TITLE
Add read-only cluster access mode for runner

### DIFF
--- a/charts/nudgebee-agent/Chart.yaml
+++ b/charts/nudgebee-agent/Chart.yaml
@@ -29,7 +29,7 @@ annotations:
 # these are set to the right value by .github/workflows/release.yaml
 # we use 0.0.1 as a placeholder for the version` because Helm wont allow `0.0.0` and we want to be able to run
 # `helm install` on development checkouts without updating this file. the version doesn't matter in that case anyway
-version: 0.1.11
+version: 0.1.12
 appVersion: 0.1.11
 dependencies:
 - name: opencost

--- a/charts/nudgebee-agent/templates/runner-service-account-readonly.yaml
+++ b/charts/nudgebee-agent/templates/runner-service-account-readonly.yaml
@@ -1,17 +1,37 @@
 {{- /*
-Standard (read-write) runner RBAC. When runner.readOnly is true this entire
-file is skipped and templates/runner-service-account-readonly.yaml renders
-instead — a strictly read-only ClusterRole plus a namespaced Role for the
-release-namespace writes the agent needs (scanner Jobs, script-runner pods,
-PrometheusRule CRUD). Keep the two files' READ rules in sync when adding
-resources here.
+Read-only runner RBAC (runner.readOnly=true). This file replaces
+templates/runner-service-account.yaml in that mode and is deliberately kept
+free of conditionals inside the rules so a security review can read it
+top-to-bottom:
+
+  - The ClusterRole is strictly get/list/watch. No Secrets API access at all
+    (not even read), no pods/exec, no pods/eviction, no ephemeralcontainers,
+    no node patch, no write verbs on anything cluster-wide.
+  - The namespaced Role at the bottom grants the only writes the agent needs,
+    confined to the RELEASE NAMESPACE: scanner Jobs (schedule_k8s_job and
+    friends), script-runner pods + their script ConfigMaps
+    (pod_script_run_enricher), exec into pods of this namespace, and
+    PrometheusRule CRUD so UI-managed alert rules keep working (the
+    alert-rule path writes to INSTALLATION_NAMESPACE = release namespace).
+
+Everything else the agent can normally do to customer workloads (delete_pod,
+drain, cordon, rollout_restart, scale, PVC ops, rightsizing applies,
+exec/profiling outside this namespace) is denied by the API server.
+
+Keep the READ rules below in sync with runner-service-account.yaml when new
+resources are added there.
 */}}
-{{- if not .Values.runner.readOnly }}
+{{- if .Values.runner.readOnly }}
+{{- if .Values.runner.enableWritePermissions }}
+{{- fail "runner.readOnly=true is incompatible with runner.enableWritePermissions=true — choose one" }}
+{{- end }}
+{{- if .Values.runner.scannerAutoCopyPullSecrets }}
+{{- fail "runner.readOnly=true is incompatible with runner.scannerAutoCopyPullSecrets=true — pull-secret auto-copy must read Secrets in workload namespaces" }}
+{{- end }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "nudgebee-agent.fullname" . }}-runner-cluster-role
-  namespace : {{ .Release.Namespace }}
   {{ if .Values.runner.serviceAccount.annotations }}
   annotations:
     {{ toYaml .Values.runner.serviceAccount.annotations | indent 4 }}
@@ -32,55 +52,17 @@ rules:
       - persistentvolumeclaims
       - pods
       - pods/status
-      - pods/exec
       - pods/log
       - replicasets
       - replicationcontrollers
       - services
       - serviceaccounts
       - endpoints
-      - secrets
-    verbs:
-      - get
-      - list
-      - watch
-
-  - apiGroups:
-      - ""
-    resources:
       - nodes
     verbs:
       - get
       - list
       - watch
-      - patch
-
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
-      - persistentvolumes
-      - persistentvolumeclaims
-      - pods
-      - pods/status
-      - pods/exec
-      - pods/log
-      - pods/eviction
-      - pods/ephemeralcontainers
-    verbs:
-      - delete
-      - create
-      - patch
-      - update
-
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    verbs:
-      - create
-      - list
-      - get
 
   - apiGroups:
       - "apiregistration.k8s.io"
@@ -95,10 +77,13 @@ rules:
     resources:
       - clusterroles
       - clusterrolebindings
+      - roles
+      - rolebindings
     verbs:
       - get
       - list
       - watch
+
   - apiGroups:
       - "autoscaling"
     resources:
@@ -107,8 +92,6 @@ rules:
       - get
       - list
       - watch
-      - patch
-      - update
 
   - apiGroups:
       - apps
@@ -123,9 +106,6 @@ rules:
       - get
       - list
       - watch
-      - patch
-      - update
-      - delete
 
   - apiGroups:
       - extensions
@@ -141,8 +121,6 @@ rules:
       - get
       - list
       - watch
-      - patch
-      - update
 
   - apiGroups:
       - batch
@@ -153,9 +131,6 @@ rules:
       - get
       - list
       - watch
-      - patch
-      - delete
-      - create
 
   - apiGroups:
       - "events.k8s.io"
@@ -168,31 +143,22 @@ rules:
   - apiGroups:
       - networking.k8s.io
     resources:
-    - ingresses
-    - networkpolicies
+      - ingresses
+      - networkpolicies
     verbs:
       - get
       - list
       - watch
-  - apiGroups:
-      - autoscaling
-    resources:
-    - horizontalpodautoscalers
-    verbs:
-      - get
-      - list
+
   - apiGroups:
       - "policy"
     resources:
-    - poddisruptionbudgets
-    - podsecuritypolicies
+      - poddisruptionbudgets
+      - podsecuritypolicies
     verbs:
       - get
       - list
-      - update
-      - patch
-  
-  # Resources affected by API deprecations/deletions
+
   - apiGroups:
       - "scheduling.k8s.io"
     resources:
@@ -201,7 +167,7 @@ rules:
       - get
       - list
       - watch
-  
+
   - apiGroups:
       - "storage.k8s.io"
     resources:
@@ -214,7 +180,7 @@ rules:
       - get
       - list
       - watch
-  
+
   - apiGroups:
       - "coordination.k8s.io"
     resources:
@@ -223,7 +189,7 @@ rules:
       - get
       - list
       - watch
-  
+
   - apiGroups:
       - "discovery.k8s.io"
     resources:
@@ -232,7 +198,7 @@ rules:
       - get
       - list
       - watch
-  
+
   - apiGroups:
       - "node.k8s.io"
     resources:
@@ -241,7 +207,7 @@ rules:
       - get
       - list
       - watch
-  
+
   - apiGroups:
       - "admissionregistration.k8s.io"
     resources:
@@ -251,7 +217,7 @@ rules:
       - get
       - list
       - watch
-  
+
   - apiGroups:
       - "flowcontrol.apiserver.k8s.io"
     resources:
@@ -261,16 +227,6 @@ rules:
       - get
       - list
       - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-    - clusterroles
-    - clusterrolebindings
-    - roles
-    - rolebindings
-    verbs:
-      - get
-      - list
 
   - apiGroups:
       - cert-manager.io
@@ -288,173 +244,26 @@ rules:
     verbs:
       - get
       - list
-      - delete
-      - create
-      - patch
-      - update
-      
+
   - apiGroups: ["metrics.k8s.io"]
     resources:
-    - pods
-    - nodes
-    verbs:     ["get", "list"]
-
-{{- if .Values.runner.enableWritePermissions }}
-  # -- Write permissions (runner.enableWritePermissions) --
-
-  # Node delete - required for node graceful shutdown (kubectl delete node)
-  - apiGroups:
-      - ""
-    resources:
+      - pods
       - nodes
-    verbs:
-      - delete
-
-  # Service lifecycle management
-  - apiGroups:
-      - ""
-    resources:
-      - services
-    verbs:
-      - create
-      - update
-      - patch
-      - delete
-
-  # Secret update/delete (base already has create/list/get)
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    verbs:
-      - update
-      - patch
-      - delete
-
-  # Namespace creation
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-    verbs:
-      - create
-      - delete
-
-  # Endpoint management
-  - apiGroups:
-      - ""
-    resources:
-      - endpoints
-    verbs:
-      - create
-      - update
-      - patch
-      - delete
-
-  # ServiceAccount management
-  - apiGroups:
-      - ""
-    resources:
-      - serviceaccounts
-    verbs:
-      - create
-      - update
-      - patch
-      - delete
-
-  # ResourceQuotas and LimitRanges
-  - apiGroups:
-      - ""
-    resources:
-      - resourcequotas
-      - limitranges
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - update
-      - patch
-      - delete
-
-  # StatefulSet scale subresource + create for all apps resources
-  - apiGroups:
-      - apps
-    resources:
-      - statefulsets/scale
-    verbs:
-      - get
-      - list
-      - watch
-      - patch
-      - update
-
-  # Workload creation (create_workload action)
-  - apiGroups:
-      - apps
-    resources:
-      - deployments
-      - statefulsets
-      - daemonsets
-      - replicasets
-    verbs:
-      - create
-
-  # Ingress write access
-  - apiGroups:
-      - networking.k8s.io
-    resources:
-      - ingresses
-      - networkpolicies
-    verbs:
-      - create
-      - update
-      - patch
-      - delete
-
-  # Extensions ingress write
-  - apiGroups:
-      - extensions
-    resources:
-      - ingresses
-    verbs:
-      - create
-      - delete
-
-  # RBAC read for roles/rolebindings (namespace-scoped)
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - roles
-      - rolebindings
-    verbs:
-      - create
-      - update
-      - patch
-      - delete
-{{- end }}
+    verbs: ["get", "list"]
 
 {{- if (.Capabilities.APIVersions.Has "argoproj.io/v1alpha1/Rollout") }}
   - apiGroups:
-    - argoproj.io
+      - argoproj.io
     resources:
-    - rollouts
+      - rollouts
     verbs:
-    - get
-    - list
-    - patch
-    - update
-{{- if .Values.runner.enableWritePermissions }}
-    - create
-    - delete
-{{- end }}
+      - get
+      - list
 {{- end }}
 
-  # Karpenter read permissions are granted unconditionally. An RBAC rule for an
-  # absent CRD is inert and becomes active the moment karpenter is installed.
-  # This avoids stale RBAC under GitOps/templated installs (where .Capabilities
-  # cannot see CRDs) or when karpenter is installed after this chart.
-  # Write verbs are gated behind runner.enableWritePermissions.
+  # Karpenter read permissions are granted unconditionally. An RBAC rule for
+  # an absent CRD is inert and becomes active the moment karpenter is
+  # installed (see runner-service-account.yaml for the full rationale).
   - apiGroups:
       - karpenter.sh
     resources:
@@ -466,12 +275,6 @@ rules:
       - get
       - list
       - watch
-{{- if .Values.runner.enableWritePermissions }}
-      - create
-      - delete
-      - patch
-      - update
-{{- end }}
 
   - apiGroups:
       - karpenter.k8s.aws
@@ -481,12 +284,6 @@ rules:
       - get
       - list
       - watch
-{{- if .Values.runner.enableWritePermissions }}
-      - create
-      - delete
-      - update
-      - patch
-{{- end }}
 
   - apiGroups:
       - karpenter.azure.com
@@ -496,12 +293,6 @@ rules:
       - get
       - list
       - watch
-{{- if .Values.runner.enableWritePermissions }}
-      - create
-      - delete
-      - update
-      - patch
-{{- end }}
 
 {{- if .Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1/VolumeSnapshot" }}
   - apiGroups:
@@ -512,8 +303,6 @@ rules:
       - get
       - list
       - watch
-      - create
-      - update
 {{- end }}
 
 {{- if .Values.openshift.enabled }}
@@ -525,6 +314,12 @@ rules:
     - use
     resourceNames:
     - {{ if .Values.openshift.createScc }}"{{ include "nudgebee-agent.fullname" . }}-scc"{{ else }}{{ .Values.openshift.sccName | quote }}{{ end }}
+{{- if .Values.openshift.createPrivilegedScc }}
+    - {{ include "nudgebee-agent.fullname" . }}-scc-privileged
+{{- end }}
+{{- if .Values.openshift.privilegedSccName }}
+    - {{ .Values.openshift.privilegedSccName }}
+{{- end }}
   - apiGroups:
     - monitoring.coreos.com
     resources:
@@ -533,21 +328,10 @@ rules:
     - alertmanagers
     - silences
     - podmonitors
-    verbs: 
+    verbs:
     - get
     - list
     - watch
-    - create
-    - update
-    - patch
-    - delete
-    - deletecollection
-{{- if .Values.openshift.createPrivilegedScc }}
-    - {{ include "nudgebee-agent.fullname" . }}-scc-privileged
-{{- end }}
-{{- if .Values.openshift.privilegedSccName }}
-    - {{ .Values.openshift.privilegedSccName }}
-{{- end }}
 {{- end }}
 
 ---
@@ -573,24 +357,53 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "nudgebee-agent.fullname" . }}-runner-service-account
     namespace: {{ .Release.Namespace }}
-{{- if .Values.runner.scannerAutoCopyPullSecrets }}
 ---
-# Auto-copy image-scan pull secrets (runner.scannerAutoCopyPullSecrets).
-# The base ClusterRole already grants secrets get/list/watch + create cluster-wide;
-# auto-copy additionally needs update/patch/delete to set the GC ownerReference
-# on, and clean up, the copies. Those destructive verbs are scoped to THIS
-# namespace only (where the copies live), not cluster-wide.
+# The ONLY writes the agent gets in readOnly mode — confined to the release
+# namespace. Deliberately no secrets rule: the agent has zero Secrets API
+# access anywhere in this mode, including its own namespace.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "nudgebee-agent.fullname" . }}-runner-scanner-pullsecrets
+  name: {{ include "nudgebee-agent.fullname" . }}-runner-namespace-writes
   namespace: {{ .Release.Namespace }}
 rules:
+  # Script-runner pods (pod_script_run_enricher) and their script ConfigMaps;
+  # scan Job pods are cleaned up by the reaper via Job ownership.
   - apiGroups:
       - ""
     resources:
-      - secrets
+      - pods
+      - configmaps
     verbs:
+      - create
+      - delete
+      - patch
+      - update
+  # Exec confined to pods of this namespace (agent self-diagnostics).
+  - apiGroups:
+      - ""
+    resources:
+      - pods/exec
+    verbs:
+      - create
+  # Scanner Jobs: schedule_k8s_job / wait_for_k8s_job / delete_k8s_job + reaper.
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - create
+      - delete
+      - patch
+      - update
+  # UI-managed Prometheus alert rules (create_or_replace_alert_rule /
+  # delete_alert_rule) — written into the install namespace.
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - prometheusrules
+    verbs:
+      - create
       - update
       - patch
       - delete
@@ -598,15 +411,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "nudgebee-agent.fullname" . }}-runner-scanner-pullsecrets
+  name: {{ include "nudgebee-agent.fullname" . }}-runner-namespace-writes
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ include "nudgebee-agent.fullname" . }}-runner-scanner-pullsecrets
+  name: {{ include "nudgebee-agent.fullname" . }}-runner-namespace-writes
 subjects:
   - kind: ServiceAccount
     name: {{ include "nudgebee-agent.fullname" . }}-runner-service-account
     namespace: {{ .Release.Namespace }}
-{{- end }}
-{{- end }}{{- /* end: not runner.readOnly */}}
+{{- end }}{{- /* end: runner.readOnly */}}

--- a/charts/nudgebee-agent/templates/runner-service-account.yaml
+++ b/charts/nudgebee-agent/templates/runner-service-account.yaml
@@ -143,7 +143,6 @@ rules:
       - patch
       - update
       - delete
-      - put
 {{- end }}
 
   - apiGroups:

--- a/charts/nudgebee-agent/templates/runner-service-account.yaml
+++ b/charts/nudgebee-agent/templates/runner-service-account.yaml
@@ -1,3 +1,17 @@
+{{- /*
+runner.readOnly renders a strictly read-only ClusterRole: get/list/watch only,
+no Secrets API access, no pods/exec, no eviction, no node patch. The writes the
+agent needs to function (scanner Jobs, script-runner pods, PrometheusRule CRUD)
+are granted by a namespaced Role in the release namespace instead — see the
+bottom of this file. Cluster-wide mutations (delete_pod, drain, cordon,
+rightsizing applies, ...) are denied by the API server in this mode.
+*/}}
+{{- if and .Values.runner.readOnly .Values.runner.enableWritePermissions }}
+{{- fail "runner.readOnly=true is incompatible with runner.enableWritePermissions=true — choose one" }}
+{{- end }}
+{{- if and .Values.runner.readOnly .Values.runner.scannerAutoCopyPullSecrets }}
+{{- fail "runner.readOnly=true is incompatible with runner.scannerAutoCopyPullSecrets=true — pull-secret auto-copy must read Secrets in workload namespaces" }}
+{{- end }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -23,14 +37,18 @@ rules:
       - persistentvolumeclaims
       - pods
       - pods/status
+{{- if not .Values.runner.readOnly }}
       - pods/exec
+{{- end }}
       - pods/log
       - replicasets
       - replicationcontrollers
       - services
       - serviceaccounts
       - endpoints
+{{- if not .Values.runner.readOnly }}
       - secrets
+{{- end }}
     verbs:
       - get
       - list
@@ -44,8 +62,12 @@ rules:
       - get
       - list
       - watch
+{{- if not .Values.runner.readOnly }}
+      # cordon/uncordon (spec.unschedulable) — mutate subsystem
       - patch
+{{- end }}
 
+{{- if not .Values.runner.readOnly }}
   - apiGroups:
       - ""
     resources:
@@ -72,6 +94,7 @@ rules:
       - create
       - list
       - get
+{{- end }}
 
   - apiGroups:
       - "apiregistration.k8s.io"
@@ -98,8 +121,10 @@ rules:
       - get
       - list
       - watch
+{{- if not .Values.runner.readOnly }}
       - patch
       - update
+{{- end }}
 
   - apiGroups:
       - apps
@@ -114,10 +139,12 @@ rules:
       - get
       - list
       - watch
+{{- if not .Values.runner.readOnly }}
       - patch
       - update
       - delete
       - put
+{{- end }}
 
   - apiGroups:
       - extensions
@@ -133,8 +160,10 @@ rules:
       - get
       - list
       - watch
+{{- if not .Values.runner.readOnly }}
       - patch
       - update
+{{- end }}
 
   - apiGroups:
       - batch
@@ -145,9 +174,13 @@ rules:
       - get
       - list
       - watch
+{{- if not .Values.runner.readOnly }}
+      # cluster-wide Job writes; scan Jobs in the release namespace are
+      # covered by the readOnly Role below
       - patch
       - delete
       - create
+{{- end }}
 
   - apiGroups:
       - "events.k8s.io"
@@ -181,8 +214,10 @@ rules:
     verbs:
       - get
       - list
+{{- if not .Values.runner.readOnly }}
       - update
       - patch
+{{- end }}
   
   # Resources affected by API deprecations/deletions
   - apiGroups:
@@ -280,10 +315,14 @@ rules:
     verbs:
       - get
       - list
+{{- if not .Values.runner.readOnly }}
+      # cluster-wide rule CRUD; under readOnly the alert-rule actions write
+      # only in the release namespace via the Role below
       - delete
       - create
       - patch
       - update
+{{- end }}
       
   - apiGroups: ["metrics.k8s.io"]
     resources:
@@ -434,8 +473,10 @@ rules:
     verbs:
     - get
     - list
+{{- if not .Values.runner.readOnly }}
     - patch
     - update
+{{- end }}
 {{- if .Values.runner.enableWritePermissions }}
     - create
     - delete
@@ -504,8 +545,10 @@ rules:
       - get
       - list
       - watch
+{{- if not .Values.runner.readOnly }}
       - create
       - update
+{{- end }}
 {{- end }}
 
 {{- if .Values.openshift.enabled }}
@@ -525,15 +568,17 @@ rules:
     - alertmanagers
     - silences
     - podmonitors
-    verbs: 
+    verbs:
     - get
     - list
     - watch
+{{- if not .Values.runner.readOnly }}
     - create
     - update
     - patch
     - delete
     - deletecollection
+{{- end }}
 {{- if .Values.openshift.createPrivilegedScc }}
     - {{ include "nudgebee-agent.fullname" . }}-scc-privileged
 {{- end }}
@@ -565,6 +610,71 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "nudgebee-agent.fullname" . }}-runner-service-account
     namespace: {{ .Release.Namespace }}
+{{- if .Values.runner.readOnly }}
+---
+# readOnly mode: the writes the agent needs to function stay confined to the
+# release namespace. This covers scanner Jobs (schedule_k8s_job & friends,
+# SCANNER_NAMESPACE is the release namespace), the pod_script_run_enricher
+# script-runner pods + their script ConfigMaps, exec into pods in this
+# namespace, and PrometheusRule CRUD for the UI's alert-rule actions (the
+# legacy path writes to INSTALLATION_NAMESPACE = release namespace).
+# Deliberately NO secrets access: with readOnly the agent has zero Secrets
+# API access anywhere, including its own namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "nudgebee-agent.fullname" . }}-runner-namespace-writes
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - configmaps
+    verbs:
+      - create
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - pods/exec
+    verbs:
+      - create
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - create
+      - delete
+      - patch
+      - update
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - prometheusrules
+    verbs:
+      - create
+      - update
+      - patch
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "nudgebee-agent.fullname" . }}-runner-namespace-writes
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "nudgebee-agent.fullname" . }}-runner-namespace-writes
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "nudgebee-agent.fullname" . }}-runner-service-account
+    namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- if .Values.runner.scannerAutoCopyPullSecrets }}
 ---
 # Auto-copy image-scan pull secrets (runner.scannerAutoCopyPullSecrets).

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -120,6 +120,24 @@ runner:
   # ingress/networkpolicy writes, resource quotas, limit ranges, namespace creation,
   # statefulset scaling, workload creation, and rollout lifecycle management.
   enableWritePermissions: false
+  # Read-only cluster access. When true the runner's ClusterRole is strictly
+  # get/list/watch — no Secrets API access at all (not even read), no
+  # pods/exec, no pod eviction, no node patch, no write verbs on any
+  # cluster-scoped or cross-namespace resource. The writes the agent needs to
+  # function are granted by a namespaced Role in the RELEASE NAMESPACE only:
+  # scanner Jobs, script-runner pods/configmaps, in-namespace exec, and
+  # PrometheusRule CRUD (so UI-managed alert rules keep working).
+  #
+  # What stops working in this mode (denied by the API server): remediation
+  # actions on customer workloads (delete_pod, drain, cordon, rollout_restart,
+  # scale, PVC ops), rightsizing APPLY (recommendations still compute),
+  # exec/profiling/terminal into pods outside the release namespace, and
+  # private-image scan pull-secret auto-copy. Helm release inventory is
+  # unaffected (the Go runner does not read Helm secrets).
+  #
+  # Mutually exclusive with enableWritePermissions and
+  # scannerAutoCopyPullSecrets — helm template fails if both are set.
+  readOnly: false
   # Kill-switch for the runner's mutate subsystem (delete_pod, cordon,
   # rollout_restart, PrometheusRule CRUD, AlertManager silences, Loki rules).
   # Default is true so the light-action alert-rule path (driven by the UI)

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -137,6 +137,8 @@ runner:
   #
   # Mutually exclusive with enableWritePermissions and
   # scannerAutoCopyPullSecrets — helm template fails if both are set.
+  # The full read-only RBAC lives in a single reviewable file:
+  # templates/runner-service-account-readonly.yaml.
   readOnly: false
   # Kill-switch for the runner's mutate subsystem (delete_pod, cordon,
   # rollout_restart, PrometheusRule CRUD, AlertManager silences, Loki rules).


### PR DESCRIPTION
## Summary

Introduces a new `runner.readOnly` configuration option that restricts the runner's ClusterRole to strictly read-only operations (get/list/watch only). When enabled, write operations are confined to a namespaced Role in the release namespace, allowing the agent to function with minimal cluster-wide permissions.

In read-only mode:
- The ClusterRole has no Secrets API access, no pods/exec, no pod eviction, no node patch, and no write verbs on cluster-scoped resources
- A new namespaced Role grants only the writes needed for core functionality: scanner Jobs, script-runner pods/ConfigMaps, in-namespace exec, and PrometheusRule CRUD
- Cluster-wide mutations (delete_pod, drain, cordon, rightsizing applies, etc.) are denied by the API server

The change includes validation to prevent incompatible configuration combinations (readOnly + enableWritePermissions, readOnly + scannerAutoCopyPullSecrets).

## Type of change

- [x] New feature (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] Breaking change (chart upgrade requires user action)
- [ ] Documentation only
- [ ] CI / tooling

## Chart version

- [x] I bumped `version` in `charts/nudgebee-agent/Chart.yaml` (required for user-visible changes)
- [ ] No version bump needed (docs/CI only)

## Test plan

- [x] `helm lint charts/nudgebee-agent` passes
- [x] `helm template` output reviewed (conditional blocks for readOnly mode verified)
- [x] Configuration validation logic verified (fail conditions for incompatible options)

https://claude.ai/code/session_01BRQ9RVJb6TBjVrC1NZdo89