### PR TITLE
chore(chart): bump nudgebee-agent chart to 0.1.18, align appVersion

### DIFF
--- a/charts/nudgebee-agent/Chart.yaml
+++ b/charts/nudgebee-agent/Chart.yaml
@@ -29,8 +29,8 @@ annotations:
 # these are set to the right value by .github/workflows/release.yaml
 # we use 0.0.1 as a placeholder for the version` because Helm wont allow `0.0.0` and we want to be able to run
 # `helm install` on development checkouts without updating this file. the version doesn't matter in that case anyway
-version: 0.1.17
-appVersion: 0.1.11
+version: 0.1.18
+appVersion: 0.1.18
 dependencies:
 - name: opencost
   version: 2.0.1

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -65,7 +65,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-08-04T08-55-17_55d9b081e1a5af6afd55fc40c4cf36111d6a0e19
+    tag: 2026-08-09T09-21-23_f8690dd164afa4865adce478b3515bdabbc7a6d8
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.


### PR DESCRIPTION
Bumps the chart version to 0.1.18 ahead of the next release (0.1.17 is already published, so `release-rc.yml`/`release.yml` need the new version to mint `0.1.18-rc-*` and the final release).

Also sets `appVersion` to match the chart version — it was stuck at 0.1.11 and no workflow reads it, so keeping it aligned is cosmetic but less confusing.

Release contents since 0.1.17 include the per-workload default alert-rule aggregation (#565), configurable alert-rule exclusions / `keep_firing_for` (#553), alert subject label resolution (#566), scan Job ActiveDeadlineSeconds bound (#555), and assorted dependency/security bumps.