### PR TITLE
chore(chart): clickhouse -nb-3 + otel-collector 0.75.0 -> 0.156.0

### DIFF
--- a/charts/nudgebee-agent/Chart.yaml
+++ b/charts/nudgebee-agent/Chart.yaml
@@ -29,7 +29,7 @@ annotations:
 # these are set to the right value by .github/workflows/release.yaml
 # we use 0.0.1 as a placeholder for the version` because Helm wont allow `0.0.0` and we want to be able to run
 # `helm install` on development checkouts without updating this file. the version doesn't matter in that case anyway
-version: 0.1.14
+version: 0.1.15
 appVersion: 0.1.11
 dependencies:
 - name: opencost

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -336,7 +336,7 @@ opentelemetry-collector:
   enabled: true
   image:
     repository: ghcr.io/nudgebee/opentelemetry-collector-contrib
-    tag: 0.75.0
+    tag: 0.156.0
   # Inherit name overrides from parent chart
   nameOverride: ""
   fullnameOverride: ""
@@ -397,12 +397,11 @@ opentelemetry-collector:
       clickhouse:
         endpoint: "tcp://nudgebee-agent-clickhouse:9000?dial_timeout=10s&compress=lz4" # Default endpoint, can be overridden
         database: default
-        ttl_days: 7
+        ttl: 168h
         username: default
         password: ${env:CLICKHOUSE_PASSWORD}
         logs_table_name: otel_logs
         traces_table_name: otel_traces
-        metrics_table_name: otel_metrics
         timeout: 5s
         retry_on_failure:
           enabled: true
@@ -428,7 +427,7 @@ clickhouse:
   image:
     registry: ghcr.io
     repository: nudgebee/clickhouse
-    tag: 24.12.4-debian-12-r0-nb-2
+    tag: 24.12.4-debian-12-r0-nb-3
   nameOverride: ""
   fullnameOverride: ""
   persistence:

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -273,7 +273,7 @@ nodeAgent:
   image:
     repository: ghcr.io/nudgebee/node-agent
     pullPolicy: IfNotPresent
-    tag: 0.1.3
+    tag: 0.1.4-rc.1
   resources:
     requests:
       cpu: "100m"


### PR DESCRIPTION
# Description

Security bumps for the agent chart's two runtime dependencies flagged by the CI Trivy scan (nudgebee/nudgebee run 29560497910):

| Component | From → To | Findings |
|---|---|---|
| clickhouse | `nb-2` → `nb-3` (nudgebee/nudgebee#618) | **5C/40H/63M → 0 fixable** — nb-2 was a one-off build that never ran `apt upgrade`; nb-3 joins the weekly mirror rebuild |
| otel-collector-contrib | `0.75.0` → `0.156.0` (current upstream, mirrored to ghcr) | **6C/63H/84M → 0/1/1** (residual = industry Go 1.26.4 stdlib pair) |

## Collector config migrations (verified against v0.156.0 exporter docs)

- `ttl_days: 7` → `ttl: 168h` (field renamed/retyped upstream)
- `metrics_table_name` dropped — the exporter now writes the `metrics_tables` split family (`otel_metrics_gauge`/`_sum`/…). **Verified nothing queries the old single `otel_metrics` table** (backend consumers read `otel_logs`/`otel_traces` only; those config keys and table names are unchanged in 0.156.0). Pipelines (otlp → filter/probabilistic_sampler/batch → clickhouse) use no components removed since 0.75.

Chart `0.1.14` → `0.1.15`.

## Merge order

After nudgebee/nudgebee#618 merges and the infra-mirrors workflow publishes `clickhouse:…-nb-3`. Then the standard **RC → `nudgebee-agent-dev-gke`** validation path exercises both swaps (collector pipeline into clickhouse is the key thing to eyeball: logs/traces flowing, no exporter config errors in the collector pod).

# How Has This Been Tested?

- [x] clickhouse nb-3 built + Trivy-scanned locally (0 fixable, was 5/40/63)
- [x] otel 0.156.0 upstream image scanned (0/1/1); mirrored to ghcr (digest verified)
- [x] Config fields checked against the v0.156.0 clickhouse-exporter documentation; `otel_metrics` consumer search came up empty
- [ ] RC deploy to dev-gke (after merge) — validate collector starts and logs/traces land in clickhouse