### PR TITLE
fix(chart): bump opentelemetry-collector subchart 0.52.* -> 0.165.0

### DIFF
--- a/charts/nudgebee-agent/Chart.yaml
+++ b/charts/nudgebee-agent/Chart.yaml
@@ -29,7 +29,7 @@ annotations:
 # these are set to the right value by .github/workflows/release.yaml
 # we use 0.0.1 as a placeholder for the version` because Helm wont allow `0.0.0` and we want to be able to run
 # `helm install` on development checkouts without updating this file. the version doesn't matter in that case anyway
-version: 0.1.15
+version: 0.1.16
 appVersion: 0.1.11
 dependencies:
 - name: opencost
@@ -41,6 +41,6 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   condition: opentelemetry-collector.enabled
 - name: opentelemetry-collector
-  version: 0.52.*
+  version: 0.165.0
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
   condition: opentelemetry-collector.enabled


### PR DESCRIPTION
# Description

The `0.1.15-rc-1` dev-gke rollout caught the collector **0.156.0 pod failing config parse** — the RC stage doing its job. Root cause: the `0.52.*`-era subchart injects defaults that modern collectors removed:

```
'extensions' unknown type: "memory_ballast"
'exporters' the logging exporter has been deprecated, use the debug exporter instead
'service.telemetry.metrics' has invalid keys: address
```

The old 0.75.0 ReplicaSet kept serving, so dev stayed up.

**Fix:** subchart → `0.165.0` (the chart release paired with app 0.156.0): defaults use `debug`, no `memory_ballast`, current telemetry keys. Our values overlay (`mode`, `image`, `ports`, `config` incl. the clickhouse exporter) is schema-compatible unchanged.

## Verified

- `helm dependency update` + `helm template`, then **`otelcol-contrib validate` from the actual 0.156.0 image against the full rendered collector ConfigMap → exit 0**
- (Previous validation covered only our exporter block — that gap is why the subchart-default breakage surfaced at RC rather than review. Full-rendered-config validation is the standard now.)

Chart `0.1.15` → `0.1.16`.

# How Has This Been Tested?

- [x] Full rendered config binary-validated on 0.156.0 (exit 0)
- [ ] RC `0.1.16-rc-1` → dev-gke redeploy after merge — confirm the new collector pod replaces the 0.75.0 ReplicaSet and logs/traces land in clickhouse