### PR TITLE
fix(chart): PodMonitor selector labels + derive runner GOMEMLIMIT

### DIFF
--- a/charts/nudgebee-agent/Chart.yaml
+++ b/charts/nudgebee-agent/Chart.yaml
@@ -29,8 +29,8 @@ annotations:
 # these are set to the right value by .github/workflows/release.yaml
 # we use 0.0.1 as a placeholder for the version` because Helm wont allow `0.0.0` and we want to be able to run
 # `helm install` on development checkouts without updating this file. the version doesn't matter in that case anyway
-version: 0.1.18
-appVersion: 0.1.18
+version: 0.1.19
+appVersion: 0.1.19
 dependencies:
 - name: opencost
   version: 2.0.1

--- a/charts/nudgebee-agent/templates/_helpers.tpl
+++ b/charts/nudgebee-agent/templates/_helpers.tpl
@@ -61,6 +61,46 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+GOMEMLIMIT (in bytes) for the runner, derived from its container memory limit.
+
+The runner is a Go process and the Go runtime is cgroup-unaware: without
+GOMEMLIMIT the GC paces off GOGC alone, so a transient allocation burst can run
+the heap past the container limit and get the pod OOM-killed while the live heap
+is still small. GOMEMLIMIT is a soft limit — as the heap approaches it the GC
+runs progressively harder, trading CPU to stay under the cgroup ceiling.
+
+Derived rather than hardcoded so it cannot drift from resources.limits.memory:
+raising the limit raises the headroom automatically. Emits nothing when no
+memory limit is set (unbounded cgroup — a soft limit would be arbitrary).
+
+Ratio is runner.goMemLimitRatio (default 0.8); the remaining 20% covers non-heap
+RSS (goroutine stacks, runtime metadata, mmap'd binary). Set runner.goMemLimit to
+override with an explicit value and skip the derivation entirely.
+*/}}
+{{- define "nudgebee-agent.goMemLimit" -}}
+{{- if .Values.runner.goMemLimit -}}
+{{- .Values.runner.goMemLimit -}}
+{{- else -}}
+{{- $lim := (dig "resources" "limits" "memory" "" .Values.runner) | toString -}}
+{{- $num := regexFind "^[0-9.]+" $lim -}}
+{{- if $num -}}
+{{- $mult := 1.0 -}}
+{{- if hasSuffix "Ki" $lim -}}{{- $mult = 1024.0 -}}
+{{- else if hasSuffix "Mi" $lim -}}{{- $mult = 1048576.0 -}}
+{{- else if hasSuffix "Gi" $lim -}}{{- $mult = 1073741824.0 -}}
+{{- else if hasSuffix "Ti" $lim -}}{{- $mult = 1099511627776.0 -}}
+{{- else if hasSuffix "k" $lim -}}{{- $mult = 1000.0 -}}
+{{- else if hasSuffix "M" $lim -}}{{- $mult = 1000000.0 -}}
+{{- else if hasSuffix "G" $lim -}}{{- $mult = 1000000000.0 -}}
+{{- else if hasSuffix "T" $lim -}}{{- $mult = 1000000000000.0 -}}
+{{- end -}}
+{{- $ratio := .Values.runner.goMemLimitRatio | default 0.8 -}}
+{{- printf "%d" (int64 (mulf (float64 $num) $mult $ratio)) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Runner container template. Invoked with root context: include "nudgebee.runner.container" .
 */}}
 {{- define "nudgebee.runner.container" -}}
@@ -79,6 +119,10 @@ Runner container template. Invoked with root context: include "nudgebee.runner.c
           fieldPath: metadata.namespace
     - name: RUNNER_VERSION
       value: {{ .Chart.AppVersion }}
+    {{- with include "nudgebee-agent.goMemLimit" . }}
+    - name: GOMEMLIMIT
+      value: {{ . | quote }}
+    {{- end }}
     - name: WEBSOCKET_RELAY_ADDRESS
       value: {{ .Values.runner.relay_address }}
     - name: SCANNERS_ENABLED

--- a/charts/nudgebee-agent/templates/pod_monitor.yaml
+++ b/charts/nudgebee-agent/templates/pod_monitor.yaml
@@ -10,11 +10,18 @@ metadata:
   labels:
     {{- include "nudgebee-agent.labels" . | nindent 4 }}
     component: node-agent
+    {{- with .Values.nodeAgent.podmonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:
       {{- include "node-agent.selectorLabels" . | nindent 6 }}
       app: nudgebee-node-agent
+  {{- with .Values.nodeAgent.podmonitor.namespaceSelector }}
+  namespaceSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   podMetricsEndpoints:
     - port: http
 {{- end -}}

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -65,7 +65,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-08-12T06-01-54_7ec58f7701909a3ce172ad2a9235f8b15255e363
+    tag: 2026-08-12T08-30-26_13e26b9dce6e3419f5e1ac52836c773a95098fde
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -88,6 +88,21 @@ runner:
       #   ~500 nodes / ~50k workloads   : 4000Mi
       #   ~1000 nodes / ~100k workloads : 6000Mi+  (and enable runner.scaling below)
       memory: 2000Mi
+  # GOMEMLIMIT is derived from resources.limits.memory above and injected into
+  # the runner container, so the Go GC knows about the cgroup ceiling instead of
+  # discovering it via SIGKILL. Without it a transient allocation burst (large
+  # Prometheus/Loki/ClickHouse responses are read whole before being decoded) can
+  # outrun the collector and OOM the pod while the live heap is still small —
+  # which is why OOMKills show up even on tiny clusters where the sizing table
+  # above says there is plenty of headroom.
+  #
+  # goMemLimitRatio is the fraction of the memory limit handed to the Go heap;
+  # the remainder covers non-heap RSS. Lower it if the pod still OOMs, raise it
+  # to trade OOM-safety margin for less GC CPU.
+  goMemLimitRatio: 0.8
+  # Explicit GOMEMLIMIT override; skips the derivation when non-empty. Accepts
+  # the Go form (e.g. "1600MiB" or a plain byte count). Leave empty to derive.
+  goMemLimit: ""
   # Liveness/readiness probes hit the always-on /healthz endpoint on :5000 so a
   # hung or restarting runner is detected and kept out of the Service.
   probes:

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -265,6 +265,15 @@ nodeAgent:
   podmonitor:
     enabled: true
     azuremanaged: false
+    # Extra labels merged into the PodMonitor metadata. Set these to match the
+    # Prometheus CR's podMonitorSelector, otherwise the operator ignores the
+    # PodMonitor and no scrape target is created.
+    # e.g. { pod-monitor: pod-monitor }
+    additionalLabels: {}
+    # Restrict which namespaces Prometheus looks in for matching pods.
+    # Empty means the operator default (the PodMonitor's own namespace).
+    # e.g. { matchNames: [ nudgebee ] } or { any: true }
+    namespaceSelector: {}
   service:
     enabled: false
     annotations: {}


### PR DESCRIPTION
Two independent chart fixes, both surfaced by the same deployment.

## 1. PodMonitor could not carry operator selector labels

The `nudgebee-agent-node-agent` pod was not being scraped. The rendered `PodMonitor` had no way to carry extra labels, so on any cluster whose Prometheus CR sets a non-empty `podMonitorSelector`:

```yaml
podMonitorSelector:
  matchLabels:
    pod-monitor: pod-monitor
```

the Prometheus Operator silently ignored it — no scrape target, no error anywhere.

- `templates/pod_monitor.yaml`: `nodeAgent.podmonitor.additionalLabels` merges into `metadata.labels`; `nodeAgent.podmonitor.namespaceSelector` is emitted into the spec when non-empty
- `values.yaml`: both keys added, defaulting to `{}`

Defaults stay empty rather than hardcoded: the selector label is per-cluster, so baking one in would ship a meaningless label everywhere and still not help clusters matching on something else. Affected clusters set it in their override:

```yaml
nodeAgent:
  podmonitor:
    additionalLabels:
      pod-monitor: pod-monitor
```

## 2. Runner OOMKilled well below its sizing headroom

A 6-node cluster was OOMKilling the runner at the default 2000Mi limit. The sizing table in `values.yaml` prices in informer-cache growth, which is steady-state and scales with object count — at 6 nodes that is negligible, so this is not a sizing shortfall and raising the limit is a bet rather than a fix.

The runner is a Go process and the Go runtime is cgroup-unaware. With no `GOMEMLIMIT` the GC paces off `GOGC` alone against a small live heap, so an allocation burst outruns the collector and the kernel kills the pod mid-burst. `cmd/agent/main.go:850` already documents the symptom:

> the runner exhibits transient heap bursts (live heap stays small, heap_sys spikes to >1.5GB then releases)

The bursts come from response bodies being read whole and then decoded — every `observability/*` client plus `clickhouse/client.go:130` does a bare `io.ReadAll(resp.Body)` followed by an unmarshal, so two full copies of a backend response are live at once. That size tracks the metrics backend's response, not the cluster's object count, which is exactly why a tiny cluster can OOM.

`GOMEMLIMIT` is the matching knob: a soft limit that makes the GC work progressively harder as the heap nears the ceiling, trading CPU to stay under it.

- `_helpers.tpl`: new `nudgebee-agent.goMemLimit` helper derives the value from `runner.resources.limits.memory` and injects `GOMEMLIMIT` into the runner container
- `values.yaml`: `runner.goMemLimitRatio` (default `0.8`) and `runner.goMemLimit` (explicit override)

Derived rather than hardcoded so the two cannot drift — raising the memory limit raises the GC ceiling with it, including for anyone who has already bumped it in response to these OOMs. Nothing is emitted when no memory limit is set, since a soft limit against an unbounded cgroup would be arbitrary.

Verified via `helm template`:

| `limits.memory` | `GOMEMLIMIT` |
|---|---|
| `2000Mi` (default) | `1677721600` (1600 MiB) |
| `4000Mi` | `3355443200` (3200 MiB) |
| `1.5Gi` | `1288490188` |
| `2G` (decimal suffix) | `1600000000` |
| `2000Mi`, ratio `0.7` | `1468006400` (1400 MiB) |
| explicit `goMemLimit: 1600MiB` | `1600MiB` (passthrough) |
| limit unset | env var omitted |

This is a runtime env var, so it takes effect on the currently pinned image with no rebuild.

## Chart version

0.1.18 → 0.1.19 (version + appVersion).

## Not included

Capping the uncapped `io.ReadAll` calls with `io.LimitReader` is the structural fix for the bursts themselves — it touches ~10 client files and needs a decision on the cap and on whether exceeding it is a hard error or a truncation, so it is left for a follow-up. `GOMEMLIMIT` bounds the damage in the meantime by making the GC fight back instead of the kernel.

## Verification

- `helm template` with defaults renders the PodMonitor byte-identical to before — no change for existing installs
- `helm template` with both PodMonitor overrides renders the label and the `namespaceSelector`
- `GOMEMLIMIT` derivation verified across the suffix/ratio/override/unset cases above
- `helm lint` passes