### PR TITLE
fix(rbac): grant Argo Rollouts permissions unconditionally

### DIFF
--- a/charts/nudgebee-agent/templates/forwarder-service-account.yaml
+++ b/charts/nudgebee-agent/templates/forwarder-service-account.yaml
@@ -120,7 +120,12 @@ rules:
     - {{ if .Values.openshift.createScc }}"{{ include "nudgebee-agent.fullname" . }}-scc"{{ else }}{{ .Values.openshift.sccName | quote }}{{ end }}
 {{- end }}
 
-{{- if (.Capabilities.APIVersions.Has "argoproj.io/v1alpha1/Rollout") }}
+  # Argo Rollouts permissions are granted unconditionally (same rationale as
+  # karpenter below): an RBAC rule for an absent CRD is inert and becomes
+  # active the moment Argo Rollouts is installed. Gating on .Capabilities left
+  # clusters that installed the CRD after this chart without rollouts RBAC
+  # until the next helm upgrade, so kubewatch could never emit Rollout change
+  # events. kubewatch probes the CRD before watching, so the grant is safe.
   - apiGroups:
     - argoproj.io
     resources:
@@ -129,7 +134,6 @@ rules:
     - get
     - list
     - watch
-{{- end }}
 
   # Karpenter permissions are granted unconditionally. An RBAC rule for an
   # absent CRD is inert and becomes active the moment karpenter is installed.

--- a/charts/nudgebee-agent/templates/runner-service-account-readonly.yaml
+++ b/charts/nudgebee-agent/templates/runner-service-account-readonly.yaml
@@ -251,7 +251,9 @@ rules:
       - nodes
     verbs: ["get", "list"]
 
-{{- if (.Capabilities.APIVersions.Has "argoproj.io/v1alpha1/Rollout") }}
+  # Argo Rollouts read permissions are granted unconditionally. An RBAC rule
+  # for an absent CRD is inert and becomes active the moment Argo Rollouts is
+  # installed (see runner-service-account.yaml for the full rationale).
   - apiGroups:
       - argoproj.io
     resources:
@@ -260,7 +262,6 @@ rules:
       - get
       - list
       - watch
-{{- end }}
 
   # Karpenter read permissions are granted unconditionally. An RBAC rule for
   # an absent CRD is inert and becomes active the moment karpenter is

--- a/charts/nudgebee-agent/templates/runner-service-account.yaml
+++ b/charts/nudgebee-agent/templates/runner-service-account.yaml
@@ -452,9 +452,12 @@ rules:
     - watch
     - patch
     - update
+    # delete is unconditional for parity with the apps workloads block above
+    # (delete_workload treats Deployment and Rollout identically); create
+    # stays gated like create for apps kinds.
+    - delete
 {{- if .Values.runner.enableWritePermissions }}
     - create
-    - delete
 {{- end }}
 
   # Karpenter read permissions are granted unconditionally. An RBAC rule for an

--- a/charts/nudgebee-agent/templates/runner-service-account.yaml
+++ b/charts/nudgebee-agent/templates/runner-service-account.yaml
@@ -445,6 +445,7 @@ rules:
     - argoproj.io
     resources:
     - rollouts
+    - rollouts/scale
     verbs:
     - get
     - list

--- a/charts/nudgebee-agent/templates/runner-service-account.yaml
+++ b/charts/nudgebee-agent/templates/runner-service-account.yaml
@@ -434,7 +434,13 @@ rules:
       - delete
 {{- end }}
 
-{{- if (.Capabilities.APIVersions.Has "argoproj.io/v1alpha1/Rollout") }}
+  # Argo Rollouts permissions are granted unconditionally (same rationale as
+  # karpenter below): an RBAC rule for an absent CRD is inert and becomes
+  # active the moment Argo Rollouts is installed. Gating on .Capabilities left
+  # clusters that installed the CRD after this chart without rollouts RBAC
+  # until the next helm upgrade (and never worked under GitOps/templated
+  # installs). The runner probes the CRD before registering informers, so the
+  # grant is safe. Write verbs are gated behind runner.enableWritePermissions.
   - apiGroups:
     - argoproj.io
     resources:
@@ -448,7 +454,6 @@ rules:
 {{- if .Values.runner.enableWritePermissions }}
     - create
     - delete
-{{- end }}
 {{- end }}
 
   # Karpenter read permissions are granted unconditionally. An RBAC rule for an

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -65,7 +65,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-07-15T16-09-55_6d1cadca59e43257a6b45048731c4a4c105b8699
+    tag: 2026-07-16T09-02-10_585a6253271b189078eb2edbcad9ee65cf82e685
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/runner/pkg/discovery/service.go
+++ b/runner/pkg/discovery/service.go
@@ -326,8 +326,9 @@ var rolloutGVR = schema.GroupVersionResource{Group: "argoproj.io", Version: "v1a
 
 // RegisterRollouts wires an Argo Rollout dynamic informer so Rollouts reach
 // the backend inventory like Deployments do. Returns false (with a log) when
-// the Rollout CRD is not served or the agent lacks list RBAC — the chart only
-// grants rollouts RBAC when the CRD existed at install time, and registering
+// the Rollout CRD is not served or the agent lacks list RBAC — the chart now
+// grants rollouts RBAC unconditionally, but releases rendered before that
+// change (or with a trimmed clusterrole) may still lack it, and registering
 // an informer that can't list would block WaitForCacheSync forever and stall
 // all discovery. Call before Run().
 //
@@ -346,7 +347,7 @@ func (s *Service) RegisterRollouts(ctx context.Context, dyn dynamic.Interface) b
 	probeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	if _, err := dyn.Resource(rolloutGVR).Namespace(metav1.NamespaceAll).List(probeCtx, metav1.ListOptions{Limit: 1}); err != nil {
-		s.logger.Warn("rollout discovery disabled: list probe failed (rollouts RBAC missing? chart gates it on the CRD existing at install time)", "err", err)
+		s.logger.Warn("rollout discovery disabled: list probe failed (rollouts RBAC missing? upgrade the chart — older releases gated it on the CRD existing at render time)", "err", err)
 		return false
 	}
 	if s.dynFactory == nil {


### PR DESCRIPTION
## Problem

Rollouts RBAC in all three clusterrole templates was gated on `.Capabilities.APIVersions.Has "argoproj.io/v1alpha1/Rollout"`, which only passes when the Rollout CRD exists at helm **render** time. Any cluster that installs Argo Rollouts after the agent chart (or installs via GitOps/templated manifests, where `.Capabilities` cannot see CRDs) never gets the grant until the next `helm upgrade`.

Observed in dev: kubewatch (forwarder) logged `rollouts.argoproj.io is forbidden` on every backoff, so Rollout UPDATE events never reached the trigger engine — no `ConfigurationChange` findings, no spec diffs for Rollouts, while Deployments worked fine.

## Fix

Grant the `argoproj.io/rollouts` rules unconditionally in:
- `forwarder-service-account.yaml` (get/list/watch)
- `runner-service-account.yaml` (get/list/watch/patch/update; create/delete still behind `runner.enableWritePermissions`)
- `runner-service-account-readonly.yaml` (get/list/watch)

This is the same pattern the karpenter block in these files already uses, with the same rationale: an RBAC rule for an absent CRD is inert and becomes active the moment the CRD is installed. Both kubewatch and the runner probe the CRD before watching, so the unconditional grant cannot stall anything.

Also updates the runner's stale comment/log in `pkg/discovery/service.go` that referenced the old render-time gating.

## Verification

- `helm lint` passes; `helm template` renders the rollouts rule in default and `runner.readOnly=true` modes.
- Applied the equivalent RBAC to the dev cluster: kubewatch immediately started watching Rollouts, and bumping a Rollout's `spec.replicas` produced a `ConfigurationChange` finding with the expected side-by-side spec diff in the UI.