### PR TITLE
fix(telemetry): report tracesUrl and explain trace disconnects

### DIFF
--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -65,7 +65,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-07-15T13-13-30_037b4a042ed03716596734435acec49d9f721274
+    tag: 2026-07-15T16-09-55_6d1cadca59e43257a6b45048731c4a4c105b8699
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/runner/cmd/agent/main.go
+++ b/runner/cmd/agent/main.go
@@ -15,6 +15,7 @@ import (
 	"maps"
 	"net/http"
 	"net/http/pprof"
+	"net/url"
 	"os"
 	"os/signal"
 	"runtime"
@@ -992,7 +993,7 @@ func run(ctx context.Context, logger *slog.Logger, cfg *config.Config) error {
 				probeClient := &http.Client{Timeout: 5 * time.Second}
 				logsProvider, logsURL, logsOK, logCfg := probeLogsProvider(probeCtx, cfg)
 				as := telemetry.DetectAutoScaler(probeCtx, typedKube, providerInfo.Provider, logger)
-				clickhouseStatus := probeClickhouse(probeCtx, probeClient, clickhouseHost, clickhousePort)
+				clickhouseStatus, clickhouseErr := probeClickhouse(probeCtx, probeClient, clickhouseHost, clickhousePort)
 				return telemetry.Datasources{
 					PrometheusURL:              cfg.PrometheusURL,
 					AlertManagerURL:            cfg.AlertManagerURL,
@@ -1013,6 +1014,8 @@ func run(ctx context.Context, logger *slog.Logger, cfg *config.Config) error {
 					ChronosphereTracesURL:      chronosphereURL,
 					ChronosphereURL:            cfg.ChronosphereURL,
 					ClickHouseStatus:           clickhouseStatus,
+					ClickHouseURL:              clickhouseHost,
+					ClickHouseError:            clickhouseErr,
 					AgentURL:                   agentURL,
 					GrafanaEnabled:             grafanaURL != "" && httpProbe(probeCtx, probeClient, grafanaURL+"/api/health"),
 					AutoScalerEnabled:          as.Enabled,
@@ -1293,16 +1296,50 @@ func probeLogsProvider(ctx context.Context, cfg *config.Config) (provider, url s
 // the host is set, hit `/ping` on the HTTP port and reflect the result.
 // TRACES_ENABLED=true|false acts as an explicit override (some users run
 // an external clickhouse the agent can't reach).
-func probeClickhouse(ctx context.Context, c *http.Client, host, port string) bool {
+//
+// The second return is the reason traces are down, shipped as
+// tracesConnectionError and rendered verbatim by the UI. It is empty whenever
+// ClickHouse is healthy, and also when traces are off deliberately — an
+// operator disabling a backend isn't a failure to explain.
+func probeClickhouse(ctx context.Context, c *http.Client, host, port string) (bool, string) {
 	if v := os.Getenv("TRACES_ENABLED"); v == "true" {
-		return true
+		return true, ""
 	} else if v == "false" {
-		return false
+		return false, ""
 	}
 	if host == "" {
-		return false
+		return false, "CLICKHOUSE_HOST is not set: no traces backend is configured"
 	}
-	return httpProbe(ctx, c, fmt.Sprintf("http://%s:%s/ping", host, port))
+	if err := httpProbeErr(ctx, c, fmt.Sprintf("http://%s:%s/ping", host, port)); err != nil {
+		return false, fmt.Sprintf("ClickHouse ping failed at %s:%s: %v", redactUserinfo(host), port, probeCause(err))
+	}
+	return true, ""
+}
+
+// probeCause unwraps the *url.Error net/http wraps around transport failures.
+// The wrapper stringifies the whole request URL; the inner cause ("connection
+// refused", "i/o timeout") is the half worth showing and carries no address.
+func probeCause(err error) error {
+	var uerr *url.Error
+	if errors.As(err, &uerr) {
+		return uerr.Err
+	}
+	return err
+}
+
+// redactUserinfo strips a `user:pass@` prefix from a host. CLICKHOUSE_HOST may
+// be a full URL rather than a bare host (pkg/clickhouse normalizes both forms),
+// and the reason string built above lands in the agent's connection_status
+// JSON, which the UI renders as-is — credentials must not ride along.
+func redactUserinfo(host string) string {
+	at := strings.LastIndex(host, "@")
+	if at < 0 {
+		return host
+	}
+	if scheme := strings.Index(host, "://"); scheme >= 0 && scheme+3 <= at {
+		return host[:scheme+3] + host[at+1:]
+	}
+	return host[at+1:]
 }
 
 // fetchSignozVersion GETs Signoz's /api/v1/version and returns the reported
@@ -1336,9 +1373,15 @@ func fetchSignozVersion(ctx context.Context, c *http.Client, baseURL string) str
 // URL is sourced from operator-provided config (PROMETHEUS_URL, LOKI_URL,
 // etc.), not request-derived — taint flow is operator → probe by design.
 func httpProbe(ctx context.Context, c *http.Client, url string, headers ...map[string]string) bool {
+	return httpProbeErr(ctx, c, url, headers...) == nil
+}
+
+// httpProbeErr is httpProbe with the failure preserved, for the callers that
+// report *why* a datasource is unreachable rather than just that it is.
+func httpProbeErr(ctx context.Context, c *http.Client, url string, headers ...map[string]string) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil) //nolint:gosec // operator-provided URL
 	if err != nil {
-		return false
+		return err
 	}
 	for _, h := range headers {
 		for k, v := range h {
@@ -1347,10 +1390,13 @@ func httpProbe(ctx context.Context, c *http.Client, url string, headers ...map[s
 	}
 	resp, err := c.Do(req) //nolint:gosec // operator-provided URL
 	if err != nil {
-		return false
+		return err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	return resp.StatusCode >= 200 && resp.StatusCode < 300
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+	return nil
 }
 
 // esHTTPClient returns the HTTP client the ES query client uses. When

--- a/runner/cmd/agent/probe_test.go
+++ b/runner/cmd/agent/probe_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"encoding/base64"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/nudgebee/nudgebee-agent/pkg/config"
 	"github.com/nudgebee/nudgebee-agent/pkg/observability/prometheus"
@@ -183,5 +186,85 @@ func TestSelectedLogsProvider_Precedence(t *testing.T) {
 				t.Errorf("selectedLogsProvider = %q; want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// A ClickHouse that answers /ping is healthy and has no reason to report.
+func TestProbeClickhouse_HealthyReportsNoReason(t *testing.T) {
+	t.Setenv("TRACES_ENABLED", "")
+	ch := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ch.Close()
+
+	host, port, _ := net.SplitHostPort(strings.TrimPrefix(ch.URL, "http://"))
+	ok, reason := probeClickhouse(context.Background(), ch.Client(), host, port)
+	if !ok {
+		t.Errorf("probeClickhouse ok = false; want true")
+	}
+	if reason != "" {
+		t.Errorf("reason = %q; want empty for a healthy ClickHouse", reason)
+	}
+}
+
+// An unreachable ClickHouse must explain itself — this is the string the UI
+// renders under the Traces "Disconnected" pill.
+func TestProbeClickhouse_UnreachableReportsReason(t *testing.T) {
+	t.Setenv("TRACES_ENABLED", "")
+	// Bind and immediately close, so the port is dead but well-formed.
+	dead := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	host, port, _ := net.SplitHostPort(strings.TrimPrefix(dead.URL, "http://"))
+	dead.Close()
+
+	ok, reason := probeClickhouse(context.Background(), &http.Client{Timeout: 2 * time.Second}, host, port)
+	if ok {
+		t.Errorf("probeClickhouse ok = true; want false for a dead ClickHouse")
+	}
+	if reason == "" {
+		t.Fatal("reason = empty; want a failure explanation")
+	}
+	if !strings.Contains(reason, "ClickHouse ping failed") {
+		t.Errorf("reason = %q; want it to name the failing probe", reason)
+	}
+}
+
+// Traces off by operator choice is not a failure, so there's nothing to explain.
+func TestProbeClickhouse_ExplicitlyDisabledReportsNoReason(t *testing.T) {
+	t.Setenv("TRACES_ENABLED", "false")
+	ok, reason := probeClickhouse(context.Background(), http.DefaultClient, "ch.example", "8123")
+	if ok {
+		t.Errorf("probeClickhouse ok = true; want false under TRACES_ENABLED=false")
+	}
+	if reason != "" {
+		t.Errorf("reason = %q; want empty — disabled on purpose isn't a failure", reason)
+	}
+}
+
+// No host means traces were never wired up; say so rather than going silent.
+func TestProbeClickhouse_UnconfiguredExplainsItself(t *testing.T) {
+	t.Setenv("TRACES_ENABLED", "")
+	ok, reason := probeClickhouse(context.Background(), http.DefaultClient, "", "8123")
+	if ok {
+		t.Errorf("probeClickhouse ok = true; want false with no CLICKHOUSE_HOST")
+	}
+	if !strings.Contains(reason, "CLICKHOUSE_HOST") {
+		t.Errorf("reason = %q; want it to name the missing env var", reason)
+	}
+}
+
+// The reason string ships to the backend and renders in the UI, so a URL-form
+// CLICKHOUSE_HOST must not leak its credentials into it.
+func TestRedactUserinfo(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"clickhouse.svc:8123", "clickhouse.svc:8123"},
+		{"https://otel.last9.io:443", "https://otel.last9.io:443"},
+		{"https://admin:hunter2@otel.last9.io:443", "https://otel.last9.io:443"},
+		{"admin:hunter2@clickhouse.svc:8123", "clickhouse.svc:8123"},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		if got := redactUserinfo(tc.in); got != tc.want {
+			t.Errorf("redactUserinfo(%q) = %q; want %q", tc.in, got, tc.want)
+		}
 	}
 }

--- a/runner/pkg/telemetry/service.go
+++ b/runner/pkg/telemetry/service.go
@@ -66,6 +66,15 @@ type ActivityStats struct {
 	HealthCheckDuration        float64           `json:"healthCheckDuration,omitempty"`
 	TraceProvider              string            `json:"traceProvider,omitempty"`
 	TraceProviderConfig        map[string]any    `json:"traceProviderConfig,omitempty"`
+	// TracesConnectionError is the reason traces are disconnected, rendered by
+	// the UI's Agent Health card under the Traces pill ("Reason - ...").
+	//
+	// Deliberately no `omitempty`: the collector merges activity_stats into
+	// `agent.connection_status` with the jsonb `||` operator, so an omitted key
+	// leaves the previous value in place. Once ClickHouse recovers we must post
+	// an explicit "" to clear the stale reason — dropping the key would strand
+	// it in the DB forever.
+	TracesConnectionError string `json:"tracesConnectionError"`
 }
 
 // ClusterStatus is the wire payload posted to /v1/k8s/telemetry.
@@ -142,6 +151,15 @@ type Datasources struct {
 	// ClickHouseStatus is the `clickhouse_status` flag — used only as the
 	// fallback for tracesEnabled when no other provider matches.
 	ClickHouseStatus bool
+	// ClickHouseURL is CLICKHOUSE_HOST verbatim (bare host, no scheme/port) —
+	// same value the legacy checker put on `clickhouse_url`. Reported as
+	// tracesUrl for the otel_clickhouse provider; the backend substring-matches
+	// it to pick the trace table (`otel.traces` for Last9, else `otel_traces`).
+	ClickHouseURL string
+	// ClickHouseError is why the probe failed, already stripped of credentials
+	// by the caller. Empty when ClickHouse is healthy or was never probed
+	// (unconfigured / disabled). Surfaced as tracesConnectionError.
+	ClickHouseError string
 
 	// Node-agent: count of `up{job=~"...nudgebee(-.*)?-node-agent"}` from
 	// Prometheus, computed by the caller.
@@ -359,6 +377,13 @@ func (s *Service) probe(ctx context.Context, ds Datasources) ActivityStats {
 	out.TracesEnabled = traceStatus(ds)
 	out.TraceProvider = traceProvider(ds)
 	out.TracesURL = traceURL(ds)
+	// The reason slot only makes sense while traces are down, and ClickHouse is
+	// the only trace backend the agent actually probes — the others (bigquery,
+	// chronosphere, jaeger) are env-configured and force TracesEnabled true
+	// without a health check, so they never have a failure to report.
+	if !out.TracesEnabled {
+		out.TracesConnectionError = ds.ClickHouseError
+	}
 	// traceProviderConfig: the legacy code queries ClickHouse for the
 	// otel_traces materialized-column flag. The agent doesn't run a
 	// local ClickHouse anymore; the backend computes this. Emit an
@@ -398,9 +423,12 @@ func traceProvider(ds Datasources) string {
 	return "otel_clickhouse"
 }
 
-// traceURL mirrors get_trace_url. Note the first
-// argument `url_from_prometheus` is what the legacy passes as
-// `clickhouse_url` — we don't run a local ClickHouse, so it's always "".
+// traceURL mirrors get_trace_url. The legacy's first argument
+// `url_from_prometheus` is what it passes as `clickhouse_url` (CLICKHOUSE_HOST)
+// — reported here via isClickHouseEnabled, but checked last rather than first:
+// the legacy order returns the ClickHouse host even when TRACE_TABLE makes the
+// provider `bigquery`, and the backend then quotes that host as a BigQuery
+// table. Checking it last keeps the URL consistent with the reported provider.
 func traceURL(ds Datasources) string {
 	if ds.TraceTable != "" {
 		return ds.TraceTable
@@ -416,6 +444,9 @@ func traceURL(ds Datasources) string {
 			return ds.ChronosphereTracesURL
 		}
 		return ds.ChronosphereURL
+	}
+	if isClickHouseEnabled(ds) {
+		return ds.ClickHouseURL
 	}
 	return ""
 }
@@ -434,6 +465,18 @@ func isChronosphereEnabled(ds Datasources) bool {
 // isJaegerEnabled mirrors _is_jaeger_enabled.
 func isJaegerEnabled(ds Datasources) bool {
 	return ds.JaegerEnabled && ds.JaegerQueryURL != ""
+}
+
+// isClickHouseEnabled is the otel_clickhouse counterpart of isJaegerEnabled:
+// a reachable ClickHouse we have an address for. The status flag alone isn't
+// enough to report a URL — TRACES_ENABLED=true forces the flag on without
+// probing, so it can be true with CLICKHOUSE_HOST unset.
+//
+// Deliberately not used by traceStatus: gating tracesEnabled on the URL would
+// turn traces off for exactly that TRACES_ENABLED=true-without-host config,
+// which the agent supports for external ClickHouse it can't probe.
+func isClickHouseEnabled(ds Datasources) bool {
+	return ds.ClickHouseStatus && ds.ClickHouseURL != ""
 }
 
 // httpHealth returns true iff GET <url> returns 2xx within 5s.

--- a/runner/pkg/telemetry/service_test.go
+++ b/runner/pkg/telemetry/service_test.go
@@ -236,15 +236,44 @@ func TestProbe_TraceProviderSelection(t *testing.T) {
 		},
 		{
 			name:     "default otel_clickhouse with clickhouse down",
-			ds:       Datasources{ClickHouseStatus: false},
+			ds:       Datasources{ClickHouseStatus: false, ClickHouseURL: "nudgebee-agent-clickhouse"},
 			provider: "otel_clickhouse",
 			enabled:  false,
 		},
 		{
 			name:     "default otel_clickhouse with clickhouse up",
+			ds:       Datasources{ClickHouseStatus: true, ClickHouseURL: "nudgebee-agent-clickhouse"},
+			provider: "otel_clickhouse",
+			enabled:  true,
+			url:      "nudgebee-agent-clickhouse",
+		},
+		{
+			// TRACES_ENABLED=true forces the status flag on without a probe;
+			// with no CLICKHOUSE_HOST there's no URL to report, but traces
+			// must still read as enabled.
+			name:     "clickhouse up without a host reports no URL",
 			ds:       Datasources{ClickHouseStatus: true},
 			provider: "otel_clickhouse",
 			enabled:  true,
+		},
+		{
+			// The backend substring-matches tracesUrl to pick `otel.traces`
+			// over `otel_traces`; an empty URL silently gets the wrong table.
+			name:     "last9 clickhouse host is reported verbatim",
+			ds:       Datasources{ClickHouseStatus: true, ClickHouseURL: "otel.last9.io:443"},
+			provider: "otel_clickhouse",
+			enabled:  true,
+			url:      "otel.last9.io:443",
+		},
+		{
+			// Legacy get_trace_url checked clickhouse_url first and would
+			// return the CH host here, which the backend then quotes as a
+			// BigQuery table name.
+			name:     "TRACE_TABLE wins over a live clickhouse",
+			ds:       Datasources{TraceTable: "bq.dataset.traces", ClickHouseStatus: true, ClickHouseURL: "nudgebee-agent-clickhouse"},
+			provider: "bigquery",
+			enabled:  true,
+			url:      "bq.dataset.traces",
 		},
 	}
 	for _, tc := range cases {
@@ -334,4 +363,60 @@ func equalStrings(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+// The reason slot is meaningful only while traces are down. Because the
+// collector merges activity_stats into connection_status with jsonb `||`, a
+// recovered ClickHouse must post an explicit "" — omitting the key would strand
+// the stale reason in the DB and the UI would keep rendering it.
+func TestProbe_TracesConnectionError(t *testing.T) {
+	cases := []struct {
+		name string
+		ds   Datasources
+		want string
+	}{
+		{
+			name: "down clickhouse reports its reason",
+			ds:   Datasources{ClickHouseStatus: false, ClickHouseError: "ClickHouse ping failed at ch.svc:8123: connection refused"},
+			want: "ClickHouse ping failed at ch.svc:8123: connection refused",
+		},
+		{
+			name: "recovered clickhouse clears the reason",
+			ds:   Datasources{ClickHouseStatus: true, ClickHouseURL: "ch.svc", ClickHouseError: ""},
+			want: "",
+		},
+		{
+			// A stale error alongside a healthy backend must never render.
+			name: "healthy traces suppress a leftover reason",
+			ds:   Datasources{ClickHouseStatus: true, ClickHouseURL: "ch.svc", ClickHouseError: "connection refused"},
+			want: "",
+		},
+		{
+			// Jaeger forces TracesEnabled true without a probe; a ClickHouse
+			// reason is irrelevant and would contradict the reported provider.
+			name: "jaeger traces ignore the clickhouse reason",
+			ds:   Datasources{JaegerEnabled: true, JaegerQueryURL: "http://jaeger", ClickHouseError: "connection refused"},
+			want: "",
+		},
+	}
+	s := &Service{Logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := s.probe(context.Background(), tc.ds).TracesConnectionError; got != tc.want {
+				t.Errorf("TracesConnectionError = %q; want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// tracesConnectionError must survive JSON marshalling as an explicit "" rather
+// than vanishing — see the jsonb-merge note on the field.
+func TestActivityStats_TracesConnectionErrorAlwaysEmitted(t *testing.T) {
+	buf, err := json.Marshal(ActivityStats{})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(buf), `"tracesConnectionError":""`) {
+		t.Errorf("marshalled ActivityStats omits an empty tracesConnectionError, so the\ncollector's jsonb merge would keep a stale reason forever: %s", buf)
+	}
 }


### PR DESCRIPTION
## Summary

Two related telemetry gaps: the agent never reported `tracesUrl`, and never explained *why* traces were disconnected.

**1. `tracesUrl` was always empty for `otel_clickhouse` clusters.** The legacy sink passed `clickhouse_url` (`CLICKHOUSE_HOST`) into `get_trace_url()` (`nudgebee_sink.py:1381`). The Go port hardcoded that path to `""`, with a comment claiming "we don't run a local ClickHouse, so it's always ''" — stale, since `main.go` does read and probe `CLICKHOUSE_HOST`.

That left `agent_service.go:235`'s `TracesUrl != nil` gate permanently closed, so `TraceProviderConfig["otel_traces"]` was never written and **Last9 clusters resolved table `otel_traces` instead of `otel.traces`**. `tool_trace_clickhouse.go:136` missed the same `last9.io` check. Standard ClickHouse was unaffected — `GetTracesTableNames` defaults to the same value.

Adds `isClickHouseEnabled` as the `otel_clickhouse` counterpart of `isJaegerEnabled`, and reports the host.

**2. `tracesConnectionError` was declared and rendered, but emitted by nobody.** Declared at `agent_service.go:94`, read at `agentHealth.jsx:198`, rendered by `renderReason(!isTracesManagerConnected, tracesError)`. Since `renderReason` needs `disconnected && error` and the value was permanently `''`, the "Reason - ..." line under a Disconnected Traces pill has never once rendered. `probeClickhouse` now returns a reason alongside its status.

| Condition | `tracesConnectionError` |
|---|---|
| ClickHouse healthy | `""` |
| Ping fails | `ClickHouse ping failed at ch.svc:8123: connection refused` |
| `CLICKHOUSE_HOST` unset | `CLICKHOUSE_HOST is not set: no traces backend is configured` |
| `TRACES_ENABLED=false` | `""` — off on purpose isn't a failure |
| Traces up via any provider | `""` |

No backend or UI change needed; both consumers already exist.

## Type of change

- [x] Bug fix (non-breaking)

## Chart version

- [x] No version bump needed (docs/CI only)

Runner-only Go change, no chart templates touched. The closest precedent — #517, which also added a telemetry field — didn't bump either. Shout if that's wrong and I'll add one.

## Test plan

- [x] `go build ./...`, `go vet`, and the **full** agent suite pass (relevant: the `httpProbe` split below touches every probe caller)
- [x] New unit tests: probe reason matrix, `redactUserinfo`, reason-clears-on-recovery, and a marshalling test pinning the no-`omitempty` contract
- [ ] **Not** installed on a real cluster — verification is build + tests only

`helm lint` / `ct lint` / `helm template` not applicable (no chart changes).

## Review Notes → Risks & Counterarguments

**`httpProbe` refactor touches every probe caller.** Split into a thin `bool` wrapper over a new `httpProbeErr` that preserves the error, so Grafana/OpenCost/logs callers are untouched by construction. Full suite passes. Behaviour is identical, but it's the widest-blast-radius hunk here.

**Two deliberate deviations from legacy parity, both documented in-code:**
- ClickHouse is checked **last** in `traceURL`, not first. The legacy order returns the ClickHouse host even when `TRACE_TABLE` makes the provider `bigquery`, and the backend then backtick-quotes that host as a BigQuery table name.
- `isClickHouseEnabled` is deliberately **not** used by `traceStatus`. Gating `tracesEnabled` on the URL would turn traces off for `TRACES_ENABLED=true`-without-host — a config `main.go:1288` explicitly supports for external ClickHouse the agent can't probe.

**The no-`omitempty` on `tracesConnectionError` is load-bearing.** The collector merges into `connection_status` with jsonb `||` (`telemetry_handler.py:267`), so keys are sticky. An omitted key would strand a stale reason in the DB forever, resurfacing under any later failure that produces no message. A recovered ClickHouse must post an explicit `""` to clear it. There's a marshalling test guarding this, because it's exactly what a future "add omitempty" cleanup would silently break.

**Newly-activated backend branch.** Populating `tracesUrl` makes `agent_service.go:235` pass its gate for the first time and start writing `TraceProviderConfig["otel_traces"]`. For standard ClickHouse the written value equals the existing default, so no behaviour change; Last9 correctly switches to `otel.traces`. I traced the consumers but haven't exercised this against a live agent.

**Credential exposure was a real risk here.** The reason string lands in `connection_status` JSON and renders verbatim in the UI, and `CLICKHOUSE_HOST` may be a full URL. `redactUserinfo` strips `user:pass@` and `probeCause` unwraps `*url.Error` so the request URL never reaches the string. Belt-and-braces — net/http already strips passwords — but the username survived that.

**Pre-existing bug, deliberately not fixed:** `probeClickhouse` builds `fmt.Sprintf("http://%s:%s/ping", host, port)`, which breaks for a URL-form `CLICKHOUSE_HOST` (`http://https://x:8123/ping`); `pkg/clickhouse.normalizeHost` exists precisely for that. Those clusters already reported traces disconnected — the change is that they now get a "ping failed" reason that's true but points at the wrong culprit. In practice Last9-style setups sidestep it via `TRACES_ENABLED=true`. Worth a follow-up routing the probe through `normalizeHost`.

## Related issues

Fixes nudgebee/nudgebee-enterprise#34231
Refs nudgebee/nudgebee-enterprise#34172 — possibly related (Traces page null for `clickhouse otel`), deliberately **not** linked as a fix. This only changes real behaviour for Last9 hosts, so it's unlikely to be that root cause unless that env is Last9-backed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
