### PR TITLE
feat(runner/triggers): detect Services whose selector matches no endpoints

### DIFF
--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -273,7 +273,7 @@ nodeAgent:
   image:
     repository: ghcr.io/nudgebee/node-agent
     pullPolicy: IfNotPresent
-    tag: 0.1.2
+    tag: 0.1.3
   resources:
     requests:
       cpu: "100m"

--- a/runner/cmd/agent/main.go
+++ b/runner/cmd/agent/main.go
@@ -837,8 +837,9 @@ func run(ctx context.Context, logger *slog.Logger, cfg *config.Config) error {
 			eng = eng.WithEventsLister(newK8sEventsLister(typedKube))
 			// Service-backends lister lets service_no_endpoints resolve a
 			// Service's selector against live pods + workload templates.
-			// Without it (no K8s client) that matcher never fires.
-			eng = eng.WithServiceBackendsLister(newServiceBackendsLister(typedKube))
+			// Without it (no K8s client) that matcher never fires. The
+			// dynamic client (nilable) adds the Argo Rollouts template sweep.
+			eng = eng.WithServiceBackendsLister(newServiceBackendsLister(typedKube, dynamicKube))
 		}
 		fwd.Engine = &triggerAdapter{e: eng}
 		logger.Info("trigger engine enabled", "matcher_count", len(triggers.Builtins()))

--- a/runner/cmd/agent/main.go
+++ b/runner/cmd/agent/main.go
@@ -835,6 +835,10 @@ func run(ctx context.Context, logger *slog.Logger, cfg *config.Config) error {
 		eng := triggers.NewEngine(triggers.Builtins(), time.Now())
 		if typedKube != nil {
 			eng = eng.WithEventsLister(newK8sEventsLister(typedKube))
+			// Service-backends lister lets service_no_endpoints resolve a
+			// Service's selector against live pods + workload templates.
+			// Without it (no K8s client) that matcher never fires.
+			eng = eng.WithServiceBackendsLister(newServiceBackendsLister(typedKube))
 		}
 		fwd.Engine = &triggerAdapter{e: eng}
 		logger.Info("trigger engine enabled", "matcher_count", len(triggers.Builtins()))

--- a/runner/cmd/agent/service_backends_lister.go
+++ b/runner/cmd/agent/service_backends_lister.go
@@ -4,12 +4,21 @@ import (
 	"context"
 	"sort"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/nudgebee/nudgebee-agent/pkg/triggers"
 )
+
+// rolloutGVR is the Argo Rollouts CRD (same GVR pkg/mutate uses). Checked
+// in the workload-template sweep so a Rollout scaled to zero doesn't
+// false-positive as a selector mismatch.
+var rolloutGVR = schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "rollouts"}
 
 // serviceBackendsLister wraps a typed clientset to satisfy
 // triggers.ServiceBackendsLister. Used by the service_no_endpoints
@@ -24,16 +33,18 @@ import (
 //     cache is eventually-consistent, which is fine for a "does anything
 //     match right now" probe (the matcher's 6h rate limit absorbs any
 //     staleness-induced double fire).
-//   - The workload sweep checks Deployments, StatefulSets and DaemonSets.
-//     Bare ReplicaSets / ReplicationControllers are rare and, when they
-//     have replicas > 0, their pods exist — so the pod probe already
-//     covers them before the template sweep is consulted.
+//   - The workload sweep checks Deployments, StatefulSets, DaemonSets and
+//     (when the CRD is installed) Argo Rollouts. Bare ReplicaSets /
+//     ReplicationControllers are rare and, when they have replicas > 0,
+//     their pods exist — so the pod probe already covers them before the
+//     template sweep is consulted.
 type serviceBackendsLister struct {
-	cs kubernetes.Interface
+	cs  kubernetes.Interface
+	dyn dynamic.Interface // optional; enables the Rollouts template check
 }
 
-func newServiceBackendsLister(cs kubernetes.Interface) triggers.ServiceBackendsLister {
-	return &serviceBackendsLister{cs: cs}
+func newServiceBackendsLister(cs kubernetes.Interface, dyn dynamic.Interface) triggers.ServiceBackendsLister {
+	return &serviceBackendsLister{cs: cs, dyn: dyn}
 }
 
 func (l *serviceBackendsLister) AnyPodMatching(ctx context.Context, namespace string, selector map[string]string) (bool, error) {
@@ -86,6 +97,31 @@ func (l *serviceBackendsLister) AnyWorkloadTemplateMatching(ctx context.Context,
 			return true, nil
 		}
 	}
+	return l.anyRolloutTemplateMatching(ctx, namespace, sel)
+}
+
+// anyRolloutTemplateMatching sweeps Argo Rollouts (a common CRD-managed
+// workload) so a Rollout scaled to zero registers as a scale state rather
+// than a selector mismatch. Rollouts using workloadRef point at a
+// Deployment, which the typed sweep above already covers. A cluster
+// without the CRD (404) counts as "no rollouts", not an error.
+func (l *serviceBackendsLister) anyRolloutTemplateMatching(ctx context.Context, namespace string, sel labels.Selector) (bool, error) {
+	if l.dyn == nil {
+		return false, nil
+	}
+	list, err := l.dyn.Resource(rolloutGVR).Namespace(namespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil // CRD not installed
+		}
+		return false, err
+	}
+	for i := range list.Items {
+		tmplLabels, _, _ := unstructured.NestedStringMap(list.Items[i].Object, "spec", "template", "metadata", "labels")
+		if len(tmplLabels) > 0 && sel.Matches(labels.Set(tmplLabels)) {
+			return true, nil
+		}
+	}
 	return false, nil
 }
 
@@ -99,17 +135,21 @@ func (l *serviceBackendsLister) ListPodLabels(ctx context.Context, namespace str
 	if err != nil {
 		return nil, err
 	}
-	samples := make([]triggers.PodLabelSample, 0, len(list.Items))
-	for i := range list.Items {
+	// The apiserver returns list items sorted by metadata.name, so taking
+	// the first `limit` is already the stable prefix; the sort below only
+	// re-asserts order over those few rows (cheap) in case a cache path
+	// ever returns them unsorted.
+	n := len(list.Items)
+	if n > limit {
+		n = limit
+	}
+	samples := make([]triggers.PodLabelSample, 0, n)
+	for i := 0; i < n; i++ {
 		samples = append(samples, triggers.PodLabelSample{
 			Name:   list.Items[i].Name,
 			Labels: list.Items[i].Labels,
 		})
 	}
-	// Sort by name so the evidence table is stable across fires.
 	sort.Slice(samples, func(i, j int) bool { return samples[i].Name < samples[j].Name })
-	if len(samples) > limit {
-		samples = samples[:limit]
-	}
 	return samples, nil
 }

--- a/runner/cmd/agent/service_backends_lister.go
+++ b/runner/cmd/agent/service_backends_lister.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"context"
+	"sort"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/nudgebee/nudgebee-agent/pkg/triggers"
+)
+
+// serviceBackendsLister wraps a typed clientset to satisfy
+// triggers.ServiceBackendsLister. Used by the service_no_endpoints
+// matcher to resolve a Service's spec.selector against live pods and
+// workload pod templates.
+//
+// Implementation notes:
+//   - ResourceVersion="0" serves every LIST from the apiserver watch
+//     cache instead of a quorum read from etcd — same rationale as
+//     k8s_events_lister.go. Label selectors aren't indexed in etcd, so
+//     the etcd path would scan the whole namespace anyway; the watch
+//     cache is eventually-consistent, which is fine for a "does anything
+//     match right now" probe (the matcher's 6h rate limit absorbs any
+//     staleness-induced double fire).
+//   - The workload sweep checks Deployments, StatefulSets and DaemonSets.
+//     Bare ReplicaSets / ReplicationControllers are rare and, when they
+//     have replicas > 0, their pods exist — so the pod probe already
+//     covers them before the template sweep is consulted.
+type serviceBackendsLister struct {
+	cs kubernetes.Interface
+}
+
+func newServiceBackendsLister(cs kubernetes.Interface) triggers.ServiceBackendsLister {
+	return &serviceBackendsLister{cs: cs}
+}
+
+func (l *serviceBackendsLister) AnyPodMatching(ctx context.Context, namespace string, selector map[string]string) (bool, error) {
+	if l.cs == nil || namespace == "" || len(selector) == 0 {
+		return false, nil
+	}
+	list, err := l.cs.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector:   labels.Set(selector).String(),
+		ResourceVersion: "0",
+	})
+	if err != nil {
+		return false, err
+	}
+	return len(list.Items) > 0, nil
+}
+
+func (l *serviceBackendsLister) AnyWorkloadTemplateMatching(ctx context.Context, namespace string, selector map[string]string) (bool, error) {
+	if l.cs == nil || namespace == "" || len(selector) == 0 {
+		return false, nil
+	}
+	// A Service selector is a plain equality map: it matches a pod
+	// template whose labels carry every selector pair.
+	sel := labels.SelectorFromSet(labels.Set(selector))
+	opts := metav1.ListOptions{ResourceVersion: "0"}
+
+	deps, err := l.cs.AppsV1().Deployments(namespace).List(ctx, opts)
+	if err != nil {
+		return false, err
+	}
+	for i := range deps.Items {
+		if sel.Matches(labels.Set(deps.Items[i].Spec.Template.Labels)) {
+			return true, nil
+		}
+	}
+	stss, err := l.cs.AppsV1().StatefulSets(namespace).List(ctx, opts)
+	if err != nil {
+		return false, err
+	}
+	for i := range stss.Items {
+		if sel.Matches(labels.Set(stss.Items[i].Spec.Template.Labels)) {
+			return true, nil
+		}
+	}
+	dss, err := l.cs.AppsV1().DaemonSets(namespace).List(ctx, opts)
+	if err != nil {
+		return false, err
+	}
+	for i := range dss.Items {
+		if sel.Matches(labels.Set(dss.Items[i].Spec.Template.Labels)) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (l *serviceBackendsLister) ListPodLabels(ctx context.Context, namespace string, limit int) ([]triggers.PodLabelSample, error) {
+	if l.cs == nil || namespace == "" || limit <= 0 {
+		return nil, nil
+	}
+	list, err := l.cs.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		ResourceVersion: "0",
+	})
+	if err != nil {
+		return nil, err
+	}
+	samples := make([]triggers.PodLabelSample, 0, len(list.Items))
+	for i := range list.Items {
+		samples = append(samples, triggers.PodLabelSample{
+			Name:   list.Items[i].Name,
+			Labels: list.Items[i].Labels,
+		})
+	}
+	// Sort by name so the evidence table is stable across fires.
+	sort.Slice(samples, func(i, j int) bool { return samples[i].Name < samples[j].Name })
+	if len(samples) > limit {
+		samples = samples[:limit]
+	}
+	return samples, nil
+}

--- a/runner/pkg/triggers/engine.go
+++ b/runner/pkg/triggers/engine.go
@@ -15,12 +15,13 @@ const DefaultGraceWindow = 2 * time.Minute
 // dispatch loop. One Engine per agent process; concurrent-safe (the
 // rate-limiter has its own mutex; spec list is read-only after build).
 type Engine struct {
-	specs        []MatcherSpec
-	rl           *RateLimiter
-	startTime    time.Time
-	graceWindow  time.Duration
-	now          func() time.Time // injectable for tests
-	eventsLister K8sEventsLister  // optional; threaded into EnrichBlocks
+	specs           []MatcherSpec
+	rl              *RateLimiter
+	startTime       time.Time
+	graceWindow     time.Duration
+	now             func() time.Time      // injectable for tests
+	eventsLister    K8sEventsLister       // optional; threaded into EnrichBlocks
+	serviceBackends ServiceBackendsLister // optional; threaded into PredicateCtx + EnrichBlocks
 }
 
 // NewEngine builds an Engine with the given specs. agentStartTime should
@@ -44,6 +45,25 @@ func NewEngine(specs []MatcherSpec, agentStartTime time.Time) *Engine {
 func (e *Engine) WithEventsLister(l K8sEventsLister) *Engine {
 	e.eventsLister = l
 	return e
+}
+
+// WithServiceBackendsLister returns the engine wired with a Service-
+// backends lister. Call once at boot from main.go after building the
+// typed clientset. PredicateCtx matchers (service_no_endpoints) receive
+// it via EnrichContext; without it they never fire.
+func (e *Engine) WithServiceBackendsLister(l ServiceBackendsLister) *Engine {
+	e.serviceBackends = l
+	return e
+}
+
+// enrichContext builds the per-event context threaded into PredicateCtx
+// and EnrichBlocks. Fields are nil when the corresponding lister wasn't
+// wired at boot (unit tests / no K8s client).
+func (e *Engine) enrichContext() EnrichContext {
+	return EnrichContext{
+		EventsLister:    e.eventsLister,
+		ServiceBackends: e.serviceBackends,
+	}
 }
 
 // fetchSubjectEvents builds a "Recent <Kind> events" table for the
@@ -105,6 +125,7 @@ func (e *Engine) Match(ev IncomingK8sEvent) []Match {
 		return nil
 	}
 	matches := make([]Match, 0, 1)
+	ec := e.enrichContext()
 	for i := range e.specs {
 		spec := &e.specs[i]
 		if !kindMatches(spec.Kind, ev.Kind) {
@@ -113,7 +134,13 @@ func (e *Engine) Match(ev IncomingK8sEvent) []Match {
 		if !operationMatches(spec.Operations, ev.Operation) {
 			continue
 		}
-		if spec.Predicate == nil || !spec.Predicate(ev.Obj, ev.OldObj) {
+		// PredicateCtx (cluster-read matchers) takes precedence over the
+		// pure Predicate. A spec with neither never fires.
+		if spec.PredicateCtx != nil {
+			if !spec.PredicateCtx(ev.Obj, ev.OldObj, ec) {
+				continue
+			}
+		} else if spec.Predicate == nil || !spec.Predicate(ev.Obj, ev.OldObj) {
 			continue
 		}
 		if spec.SuppressOnResync && e.suppressedByResync(ev.Obj) {
@@ -130,9 +157,7 @@ func (e *Engine) Match(ev IncomingK8sEvent) []Match {
 		name, namespace, lowerKind, node := SubjectFromObj(ev.Kind, ev.Obj)
 		var extra []EvidenceBlock
 		if spec.EnrichBlocks != nil {
-			extra = spec.EnrichBlocks(ev.Obj, ev.OldObj, EnrichContext{
-				EventsLister: e.eventsLister,
-			})
+			extra = spec.EnrichBlocks(ev.Obj, ev.OldObj, ec)
 		}
 		// Default evidence: three K8s events tables per match —
 		//   1. subject events (Pod / Deployment / Job / ...)

--- a/runner/pkg/triggers/predicates.go
+++ b/runner/pkg/triggers/predicates.go
@@ -26,6 +26,7 @@ func Builtins() []MatcherSpec {
 		nodeUnschedulableMatcher(),
 		nodePressureMatcher(),
 		podUnschedulableMatcher(),
+		serviceNoEndpointsMatcher(),
 	}
 	// One matcher per babysitter-watched kind. We register them as
 	// separate specs (rather than `Kind: "Any"` with an in-predicate

--- a/runner/pkg/triggers/service_endpoints.go
+++ b/runner/pkg/triggers/service_endpoints.go
@@ -1,0 +1,186 @@
+package triggers
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// ------- Service selector mismatch / zero endpoints -------
+
+// serviceBackendsTimeout caps the K8s reads the predicate + enricher make
+// per Service event. Same rationale as recentEventsTimeout: the matcher
+// path is hot, never block the trigger pipeline on a slow API server.
+const serviceBackendsTimeout = 3 * time.Second
+
+// podLabelSampleLimit caps the rows of the selector-vs-pod-labels
+// comparison table attached as evidence.
+const podLabelSampleLimit = 15
+
+// serviceNoEndpointsMatcher fires when a Service's spec.selector matches
+// no pods AND no workload pod template in its namespace — the Service has
+// no endpoints and silently blackholes every request, while looking
+// healthy at a glance (the classic `kubectl patch svc … selector:
+// wrong-label` misconfiguration).
+//
+// Firing decision needs cluster state (do any pods carry these labels?),
+// so this matcher uses PredicateCtx + the ServiceBackendsLister rather
+// than a pure Predicate. With no lister wired it never fires.
+//
+// Why the workload-template check: "selector matches zero pods" alone
+// false-positives on intentional scale-to-zero (replicas=0, KEDA). A
+// selector that matches a Deployment/StatefulSet/DaemonSet pod template
+// is wired to a real workload — no pods right now is a scale state, not a
+// misconfiguration. Only a selector matching neither pods nor templates
+// is genuinely broken.
+//
+// Why UPDATE only: helm installs Services before the workloads backing
+// them (its install order sorts Services first), so firing on CREATE
+// would flag every chart install for the seconds until the Deployment's
+// pods appear. A selector broken from birth is still caught by the first
+// subsequent UPDATE (including kubewatch resync re-emits, which carry
+// obj==oldObj and re-evaluate this level-triggered predicate).
+//
+// SuppressOnResync stays false deliberately: it suppresses by
+// creationTimestamp, which would mute every Service older than the agent
+// — i.e. nearly all of them. Dedup is handled by the fingerprint
+// (ns/name/selector) + the 6h rate limit instead, mirroring the
+// node_not_ready pattern: one Finding per broken-selector episode,
+// re-fired only while still broken 6h later. A *changed* selector hashes
+// to a fresh fingerprint and fires immediately.
+func serviceNoEndpointsMatcher() MatcherSpec {
+	return MatcherSpec{
+		Name:           "service_no_endpoints",
+		Kind:           "Service",
+		Operations:     []string{"update"},
+		AggregationKey: "service_no_endpoints",
+		Priority:       "HIGH",
+		FindingType:    "issue",
+		RateLimit:      6 * time.Hour,
+		PredicateCtx:   serviceNoEndpointsPredicate,
+		FingerprintFn: func(obj map[string]any) string {
+			return fp("service_no_endpoints", metaNS(obj), metaName(obj),
+				formatSelector(serviceSelector(obj)))
+		},
+		EnrichBlocks: serviceNoEndpointsEnrichBlocks,
+	}
+}
+
+func serviceNoEndpointsPredicate(obj, _ map[string]any, ec EnrichContext) bool {
+	if ec.ServiceBackends == nil {
+		return false // unwired (unit tests / no K8s client) — cannot decide
+	}
+	sel := serviceSelector(obj)
+	if len(sel) == 0 {
+		return false // selector-less: ExternalName / manually-managed Endpoints
+	}
+	if serviceType(obj) == "ExternalName" {
+		return false // kube-proxy ignores the selector for ExternalName
+	}
+	ns := metaNS(obj)
+	if ns == "" {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), serviceBackendsTimeout)
+	defer cancel()
+	// Fail open on API errors — never alert on missing data.
+	anyPod, err := ec.ServiceBackends.AnyPodMatching(ctx, ns, sel)
+	if err != nil || anyPod {
+		return false
+	}
+	anyTemplate, err := ec.ServiceBackends.AnyWorkloadTemplateMatching(ctx, ns, sel)
+	if err != nil || anyTemplate {
+		return false // wired to a real workload → scale-to-zero, not misconfig
+	}
+	return true
+}
+
+// serviceNoEndpointsEnrichBlocks attaches what an operator needs to see
+// the mismatch without kubectl: the configured selector, a plain-language
+// statement of the condition, and a table of actual pod labels in the
+// namespace to compare against.
+func serviceNoEndpointsEnrichBlocks(obj, _ map[string]any, ec EnrichContext) []EvidenceBlock {
+	if obj == nil {
+		return nil
+	}
+	sel := serviceSelector(obj)
+	ns := metaNS(obj)
+	blocks := []EvidenceBlock{
+		headerBlock(fmt.Sprintf("Service %s has no matching endpoints", metaName(obj))),
+		markdownBlock(fmt.Sprintf("*Configured selector:* `%s`", formatSelector(sel))),
+		markdownBlock(fmt.Sprintf(
+			"No pods and no workload pod templates in namespace `%s` match this selector. "+
+				"The Service has no endpoints and cannot route traffic — requests to it fail "+
+				"even though the Service object itself looks healthy.", ns)),
+	}
+	return append(blocks, podLabelComparisonTable(ec, ns)...)
+}
+
+// podLabelComparisonTable lists pods in the namespace with their labels so
+// the selector-vs-labels mismatch is visible on the Finding card.
+func podLabelComparisonTable(ec EnrichContext, ns string) []EvidenceBlock {
+	if ec.ServiceBackends == nil || ns == "" {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), serviceBackendsTimeout)
+	defer cancel()
+	samples, err := ec.ServiceBackends.ListPodLabels(ctx, ns, podLabelSampleLimit)
+	if err != nil {
+		return nil
+	}
+	if len(samples) == 0 {
+		return []EvidenceBlock{markdownBlock(fmt.Sprintf(
+			"Namespace `%s` currently has no pods at all.", ns))}
+	}
+	rows := make([]any, 0, len(samples))
+	for _, s := range samples {
+		rows = append(rows, []any{s.Name, formatSelector(s.Labels)})
+	}
+	return []EvidenceBlock{{
+		"type": "table",
+		"data": map[string]any{
+			"table_name":       fmt.Sprintf("*Pod labels in namespace %s*", ns),
+			"headers":          []any{"pod", "labels"},
+			"rows":             rows,
+			"column_renderers": map[string]any{},
+		},
+		"additional_info": nil,
+	}}
+}
+
+// serviceSelector returns spec.selector as a string map, or nil when the
+// Service has none (ExternalName / manually-managed Endpoints).
+func serviceSelector(obj map[string]any) map[string]string {
+	spec, _ := obj["spec"].(map[string]any)
+	raw, _ := spec["selector"].(map[string]any)
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(raw))
+	for k, v := range raw {
+		s, _ := v.(string)
+		out[k] = s
+	}
+	return out
+}
+
+// serviceType returns spec.type ("ClusterIP" / "NodePort" / "LoadBalancer"
+// / "ExternalName"), or "" when unset (defaults to ClusterIP).
+func serviceType(obj map[string]any) string {
+	spec, _ := obj["spec"].(map[string]any)
+	t, _ := spec["type"].(string)
+	return t
+}
+
+// formatSelector renders a label map as sorted "k=v,k=v" — stable for
+// fingerprints and readable in evidence blocks.
+func formatSelector(sel map[string]string) string {
+	pairs := make([]string, 0, len(sel))
+	for k, v := range sel {
+		pairs = append(pairs, k+"="+v)
+	}
+	sort.Strings(pairs)
+	return strings.Join(pairs, ",")
+}

--- a/runner/pkg/triggers/service_endpoints_test.go
+++ b/runner/pkg/triggers/service_endpoints_test.go
@@ -1,0 +1,204 @@
+package triggers
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeServiceBackends is a canned-answer ServiceBackendsLister for tests.
+type fakeServiceBackends struct {
+	anyPod      bool
+	anyTemplate bool
+	podErr      error
+	templateErr error
+	samples     []PodLabelSample
+	samplesErr  error
+}
+
+func (f *fakeServiceBackends) AnyPodMatching(_ context.Context, _ string, _ map[string]string) (bool, error) {
+	return f.anyPod, f.podErr
+}
+
+func (f *fakeServiceBackends) AnyWorkloadTemplateMatching(_ context.Context, _ string, _ map[string]string) (bool, error) {
+	return f.anyTemplate, f.templateErr
+}
+
+func (f *fakeServiceBackends) ListPodLabels(_ context.Context, _ string, _ int) ([]PodLabelSample, error) {
+	return f.samples, f.samplesErr
+}
+
+// brokenService is the classic misconfiguration: selector patched to a
+// label no pod carries.
+func brokenService(t *testing.T) map[string]any {
+	t.Helper()
+	return asObj(t, `{
+		"metadata":{"name":"nginx-test","namespace":"demo-workloads"},
+		"spec":{"type":"ClusterIP","selector":{"app":"wrong-label"},
+			"ports":[{"port":80}]}
+	}`)
+}
+
+func TestServiceNoEndpoints_FiresOnSelectorMismatch(t *testing.T) {
+	m := serviceNoEndpointsMatcher()
+	ec := EnrichContext{ServiceBackends: &fakeServiceBackends{anyPod: false, anyTemplate: false}}
+	if !m.PredicateCtx(brokenService(t), nil, ec) {
+		t.Fatal("must fire when selector matches no pods and no workload templates")
+	}
+	if m.FingerprintFn(brokenService(t)) == "" {
+		t.Error("fingerprint must be non-empty")
+	}
+}
+
+func TestServiceNoEndpoints_DropsWhenPodsMatch(t *testing.T) {
+	m := serviceNoEndpointsMatcher()
+	ec := EnrichContext{ServiceBackends: &fakeServiceBackends{anyPod: true}}
+	if m.PredicateCtx(brokenService(t), nil, ec) {
+		t.Error("must not fire when the selector matches live pods")
+	}
+}
+
+func TestServiceNoEndpoints_DropsOnScaleToZero(t *testing.T) {
+	// Selector matches a Deployment's pod template but the workload has
+	// no pods right now (replicas=0 / KEDA). Scale state, not misconfig.
+	m := serviceNoEndpointsMatcher()
+	ec := EnrichContext{ServiceBackends: &fakeServiceBackends{anyPod: false, anyTemplate: true}}
+	if m.PredicateCtx(brokenService(t), nil, ec) {
+		t.Error("must not fire when the selector matches a workload pod template (scale-to-zero)")
+	}
+}
+
+func TestServiceNoEndpoints_DropsSelectorlessAndExternalName(t *testing.T) {
+	m := serviceNoEndpointsMatcher()
+	ec := EnrichContext{ServiceBackends: &fakeServiceBackends{}}
+
+	noSelector := asObj(t, `{
+		"metadata":{"name":"manual-endpoints","namespace":"prod"},
+		"spec":{"type":"ClusterIP","ports":[{"port":80}]}
+	}`)
+	if m.PredicateCtx(noSelector, nil, ec) {
+		t.Error("must not fire for a selector-less Service (manually-managed Endpoints)")
+	}
+
+	externalName := asObj(t, `{
+		"metadata":{"name":"ext","namespace":"prod"},
+		"spec":{"type":"ExternalName","externalName":"db.example.com",
+			"selector":{"app":"ignored"}}
+	}`)
+	if m.PredicateCtx(externalName, nil, ec) {
+		t.Error("must not fire for ExternalName (kube-proxy ignores the selector)")
+	}
+}
+
+func TestServiceNoEndpoints_DropsWithoutListerAndOnErrors(t *testing.T) {
+	m := serviceNoEndpointsMatcher()
+
+	if m.PredicateCtx(brokenService(t), nil, EnrichContext{}) {
+		t.Error("must not fire when no ServiceBackends lister is wired")
+	}
+
+	// Fail open: an API error must never produce a Finding.
+	ec := EnrichContext{ServiceBackends: &fakeServiceBackends{podErr: errors.New("apiserver down")}}
+	if m.PredicateCtx(brokenService(t), nil, ec) {
+		t.Error("must not fire when the pod probe errors")
+	}
+	ec = EnrichContext{ServiceBackends: &fakeServiceBackends{templateErr: errors.New("apiserver down")}}
+	if m.PredicateCtx(brokenService(t), nil, ec) {
+		t.Error("must not fire when the workload-template probe errors")
+	}
+}
+
+func TestServiceNoEndpoints_FingerprintTracksSelector(t *testing.T) {
+	m := serviceNoEndpointsMatcher()
+	a := brokenService(t)
+	b := asObj(t, `{
+		"metadata":{"name":"nginx-test","namespace":"demo-workloads"},
+		"spec":{"type":"ClusterIP","selector":{"app":"other-label"}}
+	}`)
+	if m.FingerprintFn(a) == m.FingerprintFn(b) {
+		t.Error("a changed selector must produce a fresh fingerprint (new Finding immediately)")
+	}
+	if m.FingerprintFn(a) != m.FingerprintFn(brokenService(t)) {
+		t.Error("the same broken selector must produce a stable fingerprint (rate-limit dedup)")
+	}
+}
+
+func TestServiceNoEndpoints_EnrichBlocks(t *testing.T) {
+	ec := EnrichContext{ServiceBackends: &fakeServiceBackends{
+		samples: []PodLabelSample{
+			{Name: "nginx-abc", Labels: map[string]string{"app": "nginx-test"}},
+		},
+	}}
+	blocks := serviceNoEndpointsEnrichBlocks(brokenService(t), nil, ec)
+	joined := ""
+	var haveTable bool
+	for _, b := range blocks {
+		if b["type"] == "table" {
+			haveTable = true
+			continue
+		}
+		s, _ := b["data"].(string)
+		joined += s + "\n"
+	}
+	if !strings.Contains(joined, "app=wrong-label") {
+		t.Errorf("evidence must show the configured selector; got:\n%s", joined)
+	}
+	if !haveTable {
+		t.Error("evidence must include the pod-labels comparison table")
+	}
+
+	// Empty namespace → the table degrades to a "no pods at all" note.
+	ec = EnrichContext{ServiceBackends: &fakeServiceBackends{}}
+	blocks = serviceNoEndpointsEnrichBlocks(brokenService(t), nil, ec)
+	found := false
+	for _, b := range blocks {
+		if s, _ := b["data"].(string); strings.Contains(s, "no pods at all") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("evidence must note when the namespace has no pods at all")
+	}
+}
+
+// TestServiceNoEndpoints_EndToEndThroughEngine drives the matcher through
+// Engine.Match with the kubewatch wire shape.
+func TestServiceNoEndpoints_EndToEndThroughEngine(t *testing.T) {
+	eng := NewEngine(Builtins(), time.Now().Add(-time.Hour)).
+		WithServiceBackendsLister(&fakeServiceBackends{anyPod: false, anyTemplate: false})
+	matches := eng.Match(IncomingK8sEvent{
+		Operation: "update",
+		Kind:      "Service",
+		Obj:       brokenService(t),
+		OldObj:    brokenService(t), // kubewatch aliases obj/oldObj; must still fire
+	})
+	if len(matches) != 1 {
+		t.Fatalf("want exactly 1 match, got %d", len(matches))
+	}
+	m := matches[0]
+	if m.Spec.AggregationKey != "service_no_endpoints" {
+		t.Errorf("aggregation key = %q", m.Spec.AggregationKey)
+	}
+	if m.SubjectName != "nginx-test" || m.SubjectNamespace != "demo-workloads" || m.SubjectKind != "service" {
+		t.Errorf("subject = %s/%s kind=%s", m.SubjectNamespace, m.SubjectName, m.SubjectKind)
+	}
+
+	// Same event again inside the rate-limit window → deduped.
+	if again := eng.Match(IncomingK8sEvent{
+		Operation: "update", Kind: "Service",
+		Obj: brokenService(t), OldObj: brokenService(t),
+	}); len(again) != 0 {
+		t.Errorf("repeat within rate-limit window must not re-fire, got %d", len(again))
+	}
+
+	// CREATE never fires (helm installs Services before their workloads).
+	engCreate := NewEngine(Builtins(), time.Now().Add(-time.Hour)).
+		WithServiceBackendsLister(&fakeServiceBackends{anyPod: false, anyTemplate: false})
+	if created := engCreate.Match(IncomingK8sEvent{
+		Operation: "create", Kind: "Service", Obj: brokenService(t),
+	}); len(created) != 0 {
+		t.Errorf("must not fire on CREATE, got %d", len(created))
+	}
+}

--- a/runner/pkg/triggers/types.go
+++ b/runner/pkg/triggers/types.go
@@ -50,6 +50,16 @@ type MatcherSpec struct {
 	// no clock reads (the engine handles rate-limiting + grace window).
 	Predicate func(obj, oldObj map[string]any) bool
 
+	// PredicateCtx (optional) replaces Predicate for matchers whose firing
+	// decision needs cluster reads. It receives the same EnrichContext
+	// EnrichBlocks gets, so the matcher can consult the wired listers
+	// (service_no_endpoints resolves spec.selector against live pods —
+	// not derivable from the watched Service object alone). When set,
+	// Predicate is ignored. Implementations must treat nil context
+	// helpers as "cannot decide" and return false — never fire on
+	// missing data.
+	PredicateCtx func(obj, oldObj map[string]any, ec EnrichContext) bool
+
 	// AggregationKey is set on the emitted Finding. Determines how the
 	// UI groups + dedupes. We use the legacy strings (so the UI's
 	// per-aggregation_key handling stays unchanged).
@@ -109,6 +119,12 @@ type EnrichContext struct {
 	// client at startup; nil in unit tests, in which case event-table
 	// blocks degrade to "events unavailable".
 	EventsLister K8sEventsLister
+
+	// ServiceBackends resolves a Service selector against live pods and
+	// workload pod templates. Set when the engine was wired with a K8s
+	// client at startup; nil in unit tests, in which case the
+	// service_no_endpoints matcher never fires.
+	ServiceBackends ServiceBackendsLister
 }
 
 // K8sEventsLister fetches recent K8s events for an object. The engine
@@ -128,6 +144,42 @@ type EnrichContext struct {
 // K8s client) — matchers handle it by emitting a placeholder event-table block.
 type K8sEventsLister interface {
 	ListEvents(ctx context.Context, namespace, kind, name string, limit int) ([]K8sEvent, error)
+}
+
+// ServiceBackendsLister resolves Service selectors against cluster state.
+// Used by the service_no_endpoints matcher: whether any pod (or any
+// workload pod template) matches the Service's spec.selector is cluster
+// state, not derivable from the watched Service object alone.
+//
+// Implementation lives in cmd/agent/service_backends_lister.go and wraps
+// the typed clientset. A nil lister is valid (tests, environments without
+// a K8s client) — the matcher then never fires.
+type ServiceBackendsLister interface {
+	// AnyPodMatching reports whether any pod in the namespace carries
+	// every label pair in selector. Pod phase is ignored — a crashing pod
+	// still backs the Service's endpoints (its brokenness is another
+	// matcher's concern).
+	AnyPodMatching(ctx context.Context, namespace string, selector map[string]string) (bool, error)
+
+	// AnyWorkloadTemplateMatching reports whether any workload
+	// (Deployment / StatefulSet / DaemonSet) in the namespace has a pod
+	// template whose labels carry every pair in selector. True means the
+	// selector is wired to a real workload that currently has no pods
+	// (scaled to zero, mid-rollout) — a scale state, not a
+	// misconfiguration.
+	AnyWorkloadTemplateMatching(ctx context.Context, namespace string, selector map[string]string) (bool, error)
+
+	// ListPodLabels returns up to limit (name, labels) samples of pods in
+	// the namespace, used as selector-vs-labels comparison evidence on
+	// the emitted Finding.
+	ListPodLabels(ctx context.Context, namespace string, limit int) ([]PodLabelSample, error)
+}
+
+// PodLabelSample is one pod's name + labels, for the "compare the
+// configured selector against actual pod labels" evidence table.
+type PodLabelSample struct {
+	Name   string
+	Labels map[string]string
 }
 
 // K8sEvent is the subset of corev1.Event the agent surfaces in


### PR DESCRIPTION
## Context

A Kubernetes Service whose `spec.selector` matches no pods (e.g. a selector accidentally patched to a label nothing carries) silently loses all endpoints: traffic to it fails while the Service object itself looks healthy. Today the agent surfaces nothing for this — the misconfiguration is only visible via kubectl (`get endpoints`, comparing selector to pod labels).

## What

New `service_no_endpoints` trigger in the runner's kubewatch matcher engine. Fires when a Service's `spec.selector` matches **no pods and no workload pod template** in its namespace — the Service has no endpoints and blackholes every request.

- **New `PredicateCtx` hook on `MatcherSpec`** — like `Predicate`, but receives `EnrichContext`, for matchers whose firing decision needs cluster reads. Whether any pod carries the selector's labels is cluster state, not derivable from the watched Service object alone.
- **New `ServiceBackendsLister`** (implemented in `cmd/agent`, wraps the typed clientset with watch-cache LISTs, 3s timeout): any-pod-matching probe, any-workload-template-matching probe (Deployments / StatefulSets / DaemonSets), and pod-label samples for evidence.
- **Evidence blocks**: configured selector, plain-language condition, and a pod-labels-in-namespace comparison table — the selector-vs-labels mismatch is visible on the Finding card without kubectl. Engine-default event tables append on top.

## False-positive guards

- **Scale-to-zero is not flagged**: a selector matching a workload pod template with zero live pods (replicas=0, KEDA) is a scale state, not a misconfiguration. Only a selector matching *neither* pods *nor* templates fires.
- **CREATE never fires** — helm installs Services before the workloads backing them; a selector broken from birth is caught by the first subsequent UPDATE (incl. kubewatch resync re-emits).
- Selector-less Services (manually-managed Endpoints) and `ExternalName` are skipped.
- API errors fail open — never alert on missing data.
- Dedup: fingerprint on `ns/name/selector` + 6h rate limit (node_not_ready pattern). A *changed* selector fingerprints fresh and fires immediately.

## Testing

- 8 new unit tests covering fire/drop paths, fail-open on API errors, fingerprint stability, evidence blocks, and end-to-end through `Engine.Match` with the kubewatch wire shape (obj==oldObj aliasing, rate-limit dedup, CREATE suppression).
- `go build ./...`, `go vet`, full `go test ./...` pass.

## Notes

- Backend: the new `service_no_endpoints` aggregation_key flows through the default Finding path; per-key UI rendering/playbook mapping (nudgebee repo) can follow up.
- Steady-state pod-side drift (labels changed on pods, workload deleted, no Service update ever arriving) is only caught on the next Service UPDATE/resync; a periodic sweep piggybacking on the discovery snapshot is a possible phase 2.
