### PR TITLE
fix(node-agent): drop stale coroot-node-agent command override

### DIFF
--- a/charts/nudgebee-agent/templates/daemonset.yaml
+++ b/charts/nudgebee-agent/templates/daemonset.yaml
@@ -40,7 +40,7 @@ spec:
       containers:
         - name: node-agent
           image: "{{ .Values.nodeAgent.image.repository }}:{{ .Values.nodeAgent.image.tag }}"
-          command: ["coroot-node-agent", "--cgroupfs-root", "/host/sys/fs/cgroup"]
+          args: ["--cgroupfs-root", "/host/sys/fs/cgroup"]
           imagePullPolicy: {{ .Values.nodeAgent.image.pullPolicy }}
           resources:
             {{- toYaml .Values.nodeAgent.resources | nindent 12 }}


### PR DESCRIPTION
## Problem

node-agent DaemonSet pods fail with `RunContainerError`/`CrashLoopBackOff`:

```
exec: "coroot-node-agent": executable file not found in $PATH (exit 128, StartError)
```

The node-agent image binary was renamed to `nudgebee-node-agent` (nudgebee/node-agent#247), and the `0.1.1` image tag (plus `latest`/`0`/`0.1`) was republished on 2026-07-10 with the renamed binary. The chart's DaemonSet still overrides the entrypoint with the old name, so any node that pulls the current image fails to start the container. Nodes with a pre-2026-07-10 cached `0.1.1` keep working (`imagePullPolicy: IfNotPresent`), which is why fleets show a mix of Running and crashing pods.

## Affected versions

| Chart | Default image | Status |
|---|---|---|
| 0.1.9, 0.1.9-rc-1/2, 0.1.10 | `ghcr.io/nudgebee/node-agent:0.1.1` | Broken on any fresh image pull |
| 0.1.0-rc-1 – 0.1.8 | `ghcr.io/nudgebee/node-agent:0.1.0` (pre-rename, unchanged) | OK unless image tag overridden to `0.1.1`/`latest`/`0`/`0.1` |
| 0.0.x | immutable timestamped tags | Not affected |

## Fix

Drop the `command` override and pass only `args`, relying on the image ENTRYPOINT. This works with both old (`coroot-node-agent`) and new (`nudgebee-node-agent`) image builds, and survives future binary renames.

Verified on the dev cluster (`nudgebee-agent-dev`): patched the live DaemonSet with the same change; crashlooping pods recovered.