### PR TITLE
security(runner): kubectl v1.32.13 -> v1.36.2, Go builder 1.26.5

### DIFF
--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -65,7 +65,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-07-16T09-02-10_585a6253271b189078eb2edbcad9ee65cf82e685
+    tag: 2026-07-16T14-08-07_14f6a1ab3847086e7b53a770876b54d8e9f31180
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -2,13 +2,17 @@
 # working `kubectl` binary alongside the agent — the kubectl_command_executor
 # action shells out to it (pkg/kube/exec.go).
 
-FROM golang:1.26-alpine@sha256:f1ddd9fe14fffc091dd98cb4bfa999f32c5fc77d2f2305ea9f0e2595c5437c14 AS build
+# golang 1.26.5: fixes the stdlib pair CVE-2026-39822 (HIGH, os.Root symlink
+# traversal) / CVE-2026-42505 (crypto/tls ECH) present in 1.26.4 builds.
+FROM golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS build
 WORKDIR /src
 
 ARG VERSION=dev
 ARG COMMIT=unknown
 ARG BUILD_TIME=unknown
-ENV CGO_ENABLED=0 GOFLAGS=-trimpath
+# GOTOOLCHAIN=local: always compile with the base image's Go, never an
+# auto-downloaded toolchain — keeps the stdlib at the patched 1.26.5.
+ENV CGO_ENABLED=0 GOFLAGS=-trimpath GOTOOLCHAIN=local
 
 COPY go.mod go.sum ./
 RUN go mod download
@@ -27,7 +31,12 @@ RUN go build \
 # build pipeline should pull the arm64 variant. Currently we only build amd64
 # images (.github/workflows/build-image.yaml).
 FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b AS kubectl
-ARG KUBECTL_VERSION=v1.32.13
+# v1.36.2 (current stable): upstream builds the 1.32 line on Go 1.24.13, whose
+# stale stdlib + x/net account for 33 of the image's 37 fixable Trivy findings
+# (20 HIGH). v1.36.2 is built on Go 1.26.4 — residual is only the industry-wide
+# 1.26.4 stdlib pair, which clears when upstream rebuilds on 1.26.5. kubectl's
+# CLI surface used by kubectl_command_executor is stable across these versions.
+ARG KUBECTL_VERSION=v1.36.2
 RUN apk add --no-cache curl ca-certificates && \
 	curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
 	chmod +x /usr/local/bin/kubectl


### PR DESCRIPTION
# Description

The `nudgebee-agent` image's **37 fixable Trivy findings (20 HIGH)** are almost entirely in the **bundled kubectl binary**, not our code: upstream builds the kubectl 1.32 line on **Go 1.24.13**, whose stale stdlib (21 CVEs) and `x/net v0.30` (12 CVEs) ship inside the prebuilt binary. The agent's own go.mod deps are already current (x/net 0.55, oauth2 0.36, spdystream 0.5.1).

- **kubectl v1.32.13 → v1.36.2** (current stable, built on Go 1.26.4). Verified: `go version` on the release binary. Note the runner's k8s.io libs are already v0.36.x, so the bundled kubectl now matches the client library line.
- **Builder → `golang:1.26.5-alpine`** (digest-pinned) + `GOTOOLCHAIN=local` — fixes the stdlib pair CVE-2026-39822 (HIGH) / CVE-2026-42505 in our own binary.

**Residual after this:** only the industry-wide Go 1.26.4 stdlib pair inside upstream's kubectl build; clears when upstream rebuilds on 1.26.5.

# How Has This Been Tested?

- [x] `go build ./...` clean inside `golang:1.26.5-alpine` (CGO_ENABLED=0, GOTOOLCHAIN=local)
- [x] kubectl v1.36.2 release binary verified as go1.26.4 (vs 1.32.13's go1.24.13)
- [x] Finding attribution verified from the CI Trivy scan artifacts (nudgebee/nudgebee run 29551177314)