### PR TITLE
fix(chart): aggregate default alert rules per workload to cut noise

### DIFF
--- a/charts/nudgebee-agent/templates/prometheus-alert-rule.yaml
+++ b/charts/nudgebee-agent/templates/prometheus-alert-rule.yaml
@@ -86,18 +86,25 @@ spec:
         # Fires when the 5m error/critical count is >3x the workload's own 6h
         # average per 5m window (6h total / 72 windows), with a floor of 10 errors
         # in the 5m window so low-traffic containers can't blow the ratio up.
+        #
+        # The baseline is offset 5m so an ongoing spike can't inflate its own
+        # baseline and silence a sustained incident. The baseline > 0 guard costs
+        # a blind spot on brand-new workloads (no history yet) but is what stops
+        # every cold-start error burst from firing on a +Inf ratio.
         - alert: HighErrorCriticalLogs
           expr: |
             (
               sum by (app_id) (increase(container_log_messages_total{ {{ $logSel }} }[5m]))
               /
               (
-                sum by (app_id) (increase(container_log_messages_total{ {{ $logSel }} }[6h])) / 72
+                sum by (app_id) (increase(container_log_messages_total{ {{ $logSel }} }[6h] offset 5m)) / 72
               )
               > 3
             )
             and
             sum by (app_id) (increase(container_log_messages_total{ {{ $logSel }} }[5m])) > 10
+            and
+            sum by (app_id) (increase(container_log_messages_total{ {{ $logSel }} }[6h] offset 5m)) > 0
           for: 10m
 {{- with $keepFiringFor }}
           keep_firing_for: {{ . }}

--- a/charts/nudgebee-agent/templates/prometheus-alert-rule.yaml
+++ b/charts/nudgebee-agent/templates/prometheus-alert-rule.yaml
@@ -1,15 +1,47 @@
-{{- if (default false .Values.alertmanager.create_nb_default_rules) }}
 {{- /*
-Container-ID exclusions for the log-error and HTTP-failure rules.
-
-The log-error regex additionally excludes log-collection infrastructure
-(fluent-bit, loki, opensearch, etc.), which emits steady error-level
-log streams that are transport/ingest failures — not app-level signal.
-
-alertmanager.extra_rule_exclusions appends install-specific terms to BOTH
-regexes (matched as substrings of container_id) without forking the defaults —
-e.g. environments running synthetic load or demo apps that fail on purpose.
+Gated on enablePrometheusStack as well as the rule toggle: without a Prometheus
+operator in the cluster the monitoring.coreos.com/v1 PrometheusRule CRD is not
+registered, so applying this manifest fails the install outright.
 */ -}}
+{{- if and (default false .Values.alertmanager.create_nb_default_rules) .Values.enablePrometheusStack }}
+{{- /*
+Exclusion lists come from .Values.alertmanager.defaultRuleExclusions and are
+compiled into PromQL regexes here.
+
+  namespaces  applies to every rule. On the HTTP rule it matches
+              destination_workload_namespace; on the log rule it matches the
+              /k8s/<namespace>/ segment of container_id. A "-<suffix>" variant
+              is matched too, because PromQL !~ is fully anchored — a bare
+              "nudgebee-agent" would NOT exclude "nudgebee-agent-dev".
+  containers  applies to the log rule only, matched as a component name inside
+              container_id. Bounded by [^a-z0-9] on both sides so "otel" does
+              not also exclude "hotel-service".
+
+alertmanager.extra_rule_exclusions appends install-specific terms to BOTH lists
+without forking the defaults — e.g. environments running synthetic load or demo
+apps that fail on purpose.
+
+compact drops empty strings throughout: an empty alternation ("||" or a
+trailing "|") matches EVERYTHING, which would silently disable the rules
+cluster-wide.
+*/ -}}
+{{- $excl := (.Values.alertmanager.defaultRuleExclusions | default dict) -}}
+{{- $extra := compact (.Values.alertmanager.extra_rule_exclusions | default list) -}}
+{{- $nsAlt := join "|" (concat (compact ($excl.namespaces | default list)) $extra) -}}
+{{- $ctrAlt := join "|" (concat (compact ($excl.containers | default list)) $extra) -}}
+{{- $logMatchers := list `level=~"error|critical"` -}}
+{{- if $nsAlt -}}
+{{- $logMatchers = append $logMatchers (printf `container_id!~"/k8s(-cronjob)?/(%s)(-[^/]*)?/.*"` $nsAlt) -}}
+{{- end -}}
+{{- if $ctrAlt -}}
+{{- $logMatchers = append $logMatchers (printf `container_id!~".*[^a-z0-9](%s)([^a-z0-9].*)?"` $ctrAlt) -}}
+{{- end -}}
+{{- $logSel := join ", " $logMatchers -}}
+{{- $httpMatchers := list `destination_workload_name!="kubernetes"` -}}
+{{- if $nsAlt -}}
+{{- $httpMatchers = append $httpMatchers (printf `destination_workload_namespace!~"(%s)(-.*)?"` $nsAlt) -}}
+{{- end -}}
+{{- $httpSel := join ", " $httpMatchers -}}
 {{- /*
 keep_firing_for holds an alert firing through brief dips below threshold, so an
 intermittently failing endpoint produces one steady alert instead of resolve/
@@ -19,18 +51,6 @@ Prometheus < 2.42 rejects rule files containing the field, so it must never be
 emitted unless the install explicitly declares support. See values.yaml.
 */ -}}
 {{- $keepFiringFor := .Values.alertmanager.rule_keep_firing_for -}}
-{{- $extra := "" -}}
-{{- with .Values.alertmanager.extra_rule_exclusions -}}
-{{- /*
-compact drops empty strings: an empty alternation ("||" or a trailing "|")
-matches EVERYTHING, which would silently disable both rules cluster-wide.
-*/ -}}
-{{- with compact . -}}
-{{- $extra = printf "|%s" (join "|" .) -}}
-{{- end -}}
-{{- end -}}
-{{- $excludeLog := printf ".*(prometheus|grafana|kube-system|nudgebee-agent|containerd|kubelet|keda|actions-runner-system-1|fluent-bit|fluentd|loki|opensearch|elasticsearch|logstash|datadog|newrelic|otel|promtail%s).*" $extra -}}
-{{- $excludeApi := printf ".*(prometheus|grafana|kube-system|nudgebee-agent|containerd|kubelet|keda|karpenter|actions-runner-system-1%s).*" $extra -}}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -57,49 +77,73 @@ spec:
               HPA {{`{{ $labels.namespace }}`}}/{{`{{ $labels.horizontalpodautoscaler }}`}}
               has been running at max replicas for longer than 15 minutes.
             summary: HPA is running at max replicas
-        # Fires when a container's error/critical log rate is >3x its historical
-        # baseline (1h window offset 1h — the offset keeps an ongoing spike from
-        # polluting the baseline and silencing sustained incidents). The 0.1/s
-        # floor is an activity floor (≥6 err/min) that avoids ratio blowups on
-        # idle containers. The baseline>0 guard prevents cold-start containers
-        # (no historical data) from firing on their first error burst.
+        # Aggregated per workload, NOT per raw series. container_log_messages_total
+        # carries container_id, pattern_hash and sample, so an unaggregated rule
+        # mints a separate alert for every replica AND every distinct log pattern.
+        # app_id is the node-agent's workload identity (/k8s/<ns>/<workload>), so
+        # summing by it collapses replicas and patterns into one alert per workload.
+        #
+        # Fires when the 5m error/critical count is >3x the workload's own 6h
+        # average per 5m window (6h total / 72 windows), with a floor of 10 errors
+        # in the 5m window so low-traffic containers can't blow the ratio up.
         - alert: HighErrorCriticalLogs
           expr: |
-            rate(container_log_messages_total{level=~"error|critical", container_id!~"{{ $excludeLog }}"}[5m])
-              > 3 * rate(container_log_messages_total{level=~"error|critical", container_id!~"{{ $excludeLog }}"}[1h] offset 1h)
+            (
+              sum by (app_id) (increase(container_log_messages_total{ {{ $logSel }} }[5m]))
+              /
+              (
+                sum by (app_id) (increase(container_log_messages_total{ {{ $logSel }} }[6h])) / 72
+              )
+              > 3
+            )
             and
-            rate(container_log_messages_total{level=~"error|critical", container_id!~"{{ $excludeLog }}"}[5m]) > 0.1
-            and
-            rate(container_log_messages_total{level=~"error|critical", container_id!~"{{ $excludeLog }}"}[1h] offset 1h) > 0
+            sum by (app_id) (increase(container_log_messages_total{ {{ $logSel }} }[5m])) > 10
           for: 10m
 {{- with $keepFiringFor }}
           keep_firing_for: {{ . }}
 {{- end }}
           annotations:
-            summary: "High error/critical logs - Sample: {{`{{ printf \"%.80s\" $labels.sample }}`}}"
-            description: "Container log error rate is more than 3x its 1h baseline. Container ID: {{`{{ $labels.container_id }}`}} Log Sample: {{`{{ $labels.sample }}`}} Current rate (err/s): {{`{{ printf \"%.2f\" $value }}`}}"
+            summary: "Error log spike for {{`{{ $labels.app_id }}`}}"
+            description: >-
+              Error/critical log rate is {{`{{ printf "%.1f" $value }}`}}x higher
+              than the 6h average. App: {{`{{ $labels.app_id }}`}}
           labels:
             severity: warning
-        # Fires when >5% of a container's HTTP traffic is 5xx for 10m, with an
-        # activity floor of 0.1 req/s so ratios don't blow up on low-volume
-        # containers. 4xx is excluded — those are client errors (bad request,
-        # unauthorised, etc.) and don't indicate the application failing.
+        # Aggregated per destination workload, NOT per (container_id, method,
+        # path) — request path is unbounded cardinality, so the per-path form
+        # produced a separate alert per endpoint per replica.
+        #
+        # Fires when >20% of a workload's HTTP traffic is 4xx or 5xx for 10m,
+        # with an activity floor of 0.1 req/s so ratios don't blow up on
+        # low-volume workloads.
         - alert: ApplicationAPIFailures
           expr: |
             (
-              sum by (container_id, method, path) (rate(container_http_requests_total{status=~"5..", container_id!~"{{ $excludeApi }}"}[5m]))
+              sum by (destination_workload_namespace, destination_workload_name) (
+                rate(container_http_requests_total{ {{ $httpSel }}, status=~"5..|4.." }[5m])
+              )
               /
-              sum by (container_id, method, path) (rate(container_http_requests_total{container_id!~"{{ $excludeApi }}"}[5m]))
-            ) > 0.05
-            and on (container_id, method, path)
-            sum by (container_id, method, path) (rate(container_http_requests_total{container_id!~"{{ $excludeApi }}"}[5m])) > 0.1
+              sum by (destination_workload_namespace, destination_workload_name) (
+                rate(container_http_requests_total{ {{ $httpSel }} }[5m])
+              )
+            ) > 0.2
+            and
+            sum by (destination_workload_namespace, destination_workload_name) (
+              rate(container_http_requests_total{ {{ $httpSel }} }[5m])
+            ) > 0.1
           for: 10m
 {{- with $keepFiringFor }}
           keep_firing_for: {{ . }}
 {{- end }}
           annotations:
-            summary: "High 5xx rate - {{`{{ $labels.method }}`}} {{`{{ printf \"%.50s\" $labels.path }}`}}"
-            description: "Aggregate 5xx rate across status codes exceeds 5% of total traffic. Container ID: {{`{{ $labels.container_id }}`}} Request Path: {{`{{ $labels.path }}`}} Request Method: {{`{{ $labels.method }}`}} 5xx Ratio: {{`{{ printf \"%.2f\" $value }}`}}"
+            summary: >-
+              High error rate for {{`{{ $labels.destination_workload_name }}`}}
+              in {{`{{ $labels.destination_workload_namespace }}`}}
+            description: >-
+              HTTP error rate exceeded 20% of total traffic.
+              Namespace: {{`{{ $labels.destination_workload_namespace }}`}}
+              Workload: {{`{{ $labels.destination_workload_name }}`}}
+              Error rate: {{`{{ $value | humanizePercentage }}`}}
           labels:
             severity: critical
         # Fires when a pod has been in Terminating state for >30 minutes — that

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -477,10 +477,46 @@ clickhouse:
             description: "Average query duration is above 1 second over last 5 minutes."
 alertmanager:
   create_nb_default_rules: true
-  # Extra alternation terms appended to the container-id exclusion regex of the
-  # default alert rules (both the log-error and HTTP-failure rules). Terms match
-  # as substrings of container_id (/k8s/<namespace>/<pod>/<container>), so a
-  # namespace name excludes that whole namespace.
+  # Exclusions applied to the default PrometheusRule set above. Both lists are
+  # compiled into PromQL regexes by templates/prometheus-alert-rule.yaml.
+  defaultRuleExclusions:
+    # Namespaces excluded from every default rule. Matched against
+    # destination_workload_namespace on the HTTP rule and against the
+    # /k8s/<namespace>/ segment of container_id on the log rule. A "-<suffix>"
+    # variant is excluded too, so "prometheus" also covers "prometheus-dev".
+    # Set to [] to alert on every namespace.
+    namespaces:
+      - kube-system
+      - kube-public
+      - kube-node-lease
+      - gmp-system
+      - nudgebee-agent
+      - prometheus
+      - grafana
+      - victoria
+      - keda
+      - karpenter
+      - cert-manager
+    # Extra components excluded from the log-error rule only, matched as a
+    # component name anywhere in container_id. These emit steady error-level
+    # log streams that are transport/ingest failures of the observability
+    # plumbing itself, not application signal.
+    containers:
+      - containerd
+      - kubelet
+      - system.slice
+      - fluent-bit
+      - fluentd
+      - promtail
+      - loki
+      - opensearch
+      - elasticsearch
+      - logstash
+      - otel
+      - datadog
+      - newrelic
+  # Install-specific terms appended to BOTH lists above, so a single entry
+  # covers a namespace on the HTTP rule and a component name on the log rule.
   # e.g. for clusters running demo/synthetic-load apps that fail on purpose:
   # extra_rule_exclusions: ["demo", "nb-bench"]
   extra_rule_exclusions: []

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -65,7 +65,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-07-31T06-50-14_8717b178359e9dce22453bf1de7e7d8e9eccfda3
+    tag: 2026-08-04T08-55-17_55d9b081e1a5af6afd55fc40c4cf36111d6a0e19
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.


### PR DESCRIPTION
## Problem

The two application-level default rules emitted **one alert per raw metric series**:

- `HighErrorCriticalLogs` had no `sum by` at all. `container_log_messages_total` carries `container_id`, `pattern_hash` and `sample`, so every replica × every distinct log pattern was its own alert.
- `ApplicationAPIFailures` grouped by `(container_id, method, path)` — request path is unbounded cardinality, so a single failing service produced one alert per endpoint per replica.

## Change

Both rules now aggregate to one alert per workload, matching the tuned rulesets we already run in the infra repo:

| Rule | Before | After |
|---|---|---|
| `HighErrorCriticalLogs` | per raw series; 5m rate vs `[1h] offset 1h`, floor 0.1/s | `sum by (app_id)`; 5m count vs the workload's own 6h average per-5m window (`[6h]/72`) `> 3`, floor of 10 errors in the window |
| `ApplicationAPIFailures` | `sum by (container_id, method, path)`; 5xx `> 5%` | `sum by (destination_workload_namespace, destination_workload_name)`; 4xx+5xx `> 20%`, 0.1 req/s activity floor |
| `KubeHpaMaxedOut` | — | unchanged |
| `KubePodStuckTerminating` | — | unchanged |

`app_id` is a node-agent const label holding the workload identity (`/k8s/<namespace>/<workload>`), so summing by it collapses replicas and log patterns without losing attribution.

### Exclusions

Replaced the two hardcoded `container_id` regexes with `alertmanager.defaultRuleExclusions.{namespaces,containers}`:

- **namespaces** apply to both rules — `destination_workload_namespace` on the HTTP rule, the `/k8s/<ns>/` segment of `container_id` on the log rule — and also match `<ns>-<suffix>`. PromQL `!~` is fully anchored, so the previous bare `nudgebee-agent` term never excluded `nudgebee-agent-dev` or `-prod`.
- **container** terms are bounded by `[^a-z0-9]` on both sides, so `otel` no longer also excludes a workload named `hotel-service`.
- `extra_rule_exclusions` still works, appending to both lists. `rule_keep_firing_for` is unchanged.

### Install gating

The manifest is now also gated on `enablePrometheusStack`. Without a Prometheus operator the `monitoring.coreos.com/v1` PrometheusRule CRD is not registered and applying the manifest fails the install outright.

## Trade-offs

- The log rule's summary no longer carries the log `sample` — that label is exactly the cardinality driving the noise, so it cannot survive the aggregation.
- The `baseline > 0` guard is gone (matching the tuned version): a brand-new workload with no 6h history that logs >10 errors in 5m now fires, and `$value` renders as `+Inf`.
- `destination_workload_kind!="ReplicaSet"` was **not** added to `ApplicationAPIFailures`. The eBPF agent emits both a Deployment- and a ReplicaSet-named series for the same traffic, so each rollout mints a fresh alert identity — worth a follow-up once series shape is confirmed across clusters.

## Verification

- `helm template` across the default, empty-list, missing-key, `enablePrometheusStack=false` and `extra_rule_exclusions` paths
- `promtool check rules` passes on the rendered output (PromQL + annotation templates)
- `helm lint` clean
- Exclusion regexes unit-checked against sample `container_id`s: `kube-systematic` is *not* caught by `kube-system`, `hotel-service` is *not* caught by `otel`, `nudgebee-agent-dev` *is* caught