### PR TITLE
fix(nb-36647): drop the image from Job-collapsed backoff fingerprints

### DIFF
--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -65,7 +65,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-08-20T09-53-59_1e7426c7f4b8555ec2c620ac834c256ea1aceac7
+    tag: 2026-08-20T12-43-13_7a2f3c93f2575994b793bb376c5b7e1f5c60d7ed
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/runner/pkg/triggers/predicates.go
+++ b/runner/pkg/triggers/predicates.go
@@ -290,8 +290,9 @@ func oomKilledEnrichBlocks(obj, _ map[string]any, ec EnrichContext) []EvidenceBl
 // imagePullBackoffMatcher fires when any container is currently in
 // ImagePullBackOff or ErrImagePull. Same kubewatch pointer-aliasing
 // caveat as pod_crash_loop — we can't rely on oldObj→obj transition
-// detection. The fingerprint (`owner, image`) dedupes: distinct bad
-// images each fire once per 10-min window.
+// detection. The fingerprint is (`owner, image`) for ordinary workloads,
+// and (`job family`) for Job-owned Pods — see FingerprintFn for why the
+// image is deliberately excluded in the Job case.
 func imagePullBackoffMatcher() MatcherSpec {
 	return MatcherSpec{
 		Name:           "image_pull_backoff",
@@ -306,24 +307,30 @@ func imagePullBackoffMatcher() MatcherSpec {
 		},
 		FingerprintFn: func(obj map[string]any) string {
 			ns, name := metaNS(obj), metaName(obj)
+			// The bad image discriminates between containers of one workload:
+			// an operator typo'd a single container and the rest are fine, so
+			// those should be distinct Findings.
+			image := firstFailingImage(obj)
 			owner := ResolveOwner(obj)
 			if owner.Name != "" {
 				name = owner.Name
 				// A Pod owned by a Job resolves to that Job, whose name
 				// carries a per-run suffix — so a creator that runs one Job
-				// per unit of work (our image scanner: one Job per image)
-				// produced a brand-new fingerprint every run and never
-				// chained. Collapse to the job family (#36647).
+				// per unit of work produced a brand-new fingerprint every run
+				// and never chained. Collapse to the job family (#36647).
 				if owner.Kind == "job" {
 					name = JobFamily(name)
+					// ...and drop the image. For a one-Job-per-image creator
+					// (our image scanner) the image IS the per-run identity,
+					// so keeping it re-introduces exactly the fanout the job
+					// family collapse just removed — verified on the dev
+					// cluster after #580 shipped: every scan Job still had its
+					// own fingerprint because each pulls a different image.
+					// The failing image stays in the evidence blocks either
+					// way; it just no longer forks the identity.
+					image = ""
 				}
 			}
-			// Include the bad image — different bad images on the same
-			// workload should be distinct Findings (operator just typo'd
-			// one container, the rest are fine). This also keeps per-image
-			// resolution after the job-family collapse above: one scan Job
-			// family with two bad images is still two Findings.
-			image := firstFailingImage(obj)
 			return fp("image_pull_backoff_reporter", ns, name, image)
 		},
 		EnrichBlocks: imagePullBackoffEnrichBlocks,

--- a/runner/pkg/triggers/predicates.go
+++ b/runner/pkg/triggers/predicates.go
@@ -307,29 +307,34 @@ func imagePullBackoffMatcher() MatcherSpec {
 		},
 		FingerprintFn: func(obj map[string]any) string {
 			ns, name := metaNS(obj), metaName(obj)
-			// The bad image discriminates between containers of one workload:
-			// an operator typo'd a single container and the rest are fine, so
-			// those should be distinct Findings.
-			image := firstFailingImage(obj)
 			owner := ResolveOwner(obj)
+			// A Pod owned by a Job resolves to that Job, whose name carries a
+			// per-run suffix — so a creator that runs one Job per unit of work
+			// produced a brand-new fingerprint every run and never chained.
+			// Collapse to the job family (#36647).
+			jobOwned := owner.Name != "" && owner.Kind == "job"
 			if owner.Name != "" {
 				name = owner.Name
-				// A Pod owned by a Job resolves to that Job, whose name
-				// carries a per-run suffix — so a creator that runs one Job
-				// per unit of work produced a brand-new fingerprint every run
-				// and never chained. Collapse to the job family (#36647).
-				if owner.Kind == "job" {
+				if jobOwned {
 					name = JobFamily(name)
-					// ...and drop the image. For a one-Job-per-image creator
-					// (our image scanner) the image IS the per-run identity,
-					// so keeping it re-introduces exactly the fanout the job
-					// family collapse just removed — verified on the dev
-					// cluster after #580 shipped: every scan Job still had its
-					// own fingerprint because each pulls a different image.
-					// The failing image stays in the evidence blocks either
-					// way; it just no longer forks the identity.
-					image = ""
 				}
+			}
+			// The failing image discriminates between containers of one
+			// workload: an operator typo'd a single container and the rest are
+			// fine, so those stay distinct Findings.
+			//
+			// It is deliberately excluded for Job-owned Pods. For a
+			// one-Job-per-image creator (our image scanner) the image IS the
+			// per-run identity, so keeping it re-introduces exactly the fanout
+			// the job-family collapse just removed — verified on the dev
+			// cluster after #580 shipped: every scan Job still had its own
+			// fingerprint because each pulls a different image. The image stays
+			// in the evidence blocks either way; it just no longer forks the
+			// identity. Skipping the call also avoids walking every container
+			// status for a result we would discard.
+			var image string
+			if !jobOwned {
+				image = firstFailingImage(obj)
 			}
 			return fp("image_pull_backoff_reporter", ns, name, image)
 		},

--- a/runner/pkg/triggers/predicates_test.go
+++ b/runner/pkg/triggers/predicates_test.go
@@ -771,6 +771,56 @@ func TestImagePullBackoff_JobOwnedPodsCollapseToJobFamily(t *testing.T) {
 	}
 }
 
+func TestImagePullBackoff_JobFamilyCollapsesAcrossDifferentImages(t *testing.T) {
+	// Regression for what #580 missed: a one-Job-per-image creator gives every
+	// run a different image, so keeping the image in the fingerprint re-forked
+	// the identity even after the job-family collapse. Observed on the dev
+	// cluster — every trivy-image-scan Job still had its own fingerprint.
+	mk := func(job, image string) map[string]any {
+		return asObj(t, `{
+			"metadata":{
+				"name":"`+job+`-p9x2","namespace":"scan",
+				"ownerReferences":[{"kind":"Job","name":"`+job+`","controller":true}]
+			},
+			"status":{"containerStatuses":[
+				{"name":"scan","image":"`+image+`",
+				 "state":{"waiting":{"reason":"ErrImagePull"}}}
+			]}
+		}`)
+	}
+	m := imagePullBackoffMatcher()
+	a := m.FingerprintFn(mk("trivy-image-scan-020c9475", "reg/nudgebee-ticket-server:2026-08-20T09-31-55_2a48d6b"))
+	b := m.FingerprintFn(mk("trivy-image-scan-9d22cbf9", "reg/nudgebee-llm-server:2026-08-20T09-12-54_b8f84d9"))
+	if a != b {
+		t.Error("scan Jobs of one family must share a fingerprint even when each pulls a different image")
+	}
+	// A different family in the same namespace stays distinct.
+	if c := m.FingerprintFn(mk("kube-bench-scan-177dde3a", "reg/kube-bench:v1")); c == a {
+		t.Error("a different job family must not collapse into the same fingerprint")
+	}
+}
+
+func TestImagePullBackoff_NonJobOwnersKeepImageDiscrimination(t *testing.T) {
+	// The image must still split Findings for ordinary workloads — one typo'd
+	// container should not hide behind a sibling's good image.
+	mk := func(image string) map[string]any {
+		return asObj(t, `{
+			"metadata":{
+				"name":"api-7f9d8c5b6d-aaaaa","namespace":"prod",
+				"ownerReferences":[{"kind":"ReplicaSet","name":"api-7f9d8c5b6d","controller":true}]
+			},
+			"status":{"containerStatuses":[
+				{"name":"app","image":"`+image+`",
+				 "state":{"waiting":{"reason":"ImagePullBackOff"}}}
+			]}
+		}`)
+	}
+	m := imagePullBackoffMatcher()
+	if m.FingerprintFn(mk("registry/api:bad-v1")) == m.FingerprintFn(mk("registry/api:bad-v2")) {
+		t.Error("different bad images on a Deployment must stay distinct")
+	}
+}
+
 func TestImagePullBackoff_DeploymentReplicasStillCollapse(t *testing.T) {
 	// Guards the behaviour that already worked, so the job-family change
 	// above cannot regress it.


### PR DESCRIPTION
## What

Follow-up to #580, found by verifying that change on the dev cluster rather than trusting the projection in its PR body.

#580 collapsed a Job owner to its family so repeated runs of one logical job would share a fingerprint — but kept the failing image in the hash. For a one-Job-per-image creator the image **is** the per-run identity, so it re-forked the fingerprint immediately and the collapse achieved nothing.

Observed in `nudgebee-agent-dev` ~25 minutes after #580 rolled out — every scan Job still had its own fingerprint:

```
trivy-image-scan-020c9475  fp 3f485711404c  .../nudgebee-ticket-server:2026-08-20T09-31-55_2a48d6b
trivy-image-scan-9d22cbf9  fp 5d64210242b4  .../nudgebee-llm-server:2026-08-20T09-12-54_b8f84d9
trivy-image-scan-73c22c16  fp e885087c86bd  .../nudgebee-benchmark-server:2026-08-20T09-34-41_2a48d6b
```

This drops the image from the fingerprint **only** when a Job owner was collapsed. Ordinary workloads keep it, so a single typo'd container is still its own Finding. The failing image stays in the evidence blocks either way — it just no longer forks the identity.

## Whose noise this actually fixes — read this before the numbers

30 days of production `kubernetes_api_server` events come from exactly two places: our own tenants (Nudgebee + the `iteration-*` demo tenants) and **one customer**, "mohan's Org" / `blinq-k8s`. Every other tenant with a registered k8s account emits via `prometheus` / `Azure_Monitor_Alert` / `pagerduty_webhook` — they are not on the Go agent yet. So the population this PR measurably affects is us plus one customer.

For that customer, `image_pull_backoff_reporter` has **1 fingerprint in 30 days**. The headline below is our own image scanner running against our own dev registry.

| owner kind | fingerprints today | after |
|---|---|---|
| **job** | **3,961** | **9** |
| deployment | 35 | 35 |
| daemonset | 8 | 8 |
| statefulset | 3 | 3 |
| (none) | 20 | 17 |

That is still worth doing — it is a real defect and our demo tenants are what prospects look at — but it should not be read as customer-facing impact. The customer-facing part of this work is the `ConfigurationChange` fix in #580, which is validated on blinq's own application workloads (`blinq-prediction-hasura-graph`: 618 events, 618 fingerprints, max occurrence 1) and rests on a structural cause — `resourceVersion` advances on every write in every cluster — rather than on our sample.

The one genuine customer benefit here is indirect: 25 of blinq's 27 `job_failure` fingerprints are `kube-bench-scan-*` in the `nudgebee-agent` namespace — our own agent's scanner generating noise inside their cluster. The job-family collapse takes that to 1. Their two real jobs (`blinq-api-healthchecks`, CronJob-owned; `blinq-clob-indexer-cleardb`, no generated suffix) are untouched.

`cd runner && make validate` — exit 0, 37 packages, no failures.

## Correction to #580

That PR claimed `image_pull_backoff 4,008 -> 72`, labelled "excl. image component". The caveat was doing all the work: I measured the collapse with the image excluded and then shipped code that included it. The ConfigurationChange and job_failure numbers in #580 were not affected and are confirmed working on dev — `kube-system/calico-typha` produced 4 config-change events over 11 minutes on a single fingerprint, occurrence 1 -> 4, against a 14-day pre-fix baseline of 1,871 chains all stuck at occurrence 1.

## Risk

Two different unpullable images within one scan-Job family now collapse to one Finding with a climbing occurrence count instead of one Finding each. That is the intended grouping — "the scanner cannot pull images" is one problem — and the per-image detail is preserved in evidence.

**`JobFamily` is calibrated on a thin sample.** It strips `-<digits>` / `-<8+ hex>` / `-<uuid>` tails, and the five job-name families in the data are `trivy-image-scan`, `kube-bench-scan`, `pinot-segment-push-v2`, `grade-astropy--astropy` and `blinq-api-healthchecks` — three of them ours. The only customer job names available to test against are two, and neither exercises the heuristic. A customer running `etl-20240101` / `etl-20240102` gets the intended grouping; one running genuinely unrelated `report-a1b2c3d4` and `report-deadbeef` would see them merged. There is no data to bound that today. If it becomes a problem, the containment is to restrict stripping to CronJob-owned Jobs plus an explicit prefix allowlist.

Part of nudgebee/nudgebee-enterprise#36647
