### PR TITLE
feat(chart): source the auth key from an external Secret, and stop emitting monitoring CRs that cannot apply

### DIFF
--- a/charts/nudgebee-agent/templates/_helpers.tpl
+++ b/charts/nudgebee-agent/templates/_helpers.tpl
@@ -113,6 +113,17 @@ Runner container template. Invoked with root context: include "nudgebee.runner.c
     privileged: false
     readOnlyRootFilesystem: false
   env:
+    {{- with .Values.runner.nudgebee.authSecretKeyFrom }}
+    # Sourced from an externally-provisioned Secret rather than the runner
+    # Secret. An explicit `env` entry outranks the same name arriving through
+    # `envFrom`, and runner.yaml omits it from the runner Secret in this case,
+    # so there is exactly one source either way.
+    - name: NUDGEBEE_AUTH_SECRET_KEY
+      valueFrom:
+        secretKeyRef:
+          name: {{ .name }}
+          key: {{ .key }}
+    {{- end }}
     - name: INSTALLATION_NAMESPACE
       valueFrom:
         fieldRef:

--- a/charts/nudgebee-agent/templates/pod_monitor.yaml
+++ b/charts/nudgebee-agent/templates/pod_monitor.yaml
@@ -1,9 +1,13 @@
-{{- if (and .Values.nodeAgent.enabled .Values.nodeAgent.podmonitor.enabled) }}
-{{- if .Values.nodeAgent.podmonitor.azuremanaged }}
-apiVersion: azmonitoring.coreos.com/v1
-{{- else }}
-apiVersion: monitoring.coreos.com/v1
-{{- end }}
+{{- /*
+Gated on the PodMonitor CRD being registered, or on enablePrometheusStack as an
+explicit operator assertion for offline render (Argo CD / Flux), where
+.Capabilities carries only the built-in API versions. Without this the manifest
+is emitted on clusters that have no Prometheus operator and fails the install
+outright — same reasoning as prometheus-alert-rule.yaml.
+*/ -}}
+{{- $podMonitorApiVersion := ternary "azmonitoring.coreos.com/v1" "monitoring.coreos.com/v1" (.Values.nodeAgent.podmonitor.azuremanaged | default false) }}
+{{- if (and .Values.nodeAgent.enabled .Values.nodeAgent.podmonitor.enabled (or .Values.enablePrometheusStack (.Capabilities.APIVersions.Has (printf "%s/PodMonitor" $podMonitorApiVersion)))) }}
+apiVersion: {{ $podMonitorApiVersion }}
 kind: PodMonitor
 metadata:
   name: {{ include "nudgebee-agent.fullname" . }}-node-agent

--- a/charts/nudgebee-agent/templates/prometheus-alert-rule.yaml
+++ b/charts/nudgebee-agent/templates/prometheus-alert-rule.yaml
@@ -1,9 +1,14 @@
 {{- /*
-Gated on enablePrometheusStack as well as the rule toggle: without a Prometheus
+Gated on the rule toggle plus proof the CRD exists: without a Prometheus
 operator in the cluster the monitoring.coreos.com/v1 PrometheusRule CRD is not
-registered, so applying this manifest fails the install outright.
+registered, so applying this manifest fails the install outright. Either the CRD
+is actually registered, or enablePrometheusStack asserts it — the latter covers
+offline render (Argo CD / Flux), where .Capabilities carries only the built-in
+API versions. The capability arm lets an install set enablePrometheusStack=false
+for a cluster that may not have the operator and still get these rules where it
+does.
 */ -}}
-{{- if and (default false .Values.alertmanager.create_nb_default_rules) .Values.enablePrometheusStack }}
+{{- if and (default false .Values.alertmanager.create_nb_default_rules) (or .Values.enablePrometheusStack (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PrometheusRule")) }}
 {{- /*
 Exclusion lists come from .Values.alertmanager.defaultRuleExclusions and are
 compiled into PromQL regexes here.

--- a/charts/nudgebee-agent/templates/runner.yaml
+++ b/charts/nudgebee-agent/templates/runner.yaml
@@ -89,7 +89,17 @@ metadata:
 type: Opaque
 stringData:
   NUDGEBEE_ENDPOINT: {{ .Values.runner.nudgebee.endpoint }}
+  {{- $authFrom := .Values.runner.nudgebee.authSecretKeyFrom | default (dict) }}
+  {{- if $authFrom }}
+    {{- if not (and $authFrom.name $authFrom.key) }}
+      {{- fail "\n\n[ERROR] runner.nudgebee.authSecretKeyFrom needs both `name` and `key`.\n\n  runner:\n    nudgebee:\n      authSecretKeyFrom:\n        name: <secret-name>\n        key: <key-in-that-secret>\n" }}
+    {{- end }}
+    {{- if .Values.runner.nudgebee.auth_secret_key }}
+      {{- fail "\n\n[ERROR] Set either runner.nudgebee.auth_secret_key or runner.nudgebee.authSecretKeyFrom, not both.\nTwo sources for one credential means the effective value depends on template ordering. Pick one.\n" }}
+    {{- end }}
+  {{- else }}
   NUDGEBEE_AUTH_SECRET_KEY: {{ .Values.runner.nudgebee.auth_secret_key }}
+  {{- end }}
   # Tie cost polling/discovery to the OpenCost subchart toggle. When OpenCost is
   # disabled the runner must NOT autodiscover a neighbouring namespace's OpenCost,
   # so the server side detects cost is off and takes over centrally.

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -268,6 +268,15 @@ runner:
   nudgebee:
     endpoint: https://collector.nudgebee.com
     auth_secret_key: ""
+    # Source NUDGEBEE_AUTH_SECRET_KEY from an existing Secret instead of
+    # `auth_secret_key`. Set both `name` and `key`; setting this together with a
+    # non-empty `auth_secret_key` is an error rather than a silent precedence
+    # rule. Used when the credential is provisioned by something other than this
+    # chart — e.g. a parent chart that generates it at install time — so the
+    # runner Secret never has to carry it. Only this one variable moves; the rest
+    # of the runner Secret is unchanged.
+    # e.g. { name: nudgebee-local-agent, key: NUDGEBEE_AUTH_SECRET_KEY }
+    authSecretKeyFrom: {}
     # Relay Ed25519 public key. Lets the agent verify relay-signed requests and
     # authorize UI-triggered workload mutations (delete/create/replace/restart/
     # scale). The UI install command populates this from the server's
@@ -479,6 +488,16 @@ clickhouse:
       memory: 2000Mi
     limits:
       memory: 2000Mi
+  # NOTE: these render monitoring.coreos.com CRs from the Bitnami subchart, which
+  # this chart cannot gate on `.Capabilities` the way its own templates do — a
+  # parent cannot add a condition to a subchart's template, only flip a value. On
+  # a cluster with no Prometheus operator the CRDs are unregistered and the
+  # install fails on them, so installing there means setting BOTH:
+  #   --set enablePrometheusStack=false \
+  #   --set clickhouse.metrics.serviceMonitor.enabled=false
+  # Left enabled by default so installs that do have the operator (the case the
+  # quick-install script produces, since it installs kube-prometheus-stack) keep
+  # their ClickHouse scrape target.
   metrics:
     enabled: true
     serviceMonitor:


### PR DESCRIPTION
## Summary

Two chart changes, both prerequisites for running the agent as a subchart of the server chart so a first-time on-prem install is a single `helm install` instead of "install server, log in, copy an auth key, install agent".

**`runner.nudgebee.authSecretKeyFrom: {name, key}`** sources `NUDGEBEE_AUTH_SECRET_KEY` from an existing Secret. When set, the runner Secret omits the key and the container gets an explicit `env` entry via `secretKeyRef`. An explicit `env` entry outranks the same name arriving through `envFrom`, so there is exactly one source either way, and the rest of the runner Secret (`NUDGEBEE_ENDPOINT`, `PROMETHEUS_URL`, ...) is untouched — deliberately narrower than an `existingSecretName` that would swallow all of it.

This is for credentials provisioned outside this chart. A parent chart can generate the key at install time and the agent has it the moment the pod starts, with no ordering to arrange between the two. Setting it alongside a non-empty `auth_secret_key`, or supplying only one of `name`/`key`, fails the render with a pointed message rather than silently picking a winner.

**CRD gating.** `pod_monitor.yaml` had no guard at all, so a default install on a cluster with no Prometheus operator emitted a PodMonitor against an unregistered CRD and failed the install outright. It now uses the same gate `runner.yaml` already had: the CRD is registered, or `enablePrometheusStack` asserts it for offline render (Argo CD / Flux), where `.Capabilities` carries only built-in API versions. The apiVersion is computed once so the capability check matches the `azuremanaged` variant. `prometheus-alert-rule.yaml` gains the capability arm for the same reason, which lets an install set `enablePrometheusStack=false` for a cluster that may lack the operator and still get these rules where it does.

The Bitnami ClickHouse subchart's ServiceMonitor cannot be gated this way — a parent cannot add a condition to a subchart's template, only flip a value — so `values.yaml` documents the two flags a Prometheus-less install needs.

## Type of change

- [x] New feature (non-breaking)
- [x] Bug fix (non-breaking) — the ungated PodMonitor

## Chart version

- [x] No version bump — 0.1.20 is already on `main` and not yet released, so this rides along with it.

## Test plan

- [x] `helm lint charts/nudgebee-agent` passes
- [x] `ct lint --config .github/configs/ct.yaml` passes
- [x] `helm template` output reviewed
- [ ] Installed on a real/kind cluster — **not done**, see below

**No behavior change for existing installs.** Rendered output is byte-identical to `main` for default values in both online render (with the operator CRDs available) and offline render — 4 monitoring CRs either way. The only diff is the per-render random `clickhouse admin-password` and the `rollme` annotation, which change on every render regardless of this PR.

**Prometheus-less cluster** (`--set enablePrometheusStack=false --set clickhouse.metrics.serviceMonitor.enabled=false`): zero monitoring CRs render, so the install applies cleanly. Before this PR the PodMonitor still rendered.

**`authSecretKeyFrom` set**: exactly one `secretKeyRef` env entry, and no `NUDGEBEE_AUTH_SECRET_KEY` in any Secret `stringData`.

**Misconfiguration**: both-set and name-without-key each fail the render with the intended message.

The exact CI render command (`helm template nudgebee-agent charts/nudgebee-agent --namespace nudgebee-agent`) succeeds and the `memory_limiter` guard still passes.

Not yet exercised on a live cluster — the end-to-end proof belongs with the server-side PR that generates the Secret and reconciles it, since neither half is observable alone. Flagging that rather than checking the box.

## Related issues

No existing ticket covers the single-step install work; not filing one automatically. Happy to link if there's a ticket I should reference.