### PR TITLE
feat(chart): configurable alert-rule exclusions and opt-in keep_firing_for

### DIFF
--- a/charts/nudgebee-agent/templates/prometheus-alert-rule.yaml
+++ b/charts/nudgebee-agent/templates/prometheus-alert-rule.yaml
@@ -21,7 +21,13 @@ emitted unless the install explicitly declares support. See values.yaml.
 {{- $keepFiringFor := .Values.alertmanager.rule_keep_firing_for -}}
 {{- $extra := "" -}}
 {{- with .Values.alertmanager.extra_rule_exclusions -}}
+{{- /*
+compact drops empty strings: an empty alternation ("||" or a trailing "|")
+matches EVERYTHING, which would silently disable both rules cluster-wide.
+*/ -}}
+{{- with compact . -}}
 {{- $extra = printf "|%s" (join "|" .) -}}
+{{- end -}}
 {{- end -}}
 {{- $excludeLog := printf ".*(prometheus|grafana|kube-system|nudgebee-agent|containerd|kubelet|keda|actions-runner-system-1|fluent-bit|fluentd|loki|opensearch|elasticsearch|logstash|datadog|newrelic|otel|promtail%s).*" $extra -}}
 {{- $excludeApi := printf ".*(prometheus|grafana|kube-system|nudgebee-agent|containerd|kubelet|keda|karpenter|actions-runner-system-1%s).*" $extra -}}

--- a/charts/nudgebee-agent/templates/prometheus-alert-rule.yaml
+++ b/charts/nudgebee-agent/templates/prometheus-alert-rule.yaml
@@ -5,9 +5,26 @@ Container-ID exclusions for the log-error and HTTP-failure rules.
 The log-error regex additionally excludes log-collection infrastructure
 (fluent-bit, loki, opensearch, etc.), which emits steady error-level
 log streams that are transport/ingest failures — not app-level signal.
+
+alertmanager.extra_rule_exclusions appends install-specific terms to BOTH
+regexes (matched as substrings of container_id) without forking the defaults —
+e.g. environments running synthetic load or demo apps that fail on purpose.
 */ -}}
-{{- $excludeLog := ".*(prometheus|grafana|kube-system|nudgebee-agent|containerd|kubelet|keda|actions-runner-system-1|fluent-bit|fluentd|loki|opensearch|elasticsearch|logstash|datadog|newrelic|otel|promtail).*" -}}
-{{- $excludeApi := ".*(prometheus|grafana|kube-system|nudgebee-agent|containerd|kubelet|keda|karpenter|actions-runner-system-1).*" -}}
+{{- /*
+keep_firing_for holds an alert firing through brief dips below threshold, so an
+intermittently failing endpoint produces one steady alert instead of resolve/
+re-fire churn (observed ~8 re-fires/hour on a single flaky endpoint without it).
+OPT-IN via alertmanager.rule_keep_firing_for (default "": field omitted) —
+Prometheus < 2.42 rejects rule files containing the field, so it must never be
+emitted unless the install explicitly declares support. See values.yaml.
+*/ -}}
+{{- $keepFiringFor := .Values.alertmanager.rule_keep_firing_for -}}
+{{- $extra := "" -}}
+{{- with .Values.alertmanager.extra_rule_exclusions -}}
+{{- $extra = printf "|%s" (join "|" .) -}}
+{{- end -}}
+{{- $excludeLog := printf ".*(prometheus|grafana|kube-system|nudgebee-agent|containerd|kubelet|keda|actions-runner-system-1|fluent-bit|fluentd|loki|opensearch|elasticsearch|logstash|datadog|newrelic|otel|promtail%s).*" $extra -}}
+{{- $excludeApi := printf ".*(prometheus|grafana|kube-system|nudgebee-agent|containerd|kubelet|keda|karpenter|actions-runner-system-1%s).*" $extra -}}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -49,6 +66,9 @@ spec:
             and
             rate(container_log_messages_total{level=~"error|critical", container_id!~"{{ $excludeLog }}"}[1h] offset 1h) > 0
           for: 10m
+{{- with $keepFiringFor }}
+          keep_firing_for: {{ . }}
+{{- end }}
           annotations:
             summary: "High error/critical logs - Sample: {{`{{ printf \"%.80s\" $labels.sample }}`}}"
             description: "Container log error rate is more than 3x its 1h baseline. Container ID: {{`{{ $labels.container_id }}`}} Log Sample: {{`{{ $labels.sample }}`}} Current rate (err/s): {{`{{ printf \"%.2f\" $value }}`}}"
@@ -68,6 +88,9 @@ spec:
             and on (container_id, method, path)
             sum by (container_id, method, path) (rate(container_http_requests_total{container_id!~"{{ $excludeApi }}"}[5m])) > 0.1
           for: 10m
+{{- with $keepFiringFor }}
+          keep_firing_for: {{ . }}
+{{- end }}
           annotations:
             summary: "High 5xx rate - {{`{{ $labels.method }}`}} {{`{{ printf \"%.50s\" $labels.path }}`}}"
             description: "Aggregate 5xx rate across status codes exceeds 5% of total traffic. Container ID: {{`{{ $labels.container_id }}`}} Request Path: {{`{{ $labels.path }}`}} Request Method: {{`{{ $labels.method }}`}} 5xx Ratio: {{`{{ printf \"%.2f\" $value }}`}}"

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -477,3 +477,19 @@ clickhouse:
             description: "Average query duration is above 1 second over last 5 minutes."
 alertmanager:
   create_nb_default_rules: true
+  # Extra alternation terms appended to the container-id exclusion regex of the
+  # default alert rules (both the log-error and HTTP-failure rules). Terms match
+  # as substrings of container_id (/k8s/<namespace>/<pod>/<container>), so a
+  # namespace name excludes that whole namespace.
+  # e.g. for clusters running demo/synthetic-load apps that fail on purpose:
+  # extra_rule_exclusions: ["demo", "nb-bench"]
+  extra_rule_exclusions: []
+  # OPT-IN: keep_firing_for for the flap-prone rules (HighErrorCriticalLogs,
+  # ApplicationAPIFailures): an intermittently failing target stays one steady
+  # alert instead of resolving and re-firing on every dip below threshold.
+  # Off by default for provider compatibility — Prometheus < 2.42 REJECTS rule
+  # files containing this field (taking down every rule in the group), and
+  # other PrometheusRule consumers (VictoriaMetrics operator < v0.46, older
+  # rulers) silently drop or reject it. Only set this (e.g. "10m") when every
+  # rule evaluator in the target cluster is known to support keep_firing_for.
+  rule_keep_firing_for: ""

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -65,7 +65,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-07-21T10-40-18_0ef355a8e27b98e6b54414c6609c527a3ef65159
+    tag: 2026-07-30T09-40-57_cdcc22f6c17e1ec59e15cc9b89278b7c084aaf74
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.


### PR DESCRIPTION
## What

Two additive values knobs on the default nb alert rules (`prometheus-alert-rule.yaml`). **Both are no-ops unless set — the default render is byte-identical to the current chart** (verified by diffing `helm template` output against `origin/main`).

### `alertmanager.extra_rule_exclusions` (default `[]`)
List of alternation terms appended to the container_id exclusion regex of both the log-error and HTTP-failure rules. Terms match as substrings of `container_id` (`/k8s/<namespace>/<pod>/<container>`), so a namespace name excludes that namespace.

Motivation: clusters running demo/synthetic-load apps that fail on purpose (e.g. otel-demo load generators) flood ApplicationAPIFailures — on dev-GKE two load-generator pods alone produced ~19.5k alert activations in 7 days on `/api/cart`. This lets such installs exclude them without forking the default rules.

### `alertmanager.rule_keep_firing_for` (default `""` — opt-in)
When set (e.g. `"10m"`), emits `keep_firing_for` on the two flap-prone rules (ApplicationAPIFailures, HighErrorCriticalLogs) so an intermittently failing target stays one steady alert instead of resolve/re-fire churn (~8 re-fires/hour observed on a single flaky endpoint in dev).

**Off by default for provider compatibility**: Prometheus < 2.42 rejects rule files containing the field (taking down the whole rule group), and some PrometheusRule consumers drop it (VictoriaMetrics operator < v0.46 drops it in PrometheusRule→VMRule conversion — verified empirically on v0.45.0). Only enable where every rule evaluator in the target cluster supports it.

## Validation

- `helm template` default render diffed byte-identical vs `origin/main`
- exclusions set → terms appended in all 7 regex occurrences (3× API rule, 4× log rule)
- `rule_keep_firing_for=10m` → field emitted on exactly the 2 intended rules; `""` → omitted entirely (note: template reads the value directly — sprig `default` would swallow the empty-string disable path)
- rendered output parses as valid YAML