### PR TITLE
fix(scanners): bound scan Jobs with ActiveDeadlineSeconds so wedged Jobs self-terminate

### DIFF
--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -65,7 +65,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-07-31T05-49-10_de0915f92bf0a028846c7082445222810506ca9a
+    tag: 2026-07-31T06-50-14_8717b178359e9dce22453bf1de7e7d8e9eccfda3
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/runner/pkg/scanners/scanners.go
+++ b/runner/pkg/scanners/scanners.go
@@ -33,9 +33,18 @@ import (
 
 // Hygiene constants — agent-enforced, server cannot override.
 const (
-	jobTTLSeconds        int32 = 600 // 10 min after-finish cleanup
-	jobBackoffLimit      int32 = 0   // fail-fast; orchestrator decides retries
-	defaultMaxConcurrent int   = 5
+	jobTTLSeconds   int32 = 600 // 10 min after-finish cleanup
+	jobBackoffLimit int32 = 0   // fail-fast; orchestrator decides retries
+	// minJobActiveDeadlineSeconds is the floor for every Job's
+	// ActiveDeadlineSeconds. Without a deadline a Job whose pod never starts its
+	// container — wedged in ImagePullBackOff, or unschedulable because the pinned
+	// NodeName went away — stays Active with no terminal condition forever, which
+	// makes it invisible to both cleanup paths (the TTLAfterFinished controller
+	// and our own reaper are finished-only). 30 min is a pure hygiene backstop,
+	// comfortably above the api-server orchestrator's 15-min poll budget, so it
+	// never cuts short a scan the orchestrator would still accept.
+	minJobActiveDeadlineSeconds int64 = 1800
+	defaultMaxConcurrent        int   = 5
 	// 64 MiB raw stdout cap — large enough to absorb trivy_cis (~17 MiB) and
 	// kube_bench full reports without truncation. Agent gzips before sending,
 	// so the wire payload is typically ~5-10x smaller than the raw cap.
@@ -89,6 +98,9 @@ func NewRunner(cs kubernetes.Interface, namespace, serviceAccount string) *Runne
 // Hygiene the agent enforces (server cannot override):
 //   - Job runs in r.Namespace.
 //   - TTLSecondsAfterFinished = 600 (10 min cleanup).
+//   - ActiveDeadlineSeconds = max(spec.TimeoutHintSeconds, 1800), so a Job that
+//     can never make progress becomes terminal on its own and the normal
+//     finished-Job cleanup applies.
 //   - BackoffLimit = 0 (fail-fast).
 //   - app.kubernetes.io/managed-by + nudgebee.com/orchestrator labels are stamped.
 //   - A per-Job UUID label is added for audit.
@@ -143,6 +155,14 @@ func (r *Runner) BuildJob(spec JobSpec, jobName, jobUUID string) *batchv1.Job {
 
 	ttl := jobTTLSeconds
 	backoff := jobBackoffLimit
+	// Give the Job a wall-clock deadline so Kubernetes terminates it if it never
+	// reaches a terminal state on its own. A scanner that declares a longer budget
+	// (nova's helm-chart-upgrade sends 3000s) keeps it — the floor only applies to
+	// specs that declare nothing.
+	deadline := minJobActiveDeadlineSeconds
+	if hint := int64(spec.TimeoutHintSeconds); hint > deadline {
+		deadline = hint
+	}
 	labels := map[string]string{
 		managedByLabel:    managedByValue,
 		orchestratorLabel: orchestratorValue,
@@ -157,6 +177,7 @@ func (r *Runner) BuildJob(spec JobSpec, jobName, jobUUID string) *batchv1.Job {
 		Spec: batchv1.JobSpec{
 			BackoffLimit:            &backoff,
 			TTLSecondsAfterFinished: &ttl,
+			ActiveDeadlineSeconds:   &deadline,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{jobNameSelectorLabel: jobName},
@@ -253,10 +274,12 @@ func jobStatusSnapshot(j *batchv1.Job) (string, string) {
 	return "Running", ""
 }
 
-// imagePullFailure reports whether the Job's pod is wedged on an image pull it
-// will never recover from — the container is Waiting with reason ImagePullBackOff
-// or ErrImagePull. This is terminal in practice (a missing tag or a private
-// registry the scanner can't authenticate to won't fix itself) but the kubelet
+// imagePullFailure reports whether the Job's pod is wedged on an image it will
+// never get — the container is Waiting with reason ImagePullBackOff, ErrImagePull
+// or ErrImageNeverPull. This is terminal in practice (a missing tag, a private
+// registry the scanner can't authenticate to, or — for image_scanner, which runs
+// pull-policy Never by design — a node-local image that has since been evicted
+// won't fix itself) but the kubelet
 // never starts the container, so the Job earns no Failed condition and would
 // otherwise poll as "Running" until the orchestrator's overall deadline — never
 // getting deleted, never reaped (TTL and the reaper only touch finished Jobs).
@@ -276,7 +299,7 @@ func (r *Runner) imagePullFailure(ctx context.Context, jobName string) (string, 
 	}
 	check := func(statuses []corev1.ContainerStatus) (string, bool) {
 		for _, cs := range statuses {
-			if w := cs.State.Waiting; w != nil && (w.Reason == "ImagePullBackOff" || w.Reason == "ErrImagePull") {
+			if w := cs.State.Waiting; w != nil && (w.Reason == "ImagePullBackOff" || w.Reason == "ErrImagePull" || w.Reason == "ErrImageNeverPull") {
 				return fmt.Sprintf("image pull failed for container %q: %s", cs.Name, w.Message), true
 			}
 		}

--- a/runner/pkg/scanners/scanners_test.go
+++ b/runner/pkg/scanners/scanners_test.go
@@ -36,6 +36,7 @@ func TestBuildJob_HygieneInvariants(t *testing.T) {
 	// Every Job the agent creates MUST have:
 	//   - TTLSecondsAfterFinished = 600
 	//   - BackoffLimit = 0
+	//   - ActiveDeadlineSeconds >= 1800
 	//   - managed-by + orchestrator labels
 	//   - per-Job UUID label
 	// regardless of what the JobSpec asked for.
@@ -52,6 +53,9 @@ func TestBuildJob_HygieneInvariants(t *testing.T) {
 	if got := *job.Spec.BackoffLimit; got != jobBackoffLimit {
 		t.Errorf("BackoffLimit = %d; want hard-clamped %d", got, jobBackoffLimit)
 	}
+	if got := *job.Spec.ActiveDeadlineSeconds; got != minJobActiveDeadlineSeconds {
+		t.Errorf("ActiveDeadlineSeconds = %d; want floor %d", got, minJobActiveDeadlineSeconds)
+	}
 	if job.Labels[managedByLabel] != managedByValue {
 		t.Errorf("missing managed-by label: %v", job.Labels)
 	}
@@ -66,6 +70,32 @@ func TestBuildJob_HygieneInvariants(t *testing.T) {
 	}
 	if job.Spec.Template.Spec.RestartPolicy != corev1.RestartPolicyNever {
 		t.Errorf("RestartPolicy = %v; want Never", job.Spec.Template.Spec.RestartPolicy)
+	}
+}
+
+// A scanner that declares a budget longer than the hygiene floor keeps it — the
+// deadline is a backstop against wedged Jobs, not a scan timeout. nova's
+// helm-chart-upgrade is the real case (3000s).
+func TestBuildJob_ActiveDeadlineHonorsLongerTimeoutHint(t *testing.T) {
+	r := NewRunner(fake.NewClientset(), "ns", "agent-sa")
+
+	long := r.BuildJob(JobSpec{
+		NamePrefix:         "helm-chart-upgrade",
+		Image:              "nova:latest",
+		TimeoutHintSeconds: 3000,
+	}, "helm-chart-upgrade-abcd1234", "uuid-2")
+	if got := *long.Spec.ActiveDeadlineSeconds; got != 3000 {
+		t.Errorf("ActiveDeadlineSeconds = %d; want the spec's 3000s hint", got)
+	}
+
+	// A hint below the floor must not shorten the backstop.
+	short := r.BuildJob(JobSpec{
+		NamePrefix:         "trivy-image-scan",
+		Image:              "target:latest",
+		TimeoutHintSeconds: 60,
+	}, "trivy-image-scan-abcd1234", "uuid-3")
+	if got := *short.Spec.ActiveDeadlineSeconds; got != minJobActiveDeadlineSeconds {
+		t.Errorf("ActiveDeadlineSeconds = %d; want floor %d", got, minJobActiveDeadlineSeconds)
 	}
 }
 


### PR DESCRIPTION
## Summary

A scan Job whose pod never starts its container stays `Active` with no terminal condition **forever**. Both cleanup paths — the cluster's `TTLAfterFinished` controller and our own reaper (`jobFinishedAt` → `jobIsTerminal`) — are finished-only, so nothing in the cluster ever collects it. The Job's fate is delegated entirely to the api-server orchestrator's poll, which means cleanup needs *two* components patched and a live backend.

Observed on the dev cluster: 27 `trivy-image-scan-*` Jobs across 5 namespaces, 20–27h old, `active: 1`, no conditions. The oldest pod had logged 5617 `BackOff` events.

`BuildJob` now stamps `ActiveDeadlineSeconds = max(spec.TimeoutHintSeconds, 1800)` alongside the TTL and `BackoffLimit` it already enforced. Kubernetes marks the Job `Failed`/`DeadlineExceeded` at the deadline — exactly what `jobIsTerminal` looks for — so the existing reaper and TTL collect it with no further code and no backend involvement. Declarative on the Job, so it also survives an agent restart mid-scan.

The floor is a hygiene backstop, not a scan timeout: 30 min sits comfortably above the orchestrator's 15-min poll budget, and a scanner declaring a longer budget (nova's helm-chart-upgrade sends 3000s) keeps it.

Also treats `ErrImageNeverPull` as an image-pull failure in `imagePullFailure`, so an `image_scanner` Job running pull-policy `Never` reports the same terminal reason instead of polling as `Running` until the orchestrator's deadline. Message format is unchanged, preserving the cross-repo string contract with the api-server's `isImagePullFailure`.

Pairs with nudgebee/nudgebee-enterprise#35590, which switches the image scan to pull-policy `Never` so the wedge stops being created in the first place. Independent of it — either can land alone.

## Type of change

- [x] Bug fix (non-breaking)

## Chart version

- [x] No version bump needed — runner Go code only; ships via the image tag CI updates.

## Test plan

- [x] `go build ./...`, `go vet ./pkg/scanners/` clean
- [x] `golangci-lint run ./pkg/scanners/...` — 0 issues
- [x] `go test ./pkg/scanners/... -count=1` passes
- [x] `TestBuildJob_HygieneInvariants` extended to assert the deadline floor
- [x] `TestBuildJob_ActiveDeadlineHonorsLongerTimeoutHint` added — nova's 3000s hint is preserved; a 60s hint does not shorten the backstop

## Review notes — risks & counterarguments

- **Still needs a rollout.** This does not fix already-wedged Jobs, and stale agents keep leaking until upgraded. What it buys is that cleanup no longer depends on the *backend* version — one component up to date is enough, where today it takes two.
- **A genuinely slow scan could now be killed.** Only if it exceeds 30 min while declaring no `TimeoutHintSeconds`. The orchestrator abandons it at 15 min anyway, so nothing that survives today is lost.
- **`ErrImageNeverPull` reuses the "image pull failed" message.** Slightly inaccurate — nothing was pulled — but the string is a load-bearing contract with the api-server classifier, and it is an image-availability failure. Changing the wording would silently reclassify these as generic failures.

## Related issues

Follows #546 (closed by #547), which made the orchestrator stop early on a wedged pod but left deletion to the backend.