### PR TITLE
feat(runner): Argo Rollouts discovery inventory + rollout_restart support

### DIFF
--- a/charts/nudgebee-agent/Chart.yaml
+++ b/charts/nudgebee-agent/Chart.yaml
@@ -29,7 +29,7 @@ annotations:
 # these are set to the right value by .github/workflows/release.yaml
 # we use 0.0.1 as a placeholder for the version` because Helm wont allow `0.0.0` and we want to be able to run
 # `helm install` on development checkouts without updating this file. the version doesn't matter in that case anyway
-version: 0.1.12
+version: 0.1.13
 appVersion: 0.1.11
 dependencies:
 - name: opencost

--- a/charts/nudgebee-agent/templates/runner-service-account-readonly.yaml
+++ b/charts/nudgebee-agent/templates/runner-service-account-readonly.yaml
@@ -259,6 +259,7 @@ rules:
     verbs:
       - get
       - list
+      - watch
 {{- end }}
 
   # Karpenter read permissions are granted unconditionally. An RBAC rule for

--- a/charts/nudgebee-agent/templates/runner-service-account.yaml
+++ b/charts/nudgebee-agent/templates/runner-service-account.yaml
@@ -442,6 +442,7 @@ rules:
     verbs:
     - get
     - list
+    - watch
     - patch
     - update
 {{- if .Values.runner.enableWritePermissions }}

--- a/runner/cmd/agent/main.go
+++ b/runner/cmd/agent/main.go
@@ -1072,6 +1072,11 @@ func run(ctx context.Context, logger *slog.Logger, cfg *config.Config) error {
 		discSvc.RegisterAll() // Pod, Deployment, StatefulSet, DaemonSet, Node, Namespace
 		// TODO(phase-4): ReplicaSet, Job, CronJob, Helm releases — each requires
 		// a converter + shadow-diff before promotion.
+		if dynamicKube != nil {
+			// Argo Rollouts inventory. No-ops (with a log) when the Rollout CRD
+			// is not served or the rollouts RBAC is absent.
+			discSvc.RegisterRollouts(gctx, dynamicKube)
+		}
 		g.Go(func() error {
 			logger.Info("starting discovery", "resync", cfg.DiscoveryResync)
 			if err := discSvc.Run(gctx); err != nil && !errors.Is(err, context.Canceled) {

--- a/runner/pkg/discovery/converters.go
+++ b/runner/pkg/discovery/converters.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"encoding/json"
+	"math"
 	"strings"
 	"time"
 
@@ -123,6 +124,19 @@ func newReplicaSetConverter(lookup podLookupFn) func(any) (any, bool) {
 	}
 }
 
+// clampInt32 narrows an unstructured int64 count to int32 without overflow
+// (gosec G115). Replica counts are non-negative and far below MaxInt32 in
+// practice; clamping just keeps a malformed object from wrapping around.
+func clampInt32(v int64) int32 {
+	if v < 0 {
+		return 0
+	}
+	if v > math.MaxInt32 {
+		return math.MaxInt32
+	}
+	return int32(v)
+}
+
 // newRolloutConverter converts an unstructured Argo Rollout into the standard
 // service dict (type "Rollout"). Handles both inline-template Rollouts and
 // workloadRef Rollouts (spec.template absent → empty template; the referenced
@@ -136,11 +150,11 @@ func newRolloutConverter(lookup podLookupFn) func(any) (any, bool) {
 		// spec.replicas defaults to 1 per Rollout semantics.
 		replicas := int32(1)
 		if v, found, _ := unstructured.NestedInt64(u.Object, "spec", "replicas"); found {
-			replicas = int32(v)
+			replicas = clampInt32(v)
 		}
 		ready := int32(0)
 		if v, found, _ := unstructured.NestedInt64(u.Object, "status", "readyReplicas"); found {
-			ready = int32(v)
+			ready = clampInt32(v)
 		}
 		var tpl corev1.PodTemplateSpec
 		if tmpl, found, _ := unstructured.NestedMap(u.Object, "spec", "template"); found {

--- a/runner/pkg/discovery/converters.go
+++ b/runner/pkg/discovery/converters.go
@@ -9,6 +9,8 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -118,6 +120,45 @@ func newReplicaSetConverter(lookup podLookupFn) func(any) (any, bool) {
 		return serviceDict("ReplicaSet", r.Name, r.Namespace, r.ObjectMeta,
 			replicas, r.Status.ReadyReplicas, r.Spec.Template, r.OwnerReferences,
 			lookup), true
+	}
+}
+
+// newRolloutConverter converts an unstructured Argo Rollout into the standard
+// service dict (type "Rollout"). Handles both inline-template Rollouts and
+// workloadRef Rollouts (spec.template absent → empty template; the referenced
+// Deployment is discovered separately by its own informer).
+func newRolloutConverter(lookup podLookupFn) func(any) (any, bool) {
+	return func(obj any) (any, bool) {
+		u, ok := obj.(*unstructured.Unstructured)
+		if !ok || u.Object == nil {
+			return nil, false
+		}
+		// spec.replicas defaults to 1 per Rollout semantics.
+		replicas := int32(1)
+		if v, found, _ := unstructured.NestedInt64(u.Object, "spec", "replicas"); found {
+			replicas = int32(v)
+		}
+		ready := int32(0)
+		if v, found, _ := unstructured.NestedInt64(u.Object, "status", "readyReplicas"); found {
+			ready = int32(v)
+		}
+		var tpl corev1.PodTemplateSpec
+		if tmpl, found, _ := unstructured.NestedMap(u.Object, "spec", "template"); found {
+			// Best-effort: on conversion error emit the record with an empty
+			// template rather than dropping the Rollout from inventory.
+			_ = runtime.DefaultUnstructuredConverter.FromUnstructured(tmpl, &tpl)
+		}
+		meta := metav1.ObjectMeta{
+			Name:              u.GetName(),
+			Namespace:         u.GetNamespace(),
+			UID:               u.GetUID(), // drives the podLookup owner index
+			ResourceVersion:   u.GetResourceVersion(),
+			CreationTimestamp: u.GetCreationTimestamp(),
+			Labels:            u.GetLabels(),
+			Annotations:       u.GetAnnotations(),
+		}
+		return serviceDict("Rollout", u.GetName(), u.GetNamespace(), meta,
+			replicas, ready, tpl, u.GetOwnerReferences(), lookup), true
 	}
 }
 

--- a/runner/pkg/discovery/rollouts_test.go
+++ b/runner/pkg/discovery/rollouts_test.go
@@ -154,7 +154,7 @@ func TestRolloutConverter_PodLookup(t *testing.T) {
 // end-to-end.
 func TestService_EmitsRolloutSnapshot(t *testing.T) {
 	cs := fake.NewClientset()
-	cs.Fake.Resources = argoServedResources()
+	cs.Resources = argoServedResources()
 	dyn := dynamicfake.NewSimpleDynamicClient(rolloutScheme(), rolloutFixture("checkout", "shop"))
 
 	var (
@@ -233,7 +233,7 @@ func TestRegisterRollouts_SkipsWhenCRDAbsent(t *testing.T) {
 
 func TestRegisterRollouts_SkipsWhenListForbidden(t *testing.T) {
 	cs := fake.NewClientset()
-	cs.Fake.Resources = argoServedResources()
+	cs.Resources = argoServedResources()
 	dyn := dynamicfake.NewSimpleDynamicClient(rolloutScheme())
 	dyn.PrependReactor("list", "rollouts", func(clienttesting.Action) (bool, runtime.Object, error) {
 		return true, nil, apierrors.NewForbidden(

--- a/runner/pkg/discovery/rollouts_test.go
+++ b/runner/pkg/discovery/rollouts_test.go
@@ -1,0 +1,250 @@
+package discovery
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	fake "k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+// rolloutScheme registers the Argo Rollout GVKs as unstructured so the
+// dynamic fake can serve list/watch for them (mirrors mutate's workloadScheme).
+func rolloutScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	gv := rolloutGVR.GroupVersion()
+	s.AddKnownTypeWithName(gv.WithKind("Rollout"), &unstructured.Unstructured{})
+	s.AddKnownTypeWithName(gv.WithKind("RolloutList"), &unstructured.UnstructuredList{})
+	return s
+}
+
+// rolloutFixture builds an inline-template Rollout. Numeric fields must be
+// int64 — unstructured.NestedInt64 is strict about the concrete type.
+func rolloutFixture(name, ns string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "argoproj.io/v1alpha1",
+		"kind":       "Rollout",
+		"metadata": map[string]any{
+			"name":              name,
+			"namespace":         ns,
+			"uid":               "ro-uid-1",
+			"resourceVersion":   "42",
+			"creationTimestamp": "2026-01-01T00:00:00Z",
+			"labels":            map[string]any{"app": name},
+		},
+		"spec": map[string]any{
+			"replicas": int64(3),
+			"template": map[string]any{
+				"spec": map[string]any{
+					"containers": []any{
+						map[string]any{"name": "web", "image": "nginx:1.27"},
+					},
+				},
+			},
+		},
+		"status": map[string]any{"readyReplicas": int64(2)},
+	}}
+}
+
+// argoServedResources advertises argoproj.io/v1alpha1 on the fake discovery
+// client so RegisterRollouts' CRD gate passes.
+func argoServedResources() []*metav1.APIResourceList {
+	return []*metav1.APIResourceList{{
+		GroupVersion: "argoproj.io/v1alpha1",
+		APIResources: []metav1.APIResource{{Name: "rollouts", Kind: "Rollout", Namespaced: true}},
+	}}
+}
+
+func TestRolloutConverter_InlineTemplate(t *testing.T) {
+	item, ok := newRolloutConverter(nil)(rolloutFixture("checkout", "shop"))
+	if !ok {
+		t.Fatal("converter returned ok=false")
+	}
+	m := item.(map[string]any)
+	if m["name"] != "checkout" || m["namespace"] != "shop" || m["type"] != "Rollout" {
+		t.Errorf("wire shape: %+v", m)
+	}
+	if m["service_key"] != "shop/Rollout/checkout" {
+		t.Errorf("service_key = %v", m["service_key"])
+	}
+	if m["total_pods"] != int32(3) {
+		t.Errorf("total_pods = %v; want 3", m["total_pods"])
+	}
+	if m["ready_pods"] != int32(2) {
+		t.Errorf("ready_pods = %v; want 2", m["ready_pods"])
+	}
+	cfg := m["config"].(map[string]any)
+	containers := cfg["containers"].([]map[string]any)
+	if len(containers) != 1 || containers[0]["image"] != "nginx:1.27" {
+		t.Errorf("containers = %+v", containers)
+	}
+}
+
+func TestRolloutConverter_WorkloadRefNoTemplate(t *testing.T) {
+	u := rolloutFixture("checkout", "shop")
+	unstructured.RemoveNestedField(u.Object, "spec", "template")
+	_ = unstructured.SetNestedMap(u.Object, map[string]any{
+		"apiVersion": "apps/v1", "kind": "Deployment", "name": "checkout",
+	}, "spec", "workloadRef")
+
+	item, ok := newRolloutConverter(nil)(u)
+	if !ok {
+		t.Fatal("workloadRef Rollout must still be emitted")
+	}
+	cfg := item.(map[string]any)["config"].(map[string]any)
+	containers := cfg["containers"].([]map[string]any)
+	if len(containers) != 0 {
+		t.Errorf("containers = %+v; want empty for workloadRef Rollout", containers)
+	}
+}
+
+func TestRolloutConverter_DefaultsReplicasToOne(t *testing.T) {
+	u := rolloutFixture("checkout", "shop")
+	unstructured.RemoveNestedField(u.Object, "spec", "replicas")
+
+	item, ok := newRolloutConverter(nil)(u)
+	if !ok {
+		t.Fatal("converter returned ok=false")
+	}
+	if got := item.(map[string]any)["total_pods"]; got != int32(1) {
+		t.Errorf("total_pods = %v; want 1 (Rollout default)", got)
+	}
+}
+
+func TestRolloutConverter_RejectsNonUnstructured(t *testing.T) {
+	if _, ok := newRolloutConverter(nil)(&corev1.Pod{}); ok {
+		t.Error("typed object must be rejected")
+	}
+}
+
+func TestRolloutConverter_PodLookup(t *testing.T) {
+	lookup := func(uid types.UID) *corev1.Pod {
+		if uid != "ro-uid-1" {
+			return nil
+		}
+		return &corev1.Pod{Status: corev1.PodStatus{QOSClass: corev1.PodQOSBurstable}}
+	}
+	item, ok := newRolloutConverter(lookup)(rolloutFixture("checkout", "shop"))
+	if !ok {
+		t.Fatal("converter returned ok=false")
+	}
+	cfg := item.(map[string]any)["config"].(map[string]any)
+	if cfg["qos_class"] != "Burstable" {
+		t.Errorf("qos_class = %v; want Burstable (via UID-keyed lookup)", cfg["qos_class"])
+	}
+}
+
+// Drives the full Service with a dynamic fake and verifies a Rollout lands in
+// the initial TypeService snapshot — the informer/register/converter path
+// end-to-end.
+func TestService_EmitsRolloutSnapshot(t *testing.T) {
+	cs := fake.NewClientset()
+	cs.Fake.Resources = argoServedResources()
+	dyn := dynamicfake.NewSimpleDynamicClient(rolloutScheme(), rolloutFixture("checkout", "shop"))
+
+	var (
+		mu        sync.Mutex
+		envelopes []Envelope
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var env Envelope
+		_ = json.Unmarshal(body, &env)
+		mu.Lock()
+		envelopes = append(envelopes, env)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	sink := NewSink(srv.URL, "secret", "acc-1", "cluster-x", slog.Default())
+	svc := NewService(cs, sink, time.Hour, slog.Default())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if !svc.RegisterRollouts(ctx, dyn) {
+		t.Fatal("RegisterRollouts returned false")
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- svc.Run(ctx) }()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		n := len(envelopes)
+		mu.Unlock()
+		if n >= 1 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	cancel()
+	<-done
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(envelopes) == 0 {
+		t.Fatal("no envelopes received")
+	}
+	first := envelopes[0]
+	if first.Type != TypeService {
+		t.Errorf("type = %q; want service", first.Type)
+	}
+	dataArr, ok := first.Data.([]any)
+	if !ok || len(dataArr) != 1 {
+		t.Fatalf("data = %+v; want one item", first.Data)
+	}
+	item := dataArr[0].(map[string]any)
+	if item["service_key"] != "shop/Rollout/checkout" || item["type"] != "Rollout" {
+		t.Errorf("rollout wire shape: %+v", item)
+	}
+}
+
+func TestRegisterRollouts_SkipsWhenCRDAbsent(t *testing.T) {
+	cs := fake.NewClientset() // no Fake.Resources → argoproj.io/v1alpha1 not served
+	svc := NewService(cs, NewSink("http://unused", "", "", "", slog.Default()), time.Hour, slog.Default())
+	dyn := dynamicfake.NewSimpleDynamicClient(rolloutScheme())
+
+	if svc.RegisterRollouts(context.Background(), dyn) {
+		t.Error("expected false when the Rollout CRD is not served")
+	}
+	if len(svc.handlers) != 0 {
+		t.Errorf("handlers = %d; want 0", len(svc.handlers))
+	}
+}
+
+func TestRegisterRollouts_SkipsWhenListForbidden(t *testing.T) {
+	cs := fake.NewClientset()
+	cs.Fake.Resources = argoServedResources()
+	dyn := dynamicfake.NewSimpleDynamicClient(rolloutScheme())
+	dyn.PrependReactor("list", "rollouts", func(clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(
+			schema.GroupResource{Group: "argoproj.io", Resource: "rollouts"}, "", nil)
+	})
+
+	svc := NewService(cs, NewSink("http://unused", "", "", "", slog.Default()), time.Hour, slog.Default())
+	if svc.RegisterRollouts(context.Background(), dyn) {
+		t.Error("expected false when the list probe is Forbidden (RBAC missing)")
+	}
+	if len(svc.handlers) != 0 {
+		t.Errorf("handlers = %d; want 0", len(svc.handlers))
+	}
+}

--- a/runner/pkg/discovery/service.go
+++ b/runner/pkg/discovery/service.go
@@ -12,7 +12,10 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -40,6 +43,10 @@ type Service struct {
 	factory informers.SharedInformerFactory
 	resync  time.Duration
 	logger  *slog.Logger
+
+	// dynFactory drives CRD informers (Argo Rollouts). Nil unless
+	// RegisterRollouts succeeded; Run() starts/syncs it only when set.
+	dynFactory dynamicinformer.DynamicSharedInformerFactory
 
 	handlers []*resourceHandler
 
@@ -313,8 +320,51 @@ func (s *Service) RegisterHelmReleases() {
 	s.register(s.factory.Core().V1().Secrets().Informer(), TypeHelmRelease, convertHelmReleaseSecret)
 }
 
+// rolloutGVR is the Argo Rollouts CRD resource (matches mutate's
+// scalableWorkloadGVRs entry and the chart's argoproj.io RBAC block).
+var rolloutGVR = schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "rollouts"}
+
+// RegisterRollouts wires an Argo Rollout dynamic informer so Rollouts reach
+// the backend inventory like Deployments do. Returns false (with a log) when
+// the Rollout CRD is not served or the agent lacks list RBAC — the chart only
+// grants rollouts RBAC when the CRD existed at install time, and registering
+// an informer that can't list would block WaitForCacheSync forever and stall
+// all discovery. Call before Run().
+//
+// NOTE: no WithTransform equivalent is applied — Rollouts are low-cardinality
+// (typically <100s per cluster), so the per-object trim that matters at 100k
+// pods isn't worth an unstructured-map walker here.
+func (s *Service) RegisterRollouts(ctx context.Context, dyn dynamic.Interface) bool {
+	if dyn == nil {
+		s.logger.Info("rollout discovery disabled: no dynamic client")
+		return false
+	}
+	if _, err := s.cs.Discovery().ServerResourcesForGroupVersion(rolloutGVR.GroupVersion().String()); err != nil {
+		s.logger.Info("rollout discovery disabled: argoproj.io/v1alpha1 not served", "err", err)
+		return false
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	if _, err := dyn.Resource(rolloutGVR).Namespace(metav1.NamespaceAll).List(probeCtx, metav1.ListOptions{Limit: 1}); err != nil {
+		s.logger.Warn("rollout discovery disabled: list probe failed (rollouts RBAC missing? chart gates it on the CRD existing at install time)", "err", err)
+		return false
+	}
+	if s.dynFactory == nil {
+		s.dynFactory = dynamicinformer.NewDynamicSharedInformerFactory(dyn, s.resync)
+	}
+	inf := s.dynFactory.ForResource(rolloutGVR).Informer()
+	// RBAC revoked after start: replace client-go's default retry logging with
+	// our own throttled warn instead of crash/spam. Must be set before Run().
+	_ = inf.SetWatchErrorHandler(func(_ *cache.Reflector, err error) {
+		s.logger.Warn("rollout informer list/watch error", "err", err)
+	})
+	s.register(inf, TypeService, newRolloutConverter(s.podLookup()))
+	return true
+}
+
 // RegisterAll wires every supported resource (excluding Helm — see
-// RegisterHelmReleases for why that needs separate setup). Convenience for
+// RegisterHelmReleases for why that needs separate setup — and Rollouts,
+// which need a dynamic client: see RegisterRollouts). Convenience for
 // production deployments where the operator wants the full snapshot.
 func (s *Service) RegisterAll() {
 	s.RegisterPods()
@@ -380,6 +430,9 @@ func (s *Service) Run(ctx context.Context) error {
 	go func() { <-ctx.Done(); close(stopCh) }()
 
 	s.factory.Start(stopCh)
+	if s.dynFactory != nil {
+		s.dynFactory.Start(stopCh)
+	}
 
 	// Wait at the factory level (not just on handler-bound informers) so
 	// auxiliary informers instantiated via lookup closures — replicaSetLookup,
@@ -391,6 +444,13 @@ func (s *Service) Run(ctx context.Context) error {
 	for typ, ok := range s.factory.WaitForCacheSync(stopCh) {
 		if !ok {
 			return fmt.Errorf("discovery: cache sync timed out for %v", typ)
+		}
+	}
+	if s.dynFactory != nil {
+		for gvr, ok := range s.dynFactory.WaitForCacheSync(stopCh) {
+			if !ok {
+				return fmt.Errorf("discovery: cache sync timed out for %v", gvr)
+			}
 		}
 	}
 	s.logger.Info("discovery caches synced", "handlers", len(s.handlers))

--- a/runner/pkg/mutate/mutate.go
+++ b/runner/pkg/mutate/mutate.go
@@ -139,9 +139,13 @@ func (m *Mutator) setUnschedulable(ctx context.Context, nodeName string, unsched
 	return err
 }
 
-// RolloutRestart triggers a rolling restart by patching the pod-template
-// `kubectl.kubernetes.io/restartedAt` annotation. Same mechanism kubectl uses.
-// kind is one of: deployment, statefulset, daemonset.
+// RolloutRestart triggers a rolling restart. For deployment/statefulset/
+// daemonset it patches the pod-template `kubectl.kubernetes.io/restartedAt`
+// annotation (same mechanism kubectl uses). For Argo Rollouts it merge-patches
+// `spec.restartAt` — the canonical restart, same as `kubectl argo rollouts
+// restart`; patching the pod template instead would trigger a full
+// canary/blueGreen rollout, not a restart.
+// kind is one of: deployment, statefulset, daemonset, rollout.
 func (m *Mutator) RolloutRestart(ctx context.Context, kind, namespace, name string) error {
 	if m.Client == nil {
 		return errors.New("mutate: client not configured")
@@ -163,8 +167,16 @@ func (m *Mutator) RolloutRestart(ctx context.Context, kind, namespace, name stri
 	case "daemonset":
 		_, err := m.Client.AppsV1().DaemonSets(namespace).Patch(ctx, name, types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{})
 		return err
+	case "rollout":
+		if m.dynamic == nil {
+			return errors.New("mutate: dynamic client not configured (required for rollout restart)")
+		}
+		rolloutPatch := fmt.Sprintf(`{"spec":{"restartAt":%q}}`, time.Now().UTC().Format(time.RFC3339))
+		_, err := m.dynamic.Resource(scalableWorkloadGVRs["rollout"]).Namespace(namespace).
+			Patch(ctx, name, types.MergePatchType, []byte(rolloutPatch), metav1.PatchOptions{})
+		return err
 	default:
-		return fmt.Errorf("mutate: unsupported kind %q (deployment|statefulset|daemonset)", kind)
+		return fmt.Errorf("mutate: unsupported kind %q (deployment|statefulset|daemonset|rollout)", kind)
 	}
 }
 

--- a/runner/pkg/mutate/mutate_test.go
+++ b/runner/pkg/mutate/mutate_test.go
@@ -4,15 +4,18 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clienttesting "k8s.io/client-go/testing"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -141,6 +144,43 @@ func TestRolloutRestart_StatefulSetAndDaemonSet(t *testing.T) {
 	}
 	if err := m.RolloutRestart(context.Background(), "daemonset", "ns", "ds"); err != nil {
 		t.Errorf("daemonset: %v", err)
+	}
+}
+
+func TestRolloutRestart_Rollout_PatchesRestartAt(t *testing.T) {
+	existing := seedExisting("argoproj.io/v1alpha1", "Rollout", "checkout", "shop", "100")
+	dyn := dynamicfake.NewSimpleDynamicClient(workloadScheme(), existing)
+	m := New(fake.NewClientset(), "", nil)
+	m.SetDynamic(dyn)
+
+	if err := m.RolloutRestart(context.Background(), "rollout", "shop", "checkout"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := dyn.Resource(scalableWorkloadGVRs["rollout"]).Namespace("shop").
+		Get(context.Background(), "checkout", metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	restartAt, found, err := unstructured.NestedString(got.Object, "spec", "restartAt")
+	if err != nil || !found {
+		t.Fatalf("spec.restartAt not set (found=%v err=%v): %v", found, err, got.Object)
+	}
+	if _, err := time.Parse(time.RFC3339, restartAt); err != nil {
+		t.Errorf("spec.restartAt %q is not RFC3339: %v", restartAt, err)
+	}
+	// The canonical Argo restart must NOT touch the pod template — that would
+	// trigger a full canary/blueGreen rollout instead of a restart.
+	if _, found, _ := unstructured.NestedMap(got.Object, "spec", "template"); found {
+		t.Error("spec.template was mutated; rollout restart must only set spec.restartAt")
+	}
+}
+
+func TestRolloutRestart_Rollout_RequiresDynamicClient(t *testing.T) {
+	m := New(fake.NewClientset(), "", nil)
+	err := m.RolloutRestart(context.Background(), "rollout", "shop", "checkout")
+	if err == nil || !strings.Contains(err.Error(), "dynamic client not configured") {
+		t.Errorf("expected dynamic-client error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

An Argo Rollouts compatibility audit found two gaps in the runner; everything else (scale, replace/delete, rightsizing, trigger owner-chains) already handled Rollouts.

### 1. Discovery inventory (primary gap)
The discovery service had no Rollout informer, so Rollouts never reached the backend inventory. This adds `RegisterRollouts`, a dynamic informer for `argoproj.io/v1alpha1` Rollouts wired into the existing register/worker machinery:
- Skipped (with a log) when the CRD is not served.
- Skipped when a `Limit:1` list probe fails — the chart only renders rollouts RBAC when the CRD existed at install time, and a Forbidden informer would block `WaitForCacheSync` and stall **all** discovery.
- `newRolloutConverter` emits the standard service dict (`type: Rollout`); handles inline-template and workloadRef Rollouts (empty template — the referenced Deployment is inventoried by its own informer), and defaults `spec.replicas` to 1 per Rollout semantics.
- No new go.mod dependency — unstructured/dynamic access, matching the mutate package.

### 2. rollout_restart action
`RolloutRestart` only handled deployment/statefulset/daemonset; `kind=rollout` failed with "unsupported kind". Now merge-patches `spec.restartAt` via the dynamic client — the canonical restart (same as `kubectl argo rollouts restart`). Patching the pod-template annotation instead would trigger a full canary/blueGreen rollout, not a restart.

### 3. Chart
- Add `watch` verb to the runner's rollouts RBAC block (informer needs list+watch; block previously had get/list/patch/update).
- Chart version 0.1.12 → 0.1.13 (`appVersion` left for the runner image release).

## Testing
- Converter unit tests: inline template, workloadRef (no template), replicas default, non-unstructured rejection, UID-keyed pod lookup.
- Service-level test: fake clientset + dynamic fake end-to-end — Rollout lands in the initial `TypeService` snapshot; skip paths tested for CRD-absent and list-Forbidden.
- Mutate tests: `spec.restartAt` set and RFC3339-parseable, pod template untouched; dynamic-client-missing error.
- `go build ./... && go vet` clean; full runner test suite passes.
- `helm template` verified: `watch` rendered with the Rollout capability, block absent without it; `helm lint` clean.