### PR TITLE
chore(chart): bump node-agent image to 0.1.2, chart to 0.1.11

### DIFF
--- a/charts/nudgebee-agent/Chart.yaml
+++ b/charts/nudgebee-agent/Chart.yaml
@@ -29,8 +29,8 @@ annotations:
 # these are set to the right value by .github/workflows/release.yaml
 # we use 0.0.1 as a placeholder for the version` because Helm wont allow `0.0.0` and we want to be able to run
 # `helm install` on development checkouts without updating this file. the version doesn't matter in that case anyway
-version: 0.1.10
-appVersion: 0.1.10
+version: 0.1.11
+appVersion: 0.1.11
 dependencies:
 - name: opencost
   version: 2.0.1

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -253,7 +253,7 @@ nodeAgent:
   image:
     repository: ghcr.io/nudgebee/node-agent
     pullPolicy: IfNotPresent
-    tag: 0.1.1
+    tag: 0.1.2
   resources:
     requests:
       cpu: "100m"

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -253,7 +253,7 @@ nodeAgent:
   image:
     repository: ghcr.io/nudgebee/node-agent
     pullPolicy: IfNotPresent
-    tag: 0.1.2
+    tag: 0.1.1
   resources:
     requests:
       cpu: "100m"


### PR DESCRIPTION
Bumps `nodeAgent.image.tag` to `0.1.2` and the chart to `0.1.11`.

Picks up nudgebee/node-agent#293 (otel exporter startup fatal on plain-HTTP `TRACES_ENDPOINT` since the otel v1.43 bump). Completes the incident fix started in #521 — chart 0.1.10 fixed the entrypoint but still points at the broken `0.1.1` image, so fresh pulls crashloop on the otel bug.

**Do not merge until:**
1. nudgebee/node-agent#293 is merged (needs 1 approval, CI green)
2. `v0.1.2` is tagged on node-agent main and the release workflow publishes `ghcr.io/nudgebee/node-agent:0.1.2`

New immutable tag `0.1.2` instead of republishing `0.1.1` — the in-place republish of `0.1.1` on 2026-07-10 is what caused the incident.