### PR TITLE
chore(chart): bump agent + profiler images to security-patched builds

### DIFF
--- a/charts/nudgebee-agent/Chart.yaml
+++ b/charts/nudgebee-agent/Chart.yaml
@@ -29,7 +29,7 @@ annotations:
 # these are set to the right value by .github/workflows/release.yaml
 # we use 0.0.1 as a placeholder for the version` because Helm wont allow `0.0.0` and we want to be able to run
 # `helm install` on development checkouts without updating this file. the version doesn't matter in that case anyway
-version: 0.1.13
+version: 0.1.14
 appVersion: 0.1.11
 dependencies:
 - name: opencost

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -65,11 +65,11 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-07-16T14-08-07_14f6a1ab3847086e7b53a770876b54d8e9f31180
+    tag: 2026-07-17T04-32-36_5d6b67def3ede8e306d467fea4242b36c9eb9c68
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.
-  profilerImage: "ghcr.io/nudgebee/application-profiler-{}:e50de43"
+  profilerImage: "ghcr.io/nudgebee/application-profiler-{}:4f4b455"
   imagePullPolicy: IfNotPresent
   # Expose net/http/pprof on the runner HTTP listener (surfaces as
   # PPROF_ENABLED). Off by default — the endpoints are unauthenticated;


### PR DESCRIPTION
# Description

The chart pins pre-fix images; #541 (agent: kubectl v1.36.2 + Go 1.26.5) and application-profiler#108 (all flavors on Go 1.26.5) are merged and their images published, but nothing consumes them until these pins move.

| Pin | From | To |
|---|---|---|
| `image.tag` | `2026-07-16T14-08-07_14f6a1ab…` | `2026-07-17T04-32-36_5d6b67de…` |
| `profilerImage` | `…-{}:e50de43` | `…-{}:4f4b455` |

Verified by CI Trivy scan (nudgebee/nudgebee run 29556130451): the new agent image drops from 37 fixable findings (20 HIGH) to 9 — all 9 inside upstream's kubectl build (vendored x/net + Go 1.26.4 stdlib), clearing on upstream K8s rebuilds. Profiler image scans 0 fixable.

Chart version 0.1.13 → 0.1.14.

# How Has This Been Tested?

- [x] Both image tags verified present on ghcr and scanned via the CI Image Security Scan artifacts