### PR TITLE
fix(discovery): send the pod status subresource so real container state reaches the product

### DIFF
--- a/runner/pkg/discovery/converters_test.go
+++ b/runner/pkg/discovery/converters_test.go
@@ -1,6 +1,7 @@
 package discovery
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -588,5 +589,71 @@ func TestContainersFromTemplate_OmitsResourcesWhenUnset(t *testing.T) {
 	got := containersFromTemplate(tpl)
 	if _, present := got[0]["resources"]; present {
 		t.Errorf("resources should be absent when unset; got %v", got[0]["resources"])
+	}
+}
+
+// TestPodConverter_StatusDictCarriesContainerState pins the field the collector
+// stores as meta.status_info. While it was nil, a pod stuck in CrashLoopBackOff
+// reached the product as "Running" — that is the pod's PHASE, and the waiting
+// reason kubectl prints lives in ContainerStatuses. The readers coded against
+// status_info (pod-detail panels, knowledge-graph host_ip, cost-server's cluster
+// cache) all depend on this being populated, in the Kubernetes API's own
+// camelCase shape.
+func TestPodConverter_StatusDictCarriesContainerState(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "crashloop-demo-547d44bfc8-pnplr", Namespace: "crashloop-lab"},
+		Status: corev1.PodStatus{
+			Phase:    corev1.PodRunning,
+			HostIP:   "10.0.0.7",
+			QOSClass: corev1.PodQOSBurstable,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:         "boom",
+				Ready:        false,
+				RestartCount: 17,
+				State: corev1.ContainerState{
+					Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"},
+				},
+			}},
+		},
+	}
+
+	got, ok := newPodConverter(func(string, string) *appsv1.ReplicaSet { return nil })(pod)
+	if !ok {
+		t.Fatal("converter ok=false")
+	}
+	dict := got.(map[string]any)
+
+	// The scalar status stays the phase: existing consumers filter on it
+	// (recommendation's spot-eligibility query keys off status = 'Running').
+	if dict["status"] != "Running" {
+		t.Fatalf("status = %v; want the phase, unchanged", dict["status"])
+	}
+
+	status, isPodStatus := dict["status_dict"].(corev1.PodStatus)
+	if !isPodStatus {
+		t.Fatalf("status_dict = %T; want corev1.PodStatus", dict["status_dict"])
+	}
+	if len(status.ContainerStatuses) != 1 {
+		t.Fatalf("container statuses = %d; want 1", len(status.ContainerStatuses))
+	}
+	if got := status.ContainerStatuses[0].State.Waiting.Reason; got != "CrashLoopBackOff" {
+		t.Fatalf("waiting reason = %q; want CrashLoopBackOff — the state phase cannot express", got)
+	}
+
+	// Marshalling must produce the camelCase keys the existing readers index
+	// into: meta -> 'status_info' ->> 'hostIP' in the knowledge graph, and
+	// status_info.containerStatuses / qosClass in the pod-detail panels.
+	raw, err := json.Marshal(status)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var wire map[string]any
+	if err := json.Unmarshal(raw, &wire); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, key := range []string{"containerStatuses", "hostIP", "qosClass"} {
+		if _, present := wire[key]; !present {
+			t.Errorf("wire shape missing %q; readers index this key directly", key)
+		}
 	}
 }

--- a/runner/pkg/discovery/service.go
+++ b/runner/pkg/discovery/service.go
@@ -814,7 +814,23 @@ func newPodConverter(rsLookup replicaSetLookupFn) func(any) (any, bool) {
 			"node_name":        p.Spec.NodeName,
 			"status":           string(p.Status.Phase),
 			"restart_count":    podRestartCounts(p),
-			"status_dict":      nil,
+			// The pod's status subresource, verbatim. `status` above is only the
+			// PHASE, which is "Running" for a pod stuck in CrashLoopBackOff — the
+			// waiting reason that kubectl prints lives in ContainerStatuses and
+			// never left the agent while this was nil, so the collector stored
+			// meta.status_info = null and every reader coded against it went dark:
+			// the pod-detail panels (conditions, container statuses, IPs, QoS),
+			// the knowledge graph's host_ip, and cost-server's cluster cache.
+			//
+			// Sent whole rather than trimmed. Marshalling corev1.PodStatus yields
+			// the Kubernetes API's own camelCase shape (containerStatuses, hostIP,
+			// podIPs, qosClass), which is what those readers already expect.
+			// Dropping imageID/containerID/image saves only 19% of it (measured on
+			// a 419-pod cluster: 958 KiB -> 781 KiB) and would leave a shape that
+			// looks like PodStatus but silently isn't. Cost as sent: ~2.3 KiB/pod
+			// raw, ~200 B/pod after the sink's gzip, so ~0.8 MiB per snapshot on a
+			// 4000-pod cluster against a 100 MiB message threshold.
+			"status_dict": p.Status,
 			"config": map[string]any{
 				"labels":     nonNilLabels(p.Labels),
 				"containers": containers,

--- a/runner/pkg/discovery/transform.go
+++ b/runner/pkg/discovery/transform.go
@@ -24,11 +24,18 @@ func discoveryTransform(obj any) (any, error) {
 	switch o := obj.(type) {
 	case *corev1.Pod:
 		trimMeta(&o.ObjectMeta)
-		// Pod converter reads: Status.{Phase,QOSClass,PodIP,Conditions,
-		// ContainerStatuses[].{Name,Ready,RestartCount}}, Spec.NodeName,
+		// Pod converter reads: the WHOLE of Status (it ships as status_dict, which
+		// the collector stores as meta.status_info), plus Spec.NodeName,
 		// Spec.Containers[].{Name,Image}, OwnerReferences, Labels.
-		o.Status.InitContainerStatuses = nil
-		o.Status.EphemeralContainerStatuses = nil
+		//
+		// Status.InitContainerStatuses and Status.EphemeralContainerStatuses used to
+		// be stripped here, back when the converter only read a handful of Status
+		// fields. They are readers now -- the pod-detail panel indexes
+		// status_info.initContainerStatuses -- so stripping them would violate this
+		// function's contract of only deleting what nobody reads. Measured on a
+		// 420-pod cluster, keeping them costs 129 KiB (108 pods) and 1 KiB (1 pod)
+		// in the informer store, against 458 KiB for the container statuses already
+		// retained.
 		o.Spec.InitContainers = nil
 		o.Spec.EphemeralContainers = nil
 		o.Spec.Volumes = nil     // pod converter emits no volumes (only templates do)

--- a/runner/pkg/discovery/transform_test.go
+++ b/runner/pkg/discovery/transform_test.go
@@ -153,8 +153,15 @@ func TestDiscoveryTransform_StripsHeavyFields(t *testing.T) {
 	if pod.Spec.Containers[0].Env != nil || pod.Spec.Containers[0].LivenessProbe != nil {
 		t.Error("container Env/LivenessProbe not stripped")
 	}
-	if pod.Spec.Volumes != nil || pod.Status.InitContainerStatuses != nil {
-		t.Error("pod Volumes / InitContainerStatuses not stripped")
+	if pod.Spec.Volumes != nil {
+		t.Error("pod Volumes not stripped")
+	}
+	// Status.InitContainerStatuses is deliberately NOT stripped any more: the pod
+	// converter ships the whole Status as status_dict, and the pod-detail panel
+	// reads status_info.initContainerStatuses out of it. Stripping it here would
+	// silently blank that panel.
+	if pod.Status.InitContainerStatuses == nil {
+		t.Error("InitContainerStatuses must survive the transform — the converter ships them")
 	}
 }
 


### PR DESCRIPTION
## Description

The pod converter set `status_dict` to nil, so the collector stored `meta.status_info = null` and everything coded against it went dark. The only pod state that reached the product was `status` — the **phase** — and a pod stuck in CrashLoopBackOff has phase `Running`. Measured on a dev cluster, 402 active pods carried exactly two distinct phases (`Running`, `Pending`), so a crashlooping pod and a healthy one are indistinguishable downstream. The reason `kubectl` prints lives in `Status.ContainerStatuses` and never left the agent.

The readers already exist and already expect this field — the pod-detail panel (container statuses, init container statuses, conditions, pod IPs, QoS class), the knowledge graph's `host_ip` synthesis, and cost-server's cluster cache. No collector, schema or API change is needed on the backend side for them; only this.

Sent whole rather than trimmed: marshalling `corev1.PodStatus` produces the Kubernetes API's own camelCase shape (`containerStatuses`, `hostIP`, `podIPs`, `qosClass`) that those readers index by name. Dropping `imageID`/`containerID`/`image` saves only 19% (958 KiB → 781 KiB across 419 pods) and would leave a shape that looks like `PodStatus` but silently isn't.

**Cost as sent:** ~2.3 KiB/pod raw, ~200 B/pod after the sink's gzip — about 0.8 MiB per snapshot on a 4000-pod cluster, against a 100 MiB message threshold.

The informer transform stripped `Status.InitContainerStatuses` and `Status.EphemeralContainerStatuses` on the documented premise that it only ever deletes fields no converter reads. The converter reads all of `Status` now, so the strips are removed — the pod-detail panel indexes `status_info.initContainerStatuses` directly. Keeping them costs 129 KiB (108 pods) and 1 KiB (1 pod) in the informer store, against 458 KiB of container statuses already retained.

Pairs with nudgebee-enterprise#36582, which renders it. Fixes nudgebee-enterprise#36581.

## Testing

- `make test` — all 37 packages pass.
- New `TestPodConverter_StatusDictCarriesContainerState` pins the field, asserts `status` still carries the phase unchanged (the recommendation service's spot-eligibility query filters on `status = 'Running'`), and asserts the marshalled wire shape contains `containerStatuses` / `hostIP` / `qosClass` — the keys existing readers index by name.
- The transform's own `TestDiscoveryTransform_PreservesPodConverterOutput` caught the stripping conflict before I did; its assertion is updated to require `InitContainerStatuses` to survive, so the strip cannot be reinstated silently.
- `make lint` — `go vet` clean; one pre-existing gosec finding in `pkg/observability` reproduces on a clean tree.

## Not yet verified

Not observed on a cluster — that needs a release and an agent rollout. The check is that `meta.status_info` stops being null for freshly reported pods and that a CrashLoopBackOff pod's `containerStatuses[].state.waiting.reason` arrives intact.
