### PR TITLE
chore(chart): bump node-agent image to 0.1.3, appVersion to 0.1.12

### DIFF
--- a/charts/nudgebee-agent/Chart.yaml
+++ b/charts/nudgebee-agent/Chart.yaml
@@ -30,7 +30,7 @@ annotations:
 # we use 0.0.1 as a placeholder for the version` because Helm wont allow `0.0.0` and we want to be able to run
 # `helm install` on development checkouts without updating this file. the version doesn't matter in that case anyway
 version: 0.1.12
-appVersion: 0.1.11
+appVersion: 0.1.12
 dependencies:
 - name: opencost
   version: 2.0.1

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -273,7 +273,7 @@ nodeAgent:
   image:
     repository: ghcr.io/nudgebee/node-agent
     pullPolicy: IfNotPresent
-    tag: 0.1.2
+    tag: 0.1.3
   resources:
     requests:
       cpu: "100m"

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -65,7 +65,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-07-15T13-13-30_037b4a042ed03716596734435acec49d9f721274
+    tag: 2026-07-16T09-02-10_585a6253271b189078eb2edbcad9ee65cf82e685
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -65,7 +65,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-07-14T09-20-14_17a3cbad58bd80c14dee85a158cc4ec2de19e09f
+    tag: 2026-07-15T13-13-30_037b4a042ed03716596734435acec49d9f721274
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -65,7 +65,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-07-15T16-09-55_6d1cadca59e43257a6b45048731c4a4c105b8699
+    tag: 2026-07-16T09-02-10_585a6253271b189078eb2edbcad9ee65cf82e685
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.


### PR DESCRIPTION
Picks up node-agent v0.1.3 (nudgebee/node-agent#294): fixes the startup race where the 5s `ebpfStatsTicker` fired before `tracer.Run` loaded the eBPF collection → SIGSEGV restart bursts on slow/burstable nodes (seen on prod spot t3.2xlarge, 11 restarts before stabilizing).

Chart version was already bumped to 0.1.12 by #520 — this aligns appVersion and the node-agent image pin. The 0.1.3 image is already published in ghcr, so the update-image-tags bot should agree with the pin this time.