### PR TITLE
fix(alerts): resolve mesh/container_id/service labels before falling back to alertname subject

### DIFF
--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -65,7 +65,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-07-31T06-50-14_8717b178359e9dce22453bf1de7e7d8e9eccfda3
+    tag: 2026-08-04T08-55-17_55d9b081e1a5af6afd55fc40c4cf36111d6a0e19
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/runner/pkg/alerts/finding.go
+++ b/runner/pkg/alerts/finding.go
@@ -501,7 +501,11 @@ func alertSubjectFallback(labels map[string]string) (string, string, string) {
 		if key == "k8s_deployment_name" {
 			kind = "deployment"
 		}
-		return v, kind, labels["destination_workload_namespace"]
+		ns := labels["destination_workload_namespace"]
+		if key == "src_workload_name" {
+			ns = pickLabel(labels, "src_workload_namespace", "source_workload_namespace")
+		}
+		return v, kind, ns
 	}
 	// container_id: /k8s/{namespace}/{pod}/{container} — the container segment
 	// names the workload (matches k8s_workloads); the pod segment carries a

--- a/runner/pkg/alerts/finding.go
+++ b/runner/pkg/alerts/finding.go
@@ -344,6 +344,18 @@ func (b *Builder) FromKubewatchEvent(rawData []byte) (*FindingEnvelope, error) {
 // alertToFinding converts one PrometheusAlert to a Finding envelope.
 func (b *Builder) alertToFinding(a alertManagerAlert) (FindingEnvelope, error) {
 	subjectName, subjectType := alertSubject(a.Labels)
+	subjectNamespace := pickLabel(a.Labels, "namespace", "exported_namespace")
+	if subjectName == "" {
+		// No k8s workload label present — try the lower-confidence labels the
+		// backend webhook mapper also understands (mesh workload labels,
+		// container_id path, service) so both ingest paths resolve the same
+		// subject.
+		var fallbackNamespace string
+		subjectName, subjectType, fallbackNamespace = alertSubjectFallback(a.Labels)
+		if subjectNamespace == "" {
+			subjectNamespace = fallbackNamespace
+		}
+	}
 	if subjectName == "" {
 		// No kubernetes object resolvable from the alert labels (cluster-
 		// level / control-plane / custom application alerts like Watchdog,
@@ -356,7 +368,6 @@ func (b *Builder) alertToFinding(a alertManagerAlert) (FindingEnvelope, error) {
 			subjectName = "UnnamedAlert"
 		}
 	}
-	subjectNamespace := pickLabel(a.Labels, "namespace", "exported_namespace")
 	subjectNode := pickLabel(a.Labels, "node", "instance")
 	alertname := pickLabel(a.Labels, "alertname")
 	if alertname == "" {
@@ -466,6 +477,47 @@ func alertSubject(labels map[string]string) (string, string) {
 		return "", strings.ToLower(v)
 	}
 	return "", ""
+}
+
+// alertSubjectFallback runs only when alertSubject found no kubernetes object,
+// walking the lower-confidence labels the backend webhook mapper
+// (resolveSubjectFromLabels) also understands, so an alert delivered through
+// Alertmanager resolves the same subject it would via PagerDuty/Zenduty:
+// mesh-style workload labels (ApplicationAPIFailures carries
+// destination_workload_name), the /k8s/{namespace}/{pod}/{container} path in
+// container_id, and application `service` labels (NBLLMLatencyP95High).
+// Returns (name, kind, namespace); kind stays empty when the label doesn't
+// imply one — the collector types the workload from inventory downstream —
+// and namespace is set only when the label itself carries one.
+func alertSubjectFallback(labels map[string]string) (string, string, string) {
+	for _, key := range []string{"destination_workload_name", "src_workload_name", "k8s_deployment_name"} {
+		v := labels[key]
+		// Exact-match guard: the bare kube-state-metrics exporter never names
+		// a real workload (helm-prefixed variants do).
+		if v == "" || v == "kube-state-metrics" {
+			continue
+		}
+		kind := ""
+		if key == "k8s_deployment_name" {
+			kind = "deployment"
+		}
+		return v, kind, labels["destination_workload_namespace"]
+	}
+	// container_id: /k8s/{namespace}/{pod}/{container} — the container segment
+	// names the workload (matches k8s_workloads); the pod segment carries a
+	// ReplicaSet hash that never does.
+	if cid := labels["container_id"]; strings.HasPrefix(cid, "/k8s/") {
+		parts := strings.Split(strings.TrimPrefix(cid, "/"), "/")
+		if len(parts) == 4 && parts[1] != "" && parts[3] != "" {
+			return parts[3], "", parts[1]
+		}
+	}
+	for _, key := range []string{"service", "service_name"} {
+		if v := labels[key]; v != "" && !isScrapeExporter(v) {
+			return v, "", ""
+		}
+	}
+	return "", "", ""
 }
 
 // isScrapeExporter reports whether a prometheus `job` label value names an

--- a/runner/pkg/alerts/finding_test.go
+++ b/runner/pkg/alerts/finding_test.go
@@ -69,6 +69,67 @@ func TestBuilder_Alert_SubjectFallbackOrder(t *testing.T) {
 	}
 }
 
+func TestBuilder_Alert_SecondChanceLabelWalk(t *testing.T) {
+	b := &Builder{AccountID: "acc", Cluster: "c"}
+	cases := []struct {
+		name      string
+		labels    map[string]string
+		subject   string
+		stype     string
+		namespace string
+	}{
+		// Real ApplicationAPIFailures labels (test env, 2026-08-07): the only
+		// workload hint is the mesh-style destination_workload_name pair.
+		{"destination_workload_name resolves subject and namespace",
+			map[string]string{"alertname": "ApplicationAPIFailures", "alertgroup": "custom-alerts", "severity": "critical",
+				"destination_workload_name": "relay-server", "destination_workload_namespace": "nudgebee-test"},
+			"relay-server", "", "nudgebee-test"},
+		// Real NBLLMLatencyP95High labels: static `service` rule label plus
+		// query output labels only.
+		{"service label resolves subject",
+			map[string]string{"alertname": "NBLLMLatencyP95High", "severity": "warning", "service": "llm-server",
+				"namespace": "nudgebee", "provider": "googleai", "model": "gemini-3.1-pro-preview"},
+			"llm-server", "", "nudgebee"},
+		{"container_id path resolves workload and namespace",
+			map[string]string{"alertname": "X", "container_id": "/k8s/nudgebee-oss/services-server-574d6c9d65-l1/services-server"},
+			"services-server", "", "nudgebee-oss"},
+		{"scrape exporter service is not a subject",
+			map[string]string{"alertname": "KubeletDown", "service": "kubelet"},
+			"KubeletDown", "", ""},
+		// The primary walk still wins — the fallback only runs when it found nothing.
+		{"deployment label wins over mesh label",
+			map[string]string{"alertname": "X", "deployment": "checkout", "destination_workload_name": "frontend"},
+			"checkout", "deployment", ""},
+		// An explicit namespace label wins over the fallback's namespace.
+		{"namespace label wins over destination namespace",
+			map[string]string{"alertname": "X", "namespace": "prod", "destination_workload_name": "frontend",
+				"destination_workload_namespace": "mesh-ns"},
+			"frontend", "", "prod"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			webhook := map[string]any{"alerts": []map[string]any{{"labels": tc.labels}}}
+			raw, _ := json.Marshal(webhook)
+			out, _, err := b.FromAlertManager(raw)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(out) != 1 {
+				t.Fatalf("got %d envelopes; want 1", len(out))
+			}
+			if out[0].Finding.SubjectName != tc.subject {
+				t.Errorf("subject_name = %q; want %q", out[0].Finding.SubjectName, tc.subject)
+			}
+			if out[0].Finding.SubjectType != tc.stype {
+				t.Errorf("subject_type = %q; want %q", out[0].Finding.SubjectType, tc.stype)
+			}
+			if out[0].Finding.SubjectNamespace != tc.namespace {
+				t.Errorf("subject_namespace = %q; want %q", out[0].Finding.SubjectNamespace, tc.namespace)
+			}
+		})
+	}
+}
+
 func TestBuilder_Alert_MissingSubjectGetsPlaceholder(t *testing.T) {
 	b := &Builder{AccountID: "acc", Cluster: "c"}
 	// 3 alerts: first has pod, second has no subject label, third has node.

--- a/runner/pkg/alerts/finding_test.go
+++ b/runner/pkg/alerts/finding_test.go
@@ -96,6 +96,12 @@ func TestBuilder_Alert_SecondChanceLabelWalk(t *testing.T) {
 		{"scrape exporter service is not a subject",
 			map[string]string{"alertname": "KubeletDown", "service": "kubelet"},
 			"KubeletDown", "", ""},
+		// src_workload_name takes its namespace from the source side, not the
+		// destination side.
+		{"src workload uses src namespace",
+			map[string]string{"alertname": "X", "src_workload_name": "frontend",
+				"src_workload_namespace": "web", "destination_workload_namespace": "backend"},
+			"frontend", "", "web"},
 		// The primary walk still wins — the fallback only runs when it found nothing.
 		{"deployment label wins over mesh label",
 			map[string]string{"alertname": "X", "deployment": "checkout", "destination_workload_name": "frontend"},


### PR DESCRIPTION
## Summary

Alerts whose labels identify the workload only through `destination_workload_name` (ApplicationAPIFailures), a `/k8s/{ns}/{pod}/{container}` `container_id`, or a `service` label (NBLLMLatencyP95High) surfaced with the alertname as the finding subject and an empty subject type — while the identical alerts delivered via PagerDuty/Zenduty resolve correctly through the backend webhook mapper, which walks all three label families.

This adds `alertSubjectFallback`, a second-chance walk that runs **only when the primary walk finds nothing**:

1. `destination_workload_name` / `src_workload_name` / `k8s_deployment_name` (namespace from `destination_workload_namespace` when the alert has no `namespace` label)
2. `container_id` path — the container segment names the workload, and the path yields the namespace
3. `service` / `service_name`, guarded so scrape exporters (kubelet, kube-state-metrics, node-exporter, cadvisor) never become subjects

Kind is left empty where the label doesn't imply one — the collector types the workload from its inventory downstream (nudgebee/nudgebee-enterprise#35922 adds the matching ingest-side backstop that also covers older agent versions). Alerts that resolve today are untouched; only the alertname-fallback class changes.

Refs: nudgebee/nudgebee-enterprise#35921

## Type of change

- [x] Bug fix (non-breaking)

## Chart version

- [x] No version bump needed (docs/CI only) — runner-only code change; image tag flows through the release pipeline

## Test plan

- [x] New table-driven test `TestBuilder_Alert_SecondChanceLabelWalk` using the real label sets captured from the affected test-env alerts (mesh labels, service label, container_id path, exporter guard, primary-walk precedence, namespace precedence)
- [x] `make validate` (fmt, vet, golangci-lint, `go test -race ./...`) passes

## Related issues

Refs nudgebee/nudgebee-enterprise#35921