### PR TITLE
fix(podshell): select a container so multi-container pods can open a shell

### DIFF
--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -65,7 +65,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-08-19T15-28-06_5a862ee549e8f98366ea71c01a7d07a2a151addd
+    tag: 2026-08-20T09-53-59_1e7426c7f4b8555ec2c620ac834c256ea1aceac7
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -65,7 +65,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-08-12T08-30-26_13e26b9dce6e3419f5e1ac52836c773a95098fde
+    tag: 2026-08-19T15-28-06_5a862ee549e8f98366ea71c01a7d07a2a151addd
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/runner/pkg/podshell/session.go
+++ b/runner/pkg/podshell/session.go
@@ -99,6 +99,10 @@ type Request struct {
 	Namespace string `json:"namespace,omitempty"`
 	Command   string `json:"command,omitempty"`
 	RequestID string `json:"request_id,omitempty"`
+	// Container selects which container to exec into. Optional: when empty the
+	// agent resolves one the way kubectl does (see resolveContainer). Callers
+	// older than this field simply omit it.
+	Container string `json:"container,omitempty"`
 }
 
 // Response is the inner shape of the agent's reply. The dispatcher
@@ -114,6 +118,12 @@ type Response struct {
 	// Error is set when a request can't be satisfied (missing fields,
 	// unknown session, etc.). Matches handle_*'s {"error": "..."} returns.
 	Error string `json:"error,omitempty"`
+	// Container and Containers are set by start. They tell the client which
+	// container the session actually attached to and what else it could have
+	// picked, so a container switcher needs no extra API call — and no second
+	// agent rollout, which is the slow part for on-prem installs.
+	Container  string   `json:"container,omitempty"`
+	Containers []string `json:"containers,omitempty"`
 }
 
 // Handle dispatches a TerminalRequest. Returns the response + an HTTP
@@ -141,11 +151,17 @@ func (m *Manager) handleStart(ctx context.Context, r *Request) (*Response, int) 
 	if m.cs == nil || m.restCfg == nil {
 		return &Response{Error: "agent has no K8s client; pod_shell unavailable"}, 503
 	}
-	sess, err := m.openSession(ctx, r.Namespace, r.Name)
+	sess, containers, err := m.openSession(ctx, r.Namespace, r.Name, r.Container)
 	if err != nil {
 		return &Response{Error: err.Error()}, 500
 	}
-	return &Response{SessionID: sess.id, Data: "", Exit: false}, 200
+	return &Response{
+		SessionID:  sess.id,
+		Data:       "",
+		Exit:       false,
+		Container:  sess.container,
+		Containers: containers,
+	}, 200
 }
 
 func (m *Manager) handleExec(_ context.Context, r *Request) (*Response, int) {
@@ -198,6 +214,7 @@ type session struct {
 	id        string
 	namespace string
 	name      string
+	container string
 
 	stdinW *io.PipeWriter
 	cancel context.CancelFunc
@@ -210,12 +227,24 @@ type session struct {
 	usedMu   sync.Mutex
 }
 
-func (m *Manager) openSession(ctx context.Context, ns, name string) (*session, error) {
+// openSession attaches to a container in the pod. It returns the session plus
+// the pod's full container list, so the caller can tell the client what else was
+// available to pick.
+func (m *Manager) openSession(ctx context.Context, ns, name, wantContainer string) (*session, []string, error) {
 	// Best-effort wait for the pod to be Running.
 	// retries up to 20s. We do the same with a 10s budget — anything longer
 	// blocks the agent's WS reader.
-	if err := m.waitRunning(ctx, ns, name); err != nil {
-		return nil, err
+	pod, err := m.waitRunning(ctx, ns, name)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// The exec subresource requires an explicit container whenever the pod has
+	// more than one; without it the API server refuses the upgrade with
+	// "a container name must be specified for pod X, choose one of: [...]".
+	container, err := resolveContainer(pod, wantContainer)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	stdinR, stdinW := io.Pipe()
@@ -224,6 +253,7 @@ func (m *Manager) openSession(ctx context.Context, ns, name string) (*session, e
 		id:        uuid.NewString(),
 		namespace: ns,
 		name:      name,
+		container: container,
 		stdinW:    stdinW,
 		cancel:    cancel,
 		lastUsed:  time.Now(),
@@ -235,11 +265,12 @@ func (m *Manager) openSession(ctx context.Context, ns, name string) (*session, e
 		Namespace(ns).
 		SubResource("exec").
 		VersionedParams(&corev1.PodExecOptions{
-			Command: []string{"/bin/sh"},
-			Stdin:   true,
-			Stdout:  true,
-			Stderr:  true,
-			TTY:     true,
+			Container: container,
+			Command:   []string{"/bin/sh"},
+			Stdin:     true,
+			Stdout:    true,
+			Stderr:    true,
+			TTY:       true,
 		}, scheme.ParameterCodec)
 
 	exec, err := remotecommand.NewSPDYExecutor(m.restCfg, "POST", restReq.URL())
@@ -247,7 +278,7 @@ func (m *Manager) openSession(ctx context.Context, ns, name string) (*session, e
 		_ = stdinR.Close()
 		_ = stdinW.Close()
 		cancel()
-		return nil, fmt.Errorf("build SPDY executor: %w", err)
+		return nil, nil, fmt.Errorf("build SPDY executor: %w", err)
 	}
 
 	// Background streamer: pumps the PTY. Output goes via outWriter into
@@ -273,10 +304,63 @@ func (m *Manager) openSession(ctx context.Context, ns, name string) (*session, e
 	m.mu.Lock()
 	m.sessions[s.id] = s
 	m.mu.Unlock()
-	return s, nil
+	return s, containerNames(pod), nil
 }
 
-func (m *Manager) waitRunning(ctx context.Context, ns, name string) error {
+// defaultContainerAnnotation is the annotation kubectl honours to pick a
+// container when the user does not name one. Respecting it keeps the in-app
+// shell consistent with what `kubectl exec` on the same pod would attach to.
+const defaultContainerAnnotation = "kubectl.kubernetes.io/default-container"
+
+// containerNames lists the pod's exec-able containers, in spec order.
+func containerNames(pod *corev1.Pod) []string {
+	names := make([]string, 0, len(pod.Spec.Containers))
+	for _, c := range pod.Spec.Containers {
+		names = append(names, c.Name)
+	}
+	return names
+}
+
+// resolveContainer decides which container to attach to.
+//
+// A requested name wins, but is validated first: passing an unknown container
+// to the exec subresource fails deep in the stream with a message the user
+// cannot act on, so reject it up front and say what is available. Otherwise
+// mirror kubectl — the default-container annotation, else the first container
+// in spec order. Init containers are deliberately excluded: they have already
+// terminated by the time a pod is Running, and attaching to one only produces
+// a confusing failure.
+func resolveContainer(pod *corev1.Pod, want string) (string, error) {
+	names := containerNames(pod)
+	if len(names) == 0 {
+		return "", fmt.Errorf("pod %s/%s has no containers", pod.Namespace, pod.Name)
+	}
+
+	if want != "" {
+		for _, n := range names {
+			if n == want {
+				return n, nil
+			}
+		}
+		return "", fmt.Errorf("container %q not found in pod %s/%s, choose one of: %s",
+			want, pod.Namespace, pod.Name, strings.Join(names, ", "))
+	}
+
+	if annotated := pod.Annotations[defaultContainerAnnotation]; annotated != "" {
+		for _, n := range names {
+			if n == annotated {
+				return n, nil
+			}
+		}
+		// A stale annotation naming a removed container must not break the
+		// shell — fall through to the first container, as kubectl does.
+	}
+	return names[0], nil
+}
+
+// waitRunning blocks until the pod is Running and returns it, so callers can
+// inspect the spec without a second API round trip.
+func (m *Manager) waitRunning(ctx context.Context, ns, name string) (*corev1.Pod, error) {
 	cctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	t := time.NewTicker(500 * time.Millisecond)
@@ -284,14 +368,14 @@ func (m *Manager) waitRunning(ctx context.Context, ns, name string) error {
 	for {
 		pod, err := m.cs.CoreV1().Pods(ns).Get(cctx, name, metav1.GetOptions{})
 		if err == nil && pod.Status.Phase == corev1.PodRunning {
-			return nil
+			return pod, nil
 		}
 		select {
 		case <-cctx.Done():
 			if err != nil {
-				return fmt.Errorf("pod %s/%s not reachable: %w", ns, name, err)
+				return nil, fmt.Errorf("pod %s/%s not reachable: %w", ns, name, err)
 			}
-			return fmt.Errorf("pod %s/%s not Running", ns, name)
+			return nil, fmt.Errorf("pod %s/%s not Running", ns, name)
 		case <-t.C:
 		}
 	}

--- a/runner/pkg/podshell/session_test.go
+++ b/runner/pkg/podshell/session_test.go
@@ -5,6 +5,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // TestManager_HandleStartRequiresK8s — start without a K8s client returns
@@ -103,5 +106,131 @@ func TestManager_ReapTimesOutIdleSessions(t *testing.T) {
 	}
 	if !old.closed {
 		t.Error("expired session not flagged closed")
+	}
+}
+
+// podWith builds a Running pod with the given containers and annotations.
+func podWith(annotations map[string]string, containers ...string) *corev1.Pod {
+	cs := make([]corev1.Container, 0, len(containers))
+	for _, name := range containers {
+		cs = append(cs, corev1.Container{Name: name})
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "dev", Annotations: annotations},
+		Spec:       corev1.PodSpec{Containers: cs},
+	}
+}
+
+// TestResolveContainer — the exec subresource refuses to upgrade a
+// multi-container pod unless a container is named, so every start must resolve
+// one. Mirrors kubectl: explicit choice, then the default-container
+// annotation, then first in spec order.
+func TestResolveContainer(t *testing.T) {
+	tests := []struct {
+		name        string
+		pod         *corev1.Pod
+		want        string
+		expect      string
+		expectError string
+	}{
+		{
+			name:   "single container needs no hint",
+			pod:    podWith(nil, "app"),
+			expect: "app",
+		},
+		{
+			name:   "multi-container defaults to the first in spec order",
+			pod:    podWith(nil, "nextjs-static-init", "app", "nginx"),
+			expect: "nextjs-static-init",
+		},
+		{
+			name:   "default-container annotation wins over spec order",
+			pod:    podWith(map[string]string{defaultContainerAnnotation: "app"}, "nextjs-static-init", "app", "nginx"),
+			expect: "app",
+		},
+		{
+			name:   "stale annotation falls back rather than failing",
+			pod:    podWith(map[string]string{defaultContainerAnnotation: "removed"}, "app", "nginx"),
+			expect: "app",
+		},
+		{
+			name:   "explicit request wins over both",
+			pod:    podWith(map[string]string{defaultContainerAnnotation: "app"}, "app", "nginx"),
+			want:   "nginx",
+			expect: "nginx",
+		},
+		{
+			name:        "unknown request is rejected with the available names",
+			pod:         podWith(nil, "app", "nginx"),
+			want:        "sidecar",
+			expectError: "choose one of: app, nginx",
+		},
+		{
+			name:        "pod with no containers is an error, not a panic",
+			pod:         podWith(nil),
+			expectError: "no containers",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveContainer(tt.pod, tt.want)
+			if tt.expectError != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.expectError) {
+					t.Fatalf("err = %v; want it to contain %q", err, tt.expectError)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.expect {
+				t.Errorf("container = %q; want %q", got, tt.expect)
+			}
+		})
+	}
+}
+
+// TestContainerNames — the start response advertises what else the user could
+// have attached to, so a client can offer a switcher without another API call.
+func TestContainerNames(t *testing.T) {
+	got := containerNames(podWith(nil, "nextjs-static-init", "app", "nginx"))
+	want := []string{"nextjs-static-init", "app", "nginx"}
+	if len(got) != len(want) {
+		t.Fatalf("containerNames = %v; want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("containerNames = %v; want %v (spec order)", got, want)
+		}
+	}
+}
+
+// TestResolveContainerIgnoresInitContainers — init containers have terminated by
+// the time the pod is Running, so exec'ing into one only fails confusingly. They
+// must never be picked as the default, nor be selectable by name.
+func TestResolveContainerIgnoresInitContainers(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "dev"},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{{Name: "nextjs-static-init"}},
+			Containers:     []corev1.Container{{Name: "app"}, {Name: "nginx"}},
+		},
+	}
+
+	got, err := resolveContainer(pod, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "app" {
+		t.Errorf("default container = %q; want %q (first non-init container)", got, "app")
+	}
+
+	if _, err := resolveContainer(pod, "nextjs-static-init"); err == nil {
+		t.Error("resolveContainer accepted an init container; want it rejected")
+	}
+
+	if names := containerNames(pod); len(names) != 2 {
+		t.Errorf("containerNames = %v; want only the two non-init containers", names)
 	}
 }


### PR DESCRIPTION
## Summary

Opening the in-app shell on a pod with more than one container fails immediately:

```
[stream closed: unable to upgrade connection: a container name must be specified
 for pod app-dev-748d4bdf5b-ppszg, choose one of: [nextjs-static-init app nginx]]
```

`openSession` built `PodExecOptions` with no `Container`, so the API server had nothing to attach to and refused the SPDY upgrade. Single-container pods worked only because the API server can infer the target in that case — which is why this went unnoticed.

Worth noting the sibling exec call sites, `pkg/podexec/executor.go:87` and `pkg/podexec/profiler.go:606`, **both already pass `Container`**. `podshell` was the one outlier, not a pattern the codebase gets wrong.

## What changed

`resolveContainer` picks the target the way `kubectl` does:

1. an explicitly requested container, **validated against the pod first** — an unknown name otherwise fails deep inside the stream with a message the user can't act on, so it is rejected up front with the available names;
2. the `kubectl.kubernetes.io/default-container` annotation, so the in-app shell lands where `kubectl exec` on the same pod would;
3. otherwise the first container in spec order.

A stale annotation naming a removed container falls back rather than breaking the shell.

Init containers are deliberately excluded. They have already terminated by the time a pod is `Running`, so offering them would only produce a confusing failure — relevant here, since the reported pod's `nextjs-static-init` would otherwise be a candidate.

`waitRunning` now returns the pod it already fetched, so resolution costs no extra API round trip.

## Wire changes (both backward compatible)

- `Request` gains optional `container`. Omitting it keeps today's behaviour, so existing clients are unaffected — this is also the compatibility floor: the deployed UI sends no container, so a fix that *required* one would break every current client.
- `start` responses now carry `container` (what it attached to) and `containers` (what else it could have). This is deliberately slightly ahead of the UI: it lets a container switcher ship later with **no second agent rollout**, which is the slow part for on-prem installs. Both fields are `omitempty` and ignored by current clients. Happy to drop them if you'd rather keep the surface minimal.

## Type of change

- [x] Bug fix (non-breaking)

## Chart version

- [x] No version bump needed (runner-only change; matches #574, #566 and the other recent runner PRs, none of which bumped the chart)

## Test plan

- [x] `go test ./pkg/podshell/...` — passes, including 7 new table cases covering single-container, multi-container spec order, annotation precedence, stale annotation fallback, explicit request, unknown request (asserts the error lists the valid names), and the empty-container guard.
- [x] `make fmt` clean, `go vet ./pkg/podshell/...` clean, full `make test` green across all packages.
- [ ] `make lint` could not be run locally — the installed `golangci-lint` 2.8.0 is built with go1.25.5 while the module targets go1.26.3, so it refuses with `can't load config`. This is a stale local toolchain, not a finding; CI runs the pinned linter.
- [ ] **Not exercised against a live multi-container pod** — no cluster access from where this was written. The failure is entirely in the exec request construction and the resolution logic is unit-tested, but the end-to-end path deserves one manual check: open a shell on a multi-container pod and confirm it attaches, then confirm a pod carrying `kubectl.kubernetes.io/default-container` lands in the annotated container.

## Related issues

Reported against the in-app pod terminal, alongside nudgebee-enterprise#36589 (terminal failing to open) and nudgebee-enterprise#36642 (typing latency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)