### PR TITLE
fix(triggers): resolve Rollout-owned pods to rollout owner kind

### DIFF
--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -65,7 +65,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-07-14T09-20-14_17a3cbad58bd80c14dee85a158cc4ec2de19e09f
+    tag: 2026-07-15T13-13-30_037b4a042ed03716596734435acec49d9f721274
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/runner/pkg/triggers/owner.go
+++ b/runner/pkg/triggers/owner.go
@@ -12,9 +12,10 @@ import (
 // We only have the current obj from kubewatch — we don't fetch parent
 // objects from the API server because the matcher path is hot and we
 // want zero K8s API calls. That limits us to one walk step. The
-// ReplicaSet → Deployment derivation is heuristic (strip the
-// pod-template-hash suffix from the ReplicaSet name); same heuristic
-// the legacy implementation uses.
+// ReplicaSet → Deployment/Rollout derivation is heuristic (strip the
+// pod-template-hash suffix from the ReplicaSet name, with the
+// rollouts-pod-template-hash label distinguishing Argo Rollout pods);
+// same heuristic the legacy implementation uses.
 //
 // Returns zero OwnerRef when no controlling owner is set (bare Pod,
 // no-controller resource).
@@ -46,19 +47,30 @@ func ResolveOwner(obj map[string]any) OwnerRef {
 		if name == "" || kind == "" {
 			continue
 		}
-		return canonicalOwner(kind, name)
+		labels, _ := meta["labels"].(map[string]any)
+		return canonicalOwner(kind, name, labels)
 	}
 	return OwnerRef{}
 }
 
 // canonicalOwner normalizes the (kind, name) pair to the top-level
 // workload. ReplicaSet names are derived from their owning Deployment
-// by appending a `-<10-char-hash>` suffix, so we strip that to get the
-// Deployment name. Other kinds pass through unchanged.
-func canonicalOwner(kind, name string) OwnerRef {
+// (or Argo Rollout) by appending a `-<10-char-hash>` suffix, so we
+// strip that to get the controller name. Other kinds pass through
+// unchanged. labels are the owned object's labels, used to tell a
+// Rollout-owned ReplicaSet from a Deployment-owned one without an API
+// call.
+func canonicalOwner(kind, name string, labels map[string]any) OwnerRef {
 	lk := strings.ToLower(kind)
 	switch lk {
 	case "replicaset":
+		// Argo Rollouts stamps its pods with `rollouts-pod-template-hash`
+		// (the Deployment controller uses `pod-template-hash`), so the
+		// label identifies the ReplicaSet's controller from the pod alone.
+		// The label value is the exact suffix on the ReplicaSet name.
+		if hash, _ := labels["rollouts-pod-template-hash"].(string); hash != "" {
+			return OwnerRef{Name: strings.TrimSuffix(name, "-"+hash), Kind: "rollout"}
+		}
 		// "web-7f9d8c5b6" → "web".
 		return OwnerRef{Name: stripPodTemplateHash(name), Kind: "deployment"}
 	case "deployment", "daemonset", "statefulset", "job", "cronjob",

--- a/runner/pkg/triggers/predicates_test.go
+++ b/runner/pkg/triggers/predicates_test.go
@@ -1007,6 +1007,23 @@ func TestResolveOwner_ReplicaSetStripsHash(t *testing.T) {
 	}
 }
 
+func TestResolveOwner_RolloutPodViaLabel(t *testing.T) {
+	// Argo Rollout pods carry rollouts-pod-template-hash instead of
+	// pod-template-hash; the RS owner must resolve to the Rollout, not
+	// to a (nonexistent) Deployment.
+	pod := asObj(t, `{
+		"metadata":{
+			"labels":{"rollouts-pod-template-hash":"7f9d8c5b6"},
+			"ownerReferences":[
+				{"kind":"ReplicaSet","name":"web-7f9d8c5b6","controller":true}
+			]}
+	}`)
+	o := ResolveOwner(pod)
+	if o.Name != "web" || o.Kind != "rollout" {
+		t.Errorf("owner = %+v; want {web rollout}", o)
+	}
+}
+
 func TestResolveOwner_DaemonSetPassesThrough(t *testing.T) {
 	pod := asObj(t, `{
 		"metadata":{"ownerReferences":[


### PR DESCRIPTION
# Description

Before: findings for pods managed by an Argo Rollout were reported with `subject_owner_kind=deployment` — the owner walk assumed every ReplicaSet belongs to a Deployment. The backend then tried to correlate and act on a Deployment that doesn't exist.

Now: pods carrying the `rollouts-pod-template-hash` label (which Argo Rollouts sets instead of `pod-template-hash`) resolve to owner kind `rollout`, with the exact hash trimmed from the ReplicaSet name. Deployment-owned pods behave exactly as before. No API calls added — the label on the incoming pod object is enough, keeping the matcher path zero-lookup.

Follows up on #537 (Rollouts discovery inventory): discovery now reports Rollout workloads, and with this fix the findings pipeline attributes their pods to the right owner kind too.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] `make validate` (fmt + lint + full test suite) in `runner/`
- [x] New unit test `TestResolveOwner_RolloutPodViaLabel` covering the Rollout label path; existing owner-walk tests unchanged and green
