### PR TITLE
chore(chart): bump node-agent image to 0.1.5

### DIFF
--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -273,7 +273,7 @@ nodeAgent:
   image:
     repository: ghcr.io/nudgebee/node-agent
     pullPolicy: IfNotPresent
-    tag: 0.1.4
+    tag: 0.1.5
   resources:
     requests:
       cpu: "100m"


### PR DESCRIPTION
Picks up node-agent v0.1.5 for the 0.1.18 chart release:

- fix(metrics): resolve pods to their Deployment, not their ReplicaSet
- fix(metrics): bound the owner-chain climb against circular ownerReferences
- Go toolchain 1.26.5 + dependency bumps

The update-image-tags bot will confirm/normalize the tag on this PR. Once merged, `0.1.18-rc-2` will be cut to replace rc-1 (which still pins node-agent 0.1.4).