### PR TITLE
fix(runner/triggers): treat Forbidden as 'no rollouts' in service_no_endpoints workload sweep

### DIFF
--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -273,7 +273,7 @@ nodeAgent:
   image:
     repository: ghcr.io/nudgebee/node-agent
     pullPolicy: IfNotPresent
-    tag: 0.1.3
+    tag: 0.1.4-rc.1
   resources:
     requests:
       cpu: "100m"

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -65,7 +65,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-07-15T16-09-55_6d1cadca59e43257a6b45048731c4a4c105b8699
+    tag: 2026-07-16T09-02-10_585a6253271b189078eb2edbcad9ee65cf82e685
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/runner/cmd/agent/service_backends_lister.go
+++ b/runner/cmd/agent/service_backends_lister.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"sort"
+	"sync/atomic"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,6 +42,14 @@ var rolloutGVR = schema.GroupVersionResource{Group: "argoproj.io", Version: "v1a
 type serviceBackendsLister struct {
 	cs  kubernetes.Interface
 	dyn dynamic.Interface // optional; enables the Rollouts template check
+
+	// rolloutsUnsupported latches true after the first NotFound/Forbidden
+	// from the rollouts API, so CRD-less clusters don't take a guaranteed
+	// 403/404 round-trip (and audit-log entry) on every subsequent check.
+	// Installing the CRD later needs an agent restart to be picked up —
+	// same trade-off the chart makes by gating rollouts RBAC on the CRD
+	// existing at install time.
+	rolloutsUnsupported atomic.Bool
 }
 
 func newServiceBackendsLister(cs kubernetes.Interface, dyn dynamic.Interface) triggers.ServiceBackendsLister {
@@ -106,7 +115,7 @@ func (l *serviceBackendsLister) AnyWorkloadTemplateMatching(ctx context.Context,
 // Deployment, which the typed sweep above already covers. A cluster
 // without the CRD (404) counts as "no rollouts", not an error.
 func (l *serviceBackendsLister) anyRolloutTemplateMatching(ctx context.Context, namespace string, sel labels.Selector) (bool, error) {
-	if l.dyn == nil {
+	if l.dyn == nil || l.rolloutsUnsupported.Load() {
 		return false, nil
 	}
 	list, err := l.dyn.Resource(rolloutGVR).Namespace(namespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
@@ -117,8 +126,10 @@ func (l *serviceBackendsLister) anyRolloutTemplateMatching(ctx context.Context, 
 		// the request before checking resource existence. Either way this
 		// sweep is best-effort — treat as "no rollouts" rather than
 		// failing the whole workload probe (which would suppress the
-		// finding entirely via the predicate's fail-open).
+		// finding entirely via the predicate's fail-open), and latch the
+		// state so we don't re-probe a known-unsupported API every check.
 		if apierrors.IsNotFound(err) || apierrors.IsForbidden(err) {
+			l.rolloutsUnsupported.Store(true)
 			return false, nil
 		}
 		return false, err

--- a/runner/cmd/agent/service_backends_lister.go
+++ b/runner/cmd/agent/service_backends_lister.go
@@ -111,8 +111,15 @@ func (l *serviceBackendsLister) anyRolloutTemplateMatching(ctx context.Context, 
 	}
 	list, err := l.dyn.Resource(rolloutGVR).Namespace(namespace).List(ctx, metav1.ListOptions{ResourceVersion: "0"})
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return false, nil // CRD not installed
+		// Clusters without Argo return NotFound — or, more commonly,
+		// Forbidden: the chart only grants rollouts RBAC when the CRD
+		// exists at install time, and the apiserver's authorizer rejects
+		// the request before checking resource existence. Either way this
+		// sweep is best-effort — treat as "no rollouts" rather than
+		// failing the whole workload probe (which would suppress the
+		// finding entirely via the predicate's fail-open).
+		if apierrors.IsNotFound(err) || apierrors.IsForbidden(err) {
+			return false, nil
 		}
 		return false, err
 	}

--- a/runner/pkg/triggers/service_endpoints.go
+++ b/runner/pkg/triggers/service_endpoints.go
@@ -107,13 +107,31 @@ func serviceNoEndpointsEnrichBlocks(obj, _ map[string]any, ec EnrichContext) []E
 	}
 	sel := serviceSelector(obj)
 	ns := metaNS(obj)
+	condition := fmt.Sprintf(
+		"No pods and no workload pod templates in namespace `%s` match this selector. "+
+			"The Service has no endpoints and cannot route traffic — requests to it fail "+
+			"even though the Service object itself looks healthy.", ns)
 	blocks := []EvidenceBlock{
 		headerBlock(fmt.Sprintf("Service %s has no matching endpoints", metaName(obj))),
 		markdownBlock(fmt.Sprintf("*Configured selector:* `%s`", formatSelector(sel))),
-		markdownBlock(fmt.Sprintf(
-			"No pods and no workload pod templates in namespace `%s` match this selector. "+
-				"The Service has no endpoints and cannot route traffic — requests to it fail "+
-				"even though the Service object itself looks healthy.", ns)),
+		// The collector passes additional_info.insights through to the
+		// Finding's per-block insight list, which is what the investigate
+		// page renders as Insights. Without this the page shows nothing:
+		// its other insight sources are Warning rows in event tables (a
+		// zero-endpoint Service emits no K8s events) and pod-status
+		// extraction from the raw-event json (subject is a Service).
+		{
+			"type": "markdown",
+			"data": condition,
+			"additional_info": map[string]any{
+				"insights": []map[string]any{{
+					"message": fmt.Sprintf(
+						"Service %s/%s selector (%s) matches no pods and no workload pod templates — traffic to the Service is failing",
+						ns, metaName(obj), formatSelector(sel)),
+					"severity": "Critical",
+				}},
+			},
+		},
 	}
 	return append(blocks, podLabelComparisonTable(ec, ns)...)
 }

--- a/runner/pkg/triggers/service_endpoints_test.go
+++ b/runner/pkg/triggers/service_endpoints_test.go
@@ -149,6 +149,26 @@ func TestServiceNoEndpoints_EnrichBlocks(t *testing.T) {
 		t.Error("evidence must include the pod-labels comparison table")
 	}
 
+	// One block must carry additional_info.insights with severity Critical
+	// — the collector passes it through to the Finding's insight list,
+	// which is what the investigate page renders.
+	haveInsight := false
+	for _, b := range blocks {
+		ai, _ := b["additional_info"].(map[string]any)
+		if ai == nil {
+			continue
+		}
+		ins, _ := ai["insights"].([]map[string]any)
+		for _, i := range ins {
+			if i["severity"] == "Critical" {
+				haveInsight = true
+			}
+		}
+	}
+	if !haveInsight {
+		t.Error("evidence must carry a Critical insight via additional_info.insights")
+	}
+
 	// Empty namespace → the table degrades to a "no pods at all" note.
 	ec = EnrichContext{ServiceBackends: &fakeServiceBackends{}}
 	blocks = serviceNoEndpointsEnrichBlocks(brokenService(t), nil, ec)


### PR DESCRIPTION
## Problem

On clusters without the Argo Rollouts CRD, `service_no_endpoints` never fires. Found during live verification on the dev cluster: the selector-mismatch repro produced zero findings despite kubewatch delivering the Service update.

Root cause: the chart only grants rollouts RBAC when the CRD exists at install time, and the apiserver's authorizer rejects the request **before** checking resource existence — so CRD-less clusters return **403 Forbidden**, not 404 NotFound. The rollouts sweep propagated the 403 as an error, and the predicate's fail-open (never alert on missing data) suppressed every finding.

## Fix

Treat `Forbidden` like `NotFound` in the rollouts sweep: best-effort, counts as "no rollouts". The typed sweeps (Deployments/StatefulSets/DaemonSets) already succeeded at that point; only genuinely unexpected errors still fail open.

## Verification

- Reproduced live on the dev cluster (agent image `6d1cadc`): Service selector patched to a dead label → endpoints gone → no finding, `alerts_forwarded_total 0`, runner boot log shows the same 403 on its rollout discovery probe.
- Unit tests pass; will re-verify on dev after this image rolls out.