### PR TITLE
security(deps): opentelemetry-collector-contrib 0.156.0 -> 0.157.0

### DIFF
--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -65,7 +65,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-07-20T10-29-26_01e8d7ec1e9e88cf0e0a145f7db432d23d0db33d
+    tag: 2026-07-21T10-40-18_0ef355a8e27b98e6b54414c6609c527a3ef65159
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -336,7 +336,7 @@ opentelemetry-collector:
   enabled: true
   image:
     repository: ghcr.io/nudgebee/opentelemetry-collector-contrib
-    tag: 0.156.0
+    tag: 0.157.0
   # Inherit name overrides from parent chart
   nameOverride: ""
   fullnameOverride: ""


### PR DESCRIPTION
# Description

`ghcr.io/nudgebee/opentelemetry-collector-contrib:0.156.0` carries **GHSA-hrxh-6v49-42gf** (HIGH, grpc `v1.82.0`) plus the Go-stdlib pair **CVE-2026-39822** (HIGH) / **CVE-2026-42505** (MEDIUM) from its Go 1.26.4 build — `0/2/1` fixable in the nudgebee-oss deployed-image Trivy scan.

I pulled the `0.157.0` release binary and read its build metadata: **`go1.26.5`** with **`grpc v1.82.1`** — all three cleared.

The ghcr mirror is already published (digest identical to upstream, all 7 platforms preserved) and is now recorded in nudgebee-oss `deploy/kubernetes/nudgebee-mirrors/clone-third-party.sh` (nudgebee/nudgebee#631) so it has a reproducible source rather than an ad-hoc push.

Chart version left at `0.1.17` — that version is not yet published, so this folds in rather than cutting a new one.

# How Has This Been Tested?

- [x] `helm dependency build` + `helm template` renders `image: "ghcr.io/nudgebee/opentelemetry-collector-contrib:0.157.0"`
- [x] `helm lint` passes
- [x] Mirror verified pullable: digest matches upstream `0.157.0` exactly