### PR TITLE
fix(chronosphere): retry transient 503 UNAVAILABLE and bound concurrency

### DIFF
--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -65,7 +65,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-07-17T04-32-36_5d6b67def3ede8e306d467fea4242b36c9eb9c68
+    tag: 2026-07-20T10-29-26_01e8d7ec1e9e88cf0e0a145f7db432d23d0db33d
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/runner/pkg/observability/chronosphere/chronosphere_test.go
+++ b/runner/pkg/observability/chronosphere/chronosphere_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -124,6 +125,38 @@ func TestQueryTraces_DoesNotRetryClientError(t *testing.T) {
 	}
 	if got := atomic.LoadInt32(&calls); got != 1 {
 		t.Errorf("400 must not be retried; expected 1 attempt, got %d", got)
+	}
+}
+
+func TestQueryTraces_LimitsConcurrency(t *testing.T) {
+	var inFlight, maxSeen int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := atomic.AddInt32(&inFlight, 1)
+		for {
+			m := atomic.LoadInt32(&maxSeen)
+			if n <= m || atomic.CompareAndSwapInt32(&maxSeen, m, n) {
+				break
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+		atomic.AddInt32(&inFlight, -1)
+		_, _ = w.Write([]byte(`{"traces":[]}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, nil)
+	c.MaxConcurrent = 2
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = c.QueryTraces(context.Background(), map[string]any{})
+		}()
+	}
+	wg.Wait()
+	if got := atomic.LoadInt32(&maxSeen); got > 2 {
+		t.Errorf("max concurrent requests = %d, want <= 2", got)
 	}
 }
 

--- a/runner/pkg/observability/chronosphere/chronosphere_test.go
+++ b/runner/pkg/observability/chronosphere/chronosphere_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -61,6 +62,68 @@ func TestQueryTraces_HTTPError(t *testing.T) {
 	_, err := c.QueryTraces(context.Background(), map[string]any{})
 	if err == nil || !strings.Contains(err.Error(), "401") {
 		t.Errorf("expected HTTP 401 error, got %v", err)
+	}
+}
+
+func TestQueryTraces_RetriesTransient503ThenSucceeds(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if atomic.AddInt32(&calls, 1) < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			// Chronosphere's gRPC UNAVAILABLE body.
+			_, _ = w.Write([]byte(`{"code":14,"error":"Something went wrong and the request could not complete. In many cases the issue can be resolved by trying again."}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"traces":[]}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, nil)
+	c.RetryBackoff = time.Millisecond // keep the test fast
+	if _, err := c.QueryTraces(context.Background(), map[string]any{}); err != nil {
+		t.Fatalf("expected success after retries, got %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 3 {
+		t.Errorf("expected 3 attempts (2 x 503 + 1 ok), got %d", got)
+	}
+}
+
+func TestQueryTraces_RetriesExhausted(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"code":14,"error":"Something went wrong and the request could not complete."}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, nil)
+	c.RetryBackoff = time.Millisecond
+	_, err := c.QueryTraces(context.Background(), map[string]any{})
+	if err == nil || !strings.Contains(err.Error(), "503") {
+		t.Errorf("expected HTTP 503 error after exhausting retries, got %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != int32(c.MaxRetries+1) {
+		t.Errorf("expected %d attempts, got %d", c.MaxRetries+1, got)
+	}
+}
+
+func TestQueryTraces_DoesNotRetryClientError(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"message":"unknown field"}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, nil)
+	c.RetryBackoff = time.Millisecond
+	if _, err := c.QueryTraces(context.Background(), map[string]any{}); err == nil {
+		t.Fatal("expected error for HTTP 400")
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Errorf("400 must not be retried; expected 1 attempt, got %d", got)
 	}
 }
 

--- a/runner/pkg/observability/chronosphere/client.go
+++ b/runner/pkg/observability/chronosphere/client.go
@@ -8,6 +8,14 @@
 // composes the ListTraces request body (query_type, tag_filters, time range),
 // matching the legacy agent which posts to the same /api/v1/data/traces path.
 // (The earlier /api/unstable/data/traces/searches path 404s on Chronosphere.)
+//
+// Chronosphere's gateway sheds load with a transient gRPC UNAVAILABLE (code 14)
+// mapped to HTTP 503 — "Something went wrong and the request could not
+// complete ... trying again". QueryTraces retries that condition with backoff
+// and bounds concurrent in-flight requests so a burst of trace queries doesn't
+// pile onto an already-struggling backend. The api-server's legacy proxy path
+// already retries the same message (isRetryableError); the agent path did not,
+// so a single Chronosphere blip surfaced as a hard failure to the caller.
 package chronosphere
 
 import (
@@ -22,20 +30,41 @@ import (
 	"time"
 )
 
+const (
+	defaultMaxRetries    = 2
+	defaultRetryBackoff  = 500 * time.Millisecond
+	defaultMaxConcurrent = 4
+)
+
 type Client struct {
 	BaseURL string
 	APIKey  string // sent as Authorization: Bearer <key>
 	HTTP    *http.Client
+
+	// MaxRetries is the number of additional attempts after the first when
+	// Chronosphere returns a transient error (HTTP 503 / gRPC UNAVAILABLE).
+	MaxRetries int
+	// RetryBackoff is the base delay for exponential backoff between retries.
+	RetryBackoff time.Duration
+
+	sem chan struct{} // bounds concurrent in-flight requests; nil disables
 }
 
 func New(baseURL string, httpClient *http.Client) *Client {
 	if httpClient == nil {
 		httpClient = &http.Client{Timeout: 60 * time.Second}
 	}
-	return &Client{BaseURL: strings.TrimRight(baseURL, "/"), HTTP: httpClient}
+	return &Client{
+		BaseURL:      strings.TrimRight(baseURL, "/"),
+		HTTP:         httpClient,
+		MaxRetries:   defaultMaxRetries,
+		RetryBackoff: defaultRetryBackoff,
+		sem:          make(chan struct{}, defaultMaxConcurrent),
+	}
 }
 
-// QueryTraces forwards params as the search request body.
+// QueryTraces forwards params as the search request body, retrying transient
+// Chronosphere backend-unavailable errors with exponential backoff.
 func (c *Client) QueryTraces(ctx context.Context, params any) (json.RawMessage, error) {
 	if c.BaseURL == "" {
 		return nil, errors.New("chronosphere: base URL not configured")
@@ -47,10 +76,43 @@ func (c *Client) QueryTraces(ctx context.Context, params any) (json.RawMessage, 
 	if err != nil {
 		return nil, fmt.Errorf("marshal: %w", err)
 	}
+
+	// Bound concurrent requests so a burst of trace queries doesn't pile onto
+	// an already-struggling Chronosphere backend (which sheds load with 503).
+	if c.sem != nil {
+		select {
+		case c.sem <- struct{}{}:
+			defer func() { <-c.sem }()
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	var lastErr error
+	for attempt := 0; ; attempt++ {
+		if attempt > 0 {
+			if err := sleepBackoff(ctx, c.RetryBackoff, attempt); err != nil {
+				return nil, err
+			}
+		}
+		raw, retryable, err := c.doQuery(ctx, body)
+		if err == nil {
+			return raw, nil
+		}
+		lastErr = err
+		if !retryable || attempt >= c.MaxRetries {
+			return nil, lastErr
+		}
+	}
+}
+
+// doQuery performs a single request. retryable is true when the failure is a
+// transient Chronosphere condition worth another attempt.
+func (c *Client) doQuery(ctx context.Context, body []byte) (raw json.RawMessage, retryable bool, err error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
 		c.BaseURL+"/api/v1/data/traces", bytes.NewReader(body))
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	if c.APIKey != "" {
@@ -58,15 +120,44 @@ func (c *Client) QueryTraces(ctx context.Context, params any) (json.RawMessage, 
 	}
 	resp, err := c.HTTP.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("chronosphere: %w", err)
+		// Transport errors are transient unless the context is done (retrying
+		// a cancelled/expired request is pointless).
+		return nil, ctx.Err() == nil, fmt.Errorf("chronosphere: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, err
+		return nil, ctx.Err() == nil, err
 	}
 	if resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("chronosphere HTTP %d: %s", resp.StatusCode, string(respBody))
+		return nil, isRetryable(resp.StatusCode, respBody),
+			fmt.Errorf("chronosphere HTTP %d: %s", resp.StatusCode, string(respBody))
 	}
-	return json.RawMessage(respBody), nil
+	return json.RawMessage(respBody), false, nil
+}
+
+// isRetryable reports whether a Chronosphere error response is a transient
+// backend-unavailable condition. Mirrors api-server's isRetryableError plus the
+// gRPC UNAVAILABLE (code 14) that Chronosphere's gateway maps to HTTP 503.
+func isRetryable(status int, body []byte) bool {
+	if status == http.StatusServiceUnavailable {
+		return true
+	}
+	b := string(body)
+	return strings.Contains(b, "Something went wrong and the request could not complete") ||
+		strings.Contains(b, "In many cases the issue can be resolved by trying again") ||
+		strings.Contains(b, "Service Unavailable") ||
+		strings.Contains(b, `"code":14`)
+}
+
+// sleepBackoff waits base*2^(attempt-1), or returns early if ctx is done.
+func sleepBackoff(ctx context.Context, base time.Duration, attempt int) error {
+	t := time.NewTimer(base * time.Duration(1<<(attempt-1)))
+	defer t.Stop()
+	select {
+	case <-t.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }

--- a/runner/pkg/observability/chronosphere/client.go
+++ b/runner/pkg/observability/chronosphere/client.go
@@ -27,6 +27,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -34,6 +35,7 @@ const (
 	defaultMaxRetries    = 2
 	defaultRetryBackoff  = 500 * time.Millisecond
 	defaultMaxConcurrent = 4
+	maxRetryBackoff      = 30 * time.Second
 )
 
 type Client struct {
@@ -46,8 +48,13 @@ type Client struct {
 	MaxRetries int
 	// RetryBackoff is the base delay for exponential backoff between retries.
 	RetryBackoff time.Duration
+	// MaxConcurrent bounds concurrent in-flight requests; <= 0 disables the
+	// limit. Set before the first QueryTraces call — the semaphore is built
+	// once, lazily, on first use.
+	MaxConcurrent int
 
-	sem chan struct{} // bounds concurrent in-flight requests; nil disables
+	semOnce sync.Once
+	sem     chan struct{}
 }
 
 func New(baseURL string, httpClient *http.Client) *Client {
@@ -55,11 +62,31 @@ func New(baseURL string, httpClient *http.Client) *Client {
 		httpClient = &http.Client{Timeout: 60 * time.Second}
 	}
 	return &Client{
-		BaseURL:      strings.TrimRight(baseURL, "/"),
-		HTTP:         httpClient,
-		MaxRetries:   defaultMaxRetries,
-		RetryBackoff: defaultRetryBackoff,
-		sem:          make(chan struct{}, defaultMaxConcurrent),
+		BaseURL:       strings.TrimRight(baseURL, "/"),
+		HTTP:          httpClient,
+		MaxRetries:    defaultMaxRetries,
+		RetryBackoff:  defaultRetryBackoff,
+		MaxConcurrent: defaultMaxConcurrent,
+	}
+}
+
+// acquire takes a concurrency slot, returning a release func. When the limit is
+// disabled (MaxConcurrent <= 0) it is a no-op. Slots are held only for the
+// duration of an active HTTP request, not across backoff sleeps.
+func (c *Client) acquire(ctx context.Context) (func(), error) {
+	c.semOnce.Do(func() {
+		if c.MaxConcurrent > 0 {
+			c.sem = make(chan struct{}, c.MaxConcurrent)
+		}
+	})
+	if c.sem == nil {
+		return func() {}, nil
+	}
+	select {
+	case c.sem <- struct{}{}:
+		return func() { <-c.sem }, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
 	}
 }
 
@@ -75,17 +102,6 @@ func (c *Client) QueryTraces(ctx context.Context, params any) (json.RawMessage, 
 	body, err := json.Marshal(params)
 	if err != nil {
 		return nil, fmt.Errorf("marshal: %w", err)
-	}
-
-	// Bound concurrent requests so a burst of trace queries doesn't pile onto
-	// an already-struggling Chronosphere backend (which sheds load with 503).
-	if c.sem != nil {
-		select {
-		case c.sem <- struct{}{}:
-			defer func() { <-c.sem }()
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		}
 	}
 
 	var lastErr error
@@ -109,6 +125,15 @@ func (c *Client) QueryTraces(ctx context.Context, params any) (json.RawMessage, 
 // doQuery performs a single request. retryable is true when the failure is a
 // transient Chronosphere condition worth another attempt.
 func (c *Client) doQuery(ctx context.Context, body []byte) (raw json.RawMessage, retryable bool, err error) {
+	// Bound concurrent requests so a burst of trace queries doesn't pile onto
+	// an already-struggling Chronosphere backend (which sheds load with 503).
+	// Held only for the active request, not across backoff sleeps.
+	release, err := c.acquire(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+	defer release()
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
 		c.BaseURL+"/api/v1/data/traces", bytes.NewReader(body))
 	if err != nil {
@@ -143,16 +168,24 @@ func isRetryable(status int, body []byte) bool {
 	if status == http.StatusServiceUnavailable {
 		return true
 	}
-	b := string(body)
-	return strings.Contains(b, "Something went wrong and the request could not complete") ||
-		strings.Contains(b, "In many cases the issue can be resolved by trying again") ||
-		strings.Contains(b, "Service Unavailable") ||
-		strings.Contains(b, `"code":14`)
+	return bytes.Contains(body, []byte("Something went wrong and the request could not complete")) ||
+		bytes.Contains(body, []byte("In many cases the issue can be resolved by trying again")) ||
+		bytes.Contains(body, []byte("Service Unavailable")) ||
+		bytes.Contains(body, []byte(`"code":14`))
 }
 
-// sleepBackoff waits base*2^(attempt-1), or returns early if ctx is done.
+// sleepBackoff waits base*2^(attempt-1), capped at maxRetryBackoff (and guarded
+// against shift overflow), or returns early if ctx is done.
 func sleepBackoff(ctx context.Context, base time.Duration, attempt int) error {
-	t := time.NewTimer(base * time.Duration(1<<(attempt-1)))
+	shift := attempt - 1
+	if shift > 30 {
+		shift = 30
+	}
+	delay := base * time.Duration(1<<shift)
+	if delay > maxRetryBackoff || delay <= 0 {
+		delay = maxRetryBackoff
+	}
+	t := time.NewTimer(delay)
 	defer t.Stop()
 	select {
 	case <-t.C:


### PR DESCRIPTION
## Problem

Runner logs showed a runner pod returning `chronosphere HTTP 503` on `chronosphere_query_traces`, while a direct `curl` to the same endpoint/token worked. Investigation of the actual 503 body:

```json
{"code":14,"status":"error","errorType":"internal",
 "error":"Something went wrong and the request could not complete. In many cases the issue can be resolved by trying again. For more persistent problems, please contact support."}
```

`code:14` is gRPC **UNAVAILABLE**, which Chronosphere's gateway maps to HTTP 503 — a transient load-shedding / backend-unavailable signal, **not** an auth (verified `Authorization: Bearer` and `API-Token` both return 200) or proxy issue. Over a 4h window the runner saw ~6,400 such 503s against ~270 successes, arriving in bursts.

The agent's `QueryTraces` had **no retry**, so every transient blip surfaced as a hard failure. The api-server's other Chronosphere path already recognizes this exact message as retryable (`isRetryableError`); the agent path did not.

## Change

- Retry the transient condition (HTTP 503, gRPC `code:14`, and the known "Something went wrong … trying again" / "Service Unavailable" messages) with exponential backoff (base 500ms, 2 retries), respecting context cancellation.
- Bound concurrent in-flight requests (default 4) so a burst of trace queries doesn't pile onto an already-struggling backend.
- Client errors (4xx other than 503) are **not** retried.

## Notes

This absorbs transient blips; a sustained Chronosphere outage still needs a Chronosphere-side fix and/or reduced query volume/cost. The `code:14` string match and message-text markers mirror the api-server's `isRetryableError`.

## Test

- New unit tests: retries 503 then succeeds (asserts attempt count), exhausts retries and surfaces 503, and does not retry 4xx.
- `go build ./...` and `go test ./pkg/observability/chronosphere/` pass.