### PR TITLE
chore(chart): bump node-agent image to 0.1.2, chart to 0.1.11

### DIFF
--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -253,7 +253,7 @@ nodeAgent:
   image:
     repository: ghcr.io/nudgebee/node-agent
     pullPolicy: IfNotPresent
-    tag: 0.1.1
+    tag: 0.1.2
   resources:
     requests:
       cpu: "100m"


### PR DESCRIPTION
node-agent 0.1.1 fatals at startup when TRACES_ENDPOINT is plain HTTP (the default in-cluster collector):

```
F tracing.go:77] insecure HTTP endpoint cannot use TLS client configuration
```

Regression from the otel v1.43 group bump (nudgebee/node-agent#293 has the fix, released as node-agent v0.1.2).

Chart 0.1.10 (current Latest) pins the broken 0.1.1 — any new node or pod restart crash-loops the node-agent. This bumps the pin to 0.1.2 and the chart to 0.1.11.

Validation: 0.1.11-rc-2 cut from this branch; being validated on dev + prod before stable release.