### PR TITLE
fix(traces): restore otel_traces materialized columns and report the flag honestly

### DIFF
--- a/runner/cmd/agent/main.go
+++ b/runner/cmd/agent/main.go
@@ -22,6 +22,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -1020,6 +1021,7 @@ func run(ctx context.Context, logger *slog.Logger, cfg *config.Config) error {
 					ClickHouseStatus:           clickhouseStatus,
 					ClickHouseURL:              clickhouseHost,
 					ClickHouseError:            clickhouseErr,
+					HasMaterializedColumns:     ensureTraceColumns(probeCtx, ch, logger),
 					AgentURL:                   agentURL,
 					GrafanaEnabled:             grafanaURL != "" && httpProbe(probeCtx, probeClient, grafanaURL+"/api/health"),
 					AutoScalerEnabled:          as.Enabled,
@@ -1330,6 +1332,30 @@ func probeClickhouse(ctx context.Context, c *http.Client, host, port string) (bo
 		return false, fmt.Sprintf("ClickHouse ping failed at %s:%s: %v", redactUserinfo(host), port, probeCause(err))
 	}
 	return true, ""
+}
+
+// traceColumnsReady latches the materialized-column check. The columns are
+// created once and never removed, so after a confirmed pass there is nothing
+// left to decide — re-issuing the system.columns read on every heartbeat would
+// be pure noise. While it is false we keep retrying, which is what makes the
+// setup self-healing: the exporter creates otel_traces lazily on its first span
+// batch, so the agent usually starts before the table exists.
+var traceColumnsReady atomic.Bool
+
+// ensureTraceColumns reports whether otel_traces carries the materialized
+// columns, creating them when it doesn't.
+func ensureTraceColumns(ctx context.Context, ch *chclient.Client, logger *slog.Logger) bool {
+	if ch == nil {
+		return false
+	}
+	if traceColumnsReady.Load() {
+		return true
+	}
+	if chclient.EnsureMaterializedColumns(ctx, ch, logger) {
+		traceColumnsReady.Store(true)
+		return true
+	}
+	return false
 }
 
 // probeCause unwraps the *url.Error net/http wraps around transport failures.

--- a/runner/cmd/agent/main.go
+++ b/runner/cmd/agent/main.go
@@ -1342,8 +1342,21 @@ func probeClickhouse(ctx context.Context, c *http.Client, host, port string) (bo
 // batch, so the agent usually starts before the table exists.
 var traceColumnsReady atomic.Bool
 
+// traceColumnsWarned suppresses repeats of the same failure reason. The check
+// runs every heartbeat until it confirms, so a ClickHouse that stays down would
+// otherwise repeat one warning forever and bury the rest of the tick's output.
+var traceColumnsWarned atomic.Bool
+
 // ensureTraceColumns reports whether otel_traces carries the materialized
 // columns, creating them when it doesn't.
+//
+// Deliberately not gated on the clickhouseStatus probe. That probe pings
+// http://host:port/ping with the scheme hardcoded and no handling for a scheme
+// already in CLICKHOUSE_HOST, whereas this client honours CLICKHOUSE_SSL_ENABLED
+// and a URL-form host. Skipping the check whenever the probe says "down" would
+// therefore leave every SSL or external ClickHouse without its materialized
+// columns permanently, silently, while queries against it work fine —
+// and TRACES_ENABLED=false forces that probe false regardless of reachability.
 func ensureTraceColumns(ctx context.Context, ch *chclient.Client, logger *slog.Logger) bool {
 	if ch == nil {
 		return false
@@ -1351,10 +1364,15 @@ func ensureTraceColumns(ctx context.Context, ch *chclient.Client, logger *slog.L
 	if traceColumnsReady.Load() {
 		return true
 	}
-	if chclient.EnsureMaterializedColumns(ctx, ch, logger) {
+	l := logger
+	if traceColumnsWarned.Load() {
+		l = slog.New(slog.DiscardHandler)
+	}
+	if chclient.EnsureMaterializedColumns(ctx, ch, l) {
 		traceColumnsReady.Store(true)
 		return true
 	}
+	traceColumnsWarned.Store(true)
 	return false
 }
 

--- a/runner/pkg/clickhouse/schema.go
+++ b/runner/pkg/clickhouse/schema.go
@@ -170,7 +170,7 @@ func EnsureMaterializedColumns(ctx context.Context, c *Client, logger *slog.Logg
 	}
 
 	sort.Strings(adds)
-	stmt := fmt.Sprintf("ALTER TABLE %s.%s %s", c.Database, TracesTable, strings.Join(adds, ", "))
+	stmt := fmt.Sprintf("ALTER TABLE %s.%s %s", quoteIdent(c.Database), quoteIdent(TracesTable), strings.Join(adds, ", "))
 	res, err := c.Query(ctx, stmt, nil)
 	if err != nil {
 		logger.Warn("clickhouse: materialized-column ALTER failed", "err", err)
@@ -259,7 +259,19 @@ func traceSourceIsStale(ctx context.Context, c *Client, columns map[string]struc
 	return !strings.Contains(expr, scopeNameColumn), nil
 }
 
-// escapeLiteral escapes a value for a single-quoted ClickHouse string literal.
+// escapeLiteral escapes a value for a single-quoted ClickHouse string literal —
+// the `WHERE database = '…'` position in the system.columns reads.
 func escapeLiteral(s string) string {
 	return strings.NewReplacer(`\`, `\\`, `'`, `\'`).Replace(s)
+}
+
+// quoteIdent backtick-quotes a database or table name for the identifier
+// position in DDL. Distinct from escapeLiteral: the same name is a quoted
+// identifier in `ALTER TABLE db.table` but a string literal in a system.columns
+// predicate, and the two take different quoting.
+//
+// CLICKHOUSE_DB is operator-supplied, so it can legally contain characters —
+// a hyphen most likely — that the parser rejects unquoted.
+func quoteIdent(s string) string {
+	return "`" + strings.NewReplacer(`\`, `\\`, "`", "\\`").Replace(s) + "`"
 }

--- a/runner/pkg/clickhouse/schema.go
+++ b/runner/pkg/clickhouse/schema.go
@@ -1,0 +1,265 @@
+package clickhouse
+
+// Materialized-column management for the OTel traces table.
+//
+// The backend serves trace queries from one of two SQL shapes, picked by the
+// `hasMaterializedColumn` flag the agent reports in its heartbeat:
+//
+//   - true  — SELECT the materialized columns directly (workload_name,
+//     trace_source, …). Cheap: ClickHouse computed them at insert time.
+//   - false — recompute every one of them from the raw SpanAttributes /
+//     ResourceAttributes maps on every scan.
+//
+// Those columns are not part of the OTel exporter's schema; the agent adds
+// them. The legacy Python runner did this at startup (safe_alter_clickhouse_table)
+// and probed system.columns to report the flag honestly. Neither survived the
+// Go rewrite: the flag was hardcoded false and the columns stopped being
+// created, so every install silently took the slow path and pre-existing
+// installs were mis-reported as lacking columns they actually had.
+//
+// EnsureMaterializedColumns restores both halves.
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+)
+
+// TracesTable is the OTel exporter's traces table. The exporter only creates
+// its tables when absent — it never ALTERs one — so additive schema changes
+// are ours to make.
+const TracesTable = "otel_traces"
+
+// scopeNameColumn is the collector's own scope column, added in the
+// 0.75 -> 0.156 exporter upgrade. Its presence is what decides which
+// trace_source expression a given install can actually run: referencing it on
+// a table that predates it fails the ALTER outright.
+const scopeNameColumn = "ScopeName"
+
+// ebpfScopeName identifies spans emitted by our eBPF node agent, as opposed to
+// application-instrumented OTel spans.
+const ebpfScopeName = "nudgebee-node-agent"
+
+// materializedColumns are the columns the backend's materialized query shape
+// selects, in the order the legacy runner declared them. Definitions are ported
+// verbatim except trace_source, which is built per-install by
+// traceSourceDefinition.
+//
+// Adding an entry here is enough to roll it out — the ensure pass adds whatever
+// is missing, and the flag is computed from this map rather than a hardcoded
+// count, so a new column can't silently flip installs to the slow path.
+var materializedColumns = map[string]string{
+	"workload_namespace": "String MATERIALIZED CASE WHEN mapContains(SpanAttributes, 'source.workload_namespace') " +
+		"THEN SpanAttributes['source.workload_namespace'] WHEN mapContains(ResourceAttributes, " +
+		"'k8s.namespace.name') THEN ResourceAttributes['k8s.namespace.name'] ELSE " +
+		"ResourceAttributes['service.namespace'] END CODEC(ZSTD(1))",
+	"workload_name": "String MATERIALIZED CASE WHEN mapContains(SpanAttributes, 'source.workload_name') THEN " +
+		"SpanAttributes['source.workload_name'] WHEN mapContains(ResourceAttributes, " +
+		"'k8s.deployment.name') THEN ResourceAttributes['k8s.deployment.name'] ELSE ResourceAttributes[" +
+		"'service.name'] END CODEC(ZSTD(1))",
+	"resource": "String MATERIALIZED CASE WHEN mapContains(SpanAttributes, 'db.statement') THEN SpanAttributes[" +
+		"'db.statement'] ELSE SpanAttributes['http.url'] END CODEC(ZSTD(1))",
+	"destination_workload_name": "String MATERIALIZED CASE WHEN mapContains(SpanAttributes, " +
+		"'destination.workload_name') THEN SpanAttributes['destination.workload_name'] WHEN " +
+		"mapContains(ResourceAttributes, 'k8s.deployment.name') THEN ResourceAttributes[" +
+		"'k8s.deployment.name'] WHEN mapContains(ResourceAttributes, 'service.name') THEN " +
+		"ResourceAttributes['service.name'] ELSE ResourceAttributes['net.peer.name'] END CODEC(ZSTD(1))",
+	"destination_workload_namespace": "String MATERIALIZED CASE WHEN mapContains(SpanAttributes, " +
+		"'destination.workload_namespace') THEN SpanAttributes['destination.workload_namespace'] WHEN " +
+		"mapContains(ResourceAttributes, 'k8s.namespace.name') THEN ResourceAttributes['k8s.namespace.name'] " +
+		"ELSE ResourceAttributes['service.namespace'] END CODEC(ZSTD(1))",
+	"destination_name": "String MATERIALIZED CASE WHEN mapContains(SpanAttributes, 'destination.name') THEN " +
+		"SpanAttributes['destination.name'] WHEN mapContains(ResourceAttributes, 'service.name') THEN " +
+		"ResourceAttributes['service.name'] ELSE ResourceAttributes['net.peer.name'] END CODEC(ZSTD(1))",
+	"headers":          "String MATERIALIZED base64Decode(toString(SpanAttributes['http.headers'])) CODEC(ZSTD(1))",
+	"http_status_code": "LowCardinality(String) MATERIALIZED toString(SpanAttributes['http.status_code']) CODEC(ZSTD(1))",
+	"request_payload":  "String MATERIALIZED toString(SpanAttributes['http.request_payload']) CODEC(ZSTD(1))",
+	"http_response":    "String MATERIALIZED toString(SpanAttributes['http.response']) CODEC(ZSTD(1))",
+	"workload_zone":    "String MATERIALIZED toString(ResourceAttributes['cloud.availability_zone']) CODEC(ZSTD(1))",
+	"destination_workload_zone": "String MATERIALIZED toString(SpanAttributes['destination.cloud.availablity_zone']) " +
+		"CODEC(ZSTD(1))",
+	"cloud_availability_zone": "String MATERIALIZED toString(ResourceAttributes['cloud.availability_zone']) " +
+		"CODEC(ZSTD(1))",
+	// trace_source is filled in by requiredColumns — its definition depends on
+	// whether this install's table has ScopeName.
+	"trace_source": "",
+}
+
+// traceSourceDefinition returns the trace_source column definition valid for a
+// table with the given column set.
+//
+// The collector upgrade moved the scope name out of SpanAttributes and into a
+// dedicated ScopeName column: on 0.157 tables SpanAttributes['otel.scope.name']
+// is empty on every span, and on pre-0.156 tables ScopeName does not exist at
+// all. Neither expression works on both, and a bare reference to a missing
+// column fails the whole statement at name-resolution — so the OR arm cannot
+// serve as a fallback and the choice has to be made here, from the real schema.
+func traceSourceDefinition(columns map[string]struct{}) string {
+	expr := fmt.Sprintf("toString(SpanAttributes['otel.scope.name']) = '%s'", ebpfScopeName)
+	if _, ok := columns[scopeNameColumn]; ok {
+		// Keep the attribute arm alongside the column: a table upgraded across
+		// the boundary holds spans written under both schemas.
+		expr = fmt.Sprintf("%s = '%s' OR %s", scopeNameColumn, ebpfScopeName, expr)
+	}
+	return fmt.Sprintf("LowCardinality(String) MATERIALIZED CASE WHEN %s THEN 'ebpf' ELSE 'otel' END CODEC(ZSTD(1))", expr)
+}
+
+// requiredColumns resolves the schema-dependent definitions against a table's
+// actual column set.
+func requiredColumns(columns map[string]struct{}) map[string]string {
+	out := make(map[string]string, len(materializedColumns))
+	for name, def := range materializedColumns {
+		if name == "trace_source" {
+			def = traceSourceDefinition(columns)
+		}
+		out[name] = def
+	}
+	return out
+}
+
+// EnsureMaterializedColumns brings otel_traces up to the materialized-column
+// schema and reports whether the table now carries all of them — the value the
+// heartbeat's hasMaterializedColumn flag must carry.
+//
+// Safe to call repeatedly: it diffs against system.columns and only issues DDL
+// for what is missing or stale. ADD COLUMN ... MATERIALIZED is a metadata-only
+// operation in ClickHouse — existing parts keep their data and compute the
+// expression on read — so this does not rewrite the table.
+//
+// Every failure path returns false rather than an error the caller must handle
+// as fatal: reporting "no materialized columns" costs a slower query shape,
+// which is exactly the degraded mode the backend already supports.
+func EnsureMaterializedColumns(ctx context.Context, c *Client, logger *slog.Logger) bool {
+	if c == nil {
+		return false
+	}
+	columns, err := tableColumns(ctx, c)
+	if err != nil {
+		logger.Warn("clickhouse: cannot read otel_traces columns; reporting no materialized columns", "err", err)
+		return false
+	}
+	if len(columns) == 0 {
+		// The exporter creates the table lazily on the first span batch. Nothing
+		// to alter yet; a later tick picks it up.
+		logger.Info("clickhouse: otel_traces does not exist yet; skipping materialized-column setup")
+		return false
+	}
+
+	required := requiredColumns(columns)
+	var adds []string
+	for name, def := range required {
+		if _, ok := columns[name]; !ok {
+			adds = append(adds, fmt.Sprintf("ADD COLUMN %s %s", name, def))
+		}
+	}
+	// A trace_source carried over from an install that predates the collector
+	// upgrade still tests only SpanAttributes['otel.scope.name'], which is empty
+	// on every span the new collector writes — it would silently classify all
+	// traffic as 'otel'. Name-presence alone can't catch that, so compare the
+	// stored expression against what this schema should have.
+	if stale, err := traceSourceIsStale(ctx, c, columns); err != nil {
+		logger.Warn("clickhouse: cannot inspect trace_source definition", "err", err)
+	} else if stale {
+		adds = append(adds, fmt.Sprintf("MODIFY COLUMN trace_source %s", required["trace_source"]))
+	}
+
+	if len(adds) == 0 {
+		return hasAll(columns, required)
+	}
+
+	sort.Strings(adds)
+	stmt := fmt.Sprintf("ALTER TABLE %s.%s %s", c.Database, TracesTable, strings.Join(adds, ", "))
+	res, err := c.Query(ctx, stmt, nil)
+	if err != nil {
+		logger.Warn("clickhouse: materialized-column ALTER failed", "err", err)
+		return false
+	}
+	if res.Error != nil {
+		logger.Warn("clickhouse: materialized-column ALTER failed", "err", *res.Error)
+		return false
+	}
+	logger.Info("clickhouse: otel_traces materialized columns updated", "statements", len(adds))
+
+	// Re-read rather than assume: a partially applied ALTER must not report
+	// success, or the backend selects columns that aren't there.
+	columns, err = tableColumns(ctx, c)
+	if err != nil {
+		logger.Warn("clickhouse: cannot re-read otel_traces columns after ALTER", "err", err)
+		return false
+	}
+	return hasAll(columns, required)
+}
+
+// hasAll reports whether every required column is present. Deliberately a set
+// comparison and not a count: the legacy probe asserted `count() = 14`, so
+// adding a column to the set would have flipped every install to the slow path
+// until each one had been altered.
+func hasAll(columns map[string]struct{}, required map[string]string) bool {
+	for name := range required {
+		if _, ok := columns[name]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// tableColumns returns the column names of otel_traces. An absent table yields
+// an empty set, not an error — that is the normal pre-first-span state.
+func tableColumns(ctx context.Context, c *Client) (map[string]struct{}, error) {
+	q := fmt.Sprintf(
+		"SELECT name FROM system.columns WHERE database = '%s' AND table = '%s'",
+		escapeLiteral(c.Database), escapeLiteral(TracesTable),
+	)
+	res, err := c.Query(ctx, q, nil)
+	if err != nil {
+		return nil, err
+	}
+	if res.Error != nil {
+		return nil, fmt.Errorf("%s", *res.Error)
+	}
+	out := make(map[string]struct{}, len(res.Data))
+	for _, row := range res.Data {
+		if len(row) == 0 {
+			continue
+		}
+		if name, ok := row[0].(string); ok && name != "" {
+			out[name] = struct{}{}
+		}
+	}
+	return out, nil
+}
+
+// traceSourceIsStale reports whether an existing trace_source column was built
+// without the ScopeName arm on a table that now has ScopeName.
+func traceSourceIsStale(ctx context.Context, c *Client, columns map[string]struct{}) (bool, error) {
+	if _, ok := columns["trace_source"]; !ok {
+		return false, nil
+	}
+	if _, ok := columns[scopeNameColumn]; !ok {
+		// Without the column there is nothing better to migrate to.
+		return false, nil
+	}
+	q := fmt.Sprintf(
+		"SELECT default_expression FROM system.columns WHERE database = '%s' AND table = '%s' AND name = 'trace_source'",
+		escapeLiteral(c.Database), escapeLiteral(TracesTable),
+	)
+	res, err := c.Query(ctx, q, nil)
+	if err != nil {
+		return false, err
+	}
+	if res.Error != nil {
+		return false, fmt.Errorf("%s", *res.Error)
+	}
+	if len(res.Data) == 0 || len(res.Data[0]) == 0 {
+		return false, nil
+	}
+	expr, _ := res.Data[0][0].(string)
+	return !strings.Contains(expr, scopeNameColumn), nil
+}
+
+// escapeLiteral escapes a value for a single-quoted ClickHouse string literal.
+func escapeLiteral(s string) string {
+	return strings.NewReplacer(`\`, `\\`, `'`, `\'`).Replace(s)
+}

--- a/runner/pkg/clickhouse/schema_test.go
+++ b/runner/pkg/clickhouse/schema_test.go
@@ -308,3 +308,38 @@ func TestEnsure_RealRackspaceSchema(t *testing.T) {
 		t.Errorf("issued DDL against a table that needs none: %v", s.alters)
 	}
 }
+
+// CLICKHOUSE_DB is operator-supplied and may contain characters the parser
+// rejects unquoted — a hyphen being the likely one. The identifier position in
+// the ALTER takes backticks, which is a different quoting rule from the string
+// literal the same name sits in inside the system.columns predicate.
+func TestEnsure_QuotesHyphenatedDatabase(t *testing.T) {
+	s := &chStub{
+		columns:           []string{"Timestamp", "SpanAttributes", scopeNameColumn},
+		columnsAfterAlter: append([]string{"Timestamp", "SpanAttributes", scopeNameColumn}, allMaterialized()...),
+	}
+	srv := s.server(t)
+	srv.Database = "nudgebee-agent-dev"
+
+	if got := EnsureMaterializedColumns(context.Background(), srv, discardLogger()); !got {
+		t.Fatal("EnsureMaterializedColumns = false; want true")
+	}
+	if len(s.alters) != 1 {
+		t.Fatalf("issued %d ALTERs; want 1", len(s.alters))
+	}
+	if !strings.Contains(s.alters[0], "ALTER TABLE `nudgebee-agent-dev`.`otel_traces`") {
+		t.Errorf("unquoted identifiers would be a parse error:\n%s", s.alters[0])
+	}
+}
+
+func TestQuoteIdent(t *testing.T) {
+	for in, want := range map[string]string{
+		"default":            "`default`",
+		"nudgebee-agent-dev": "`nudgebee-agent-dev`",
+		"we`ird":             "`we\\`ird`",
+	} {
+		if got := quoteIdent(in); got != want {
+			t.Errorf("quoteIdent(%q) = %q; want %q", in, got, want)
+		}
+	}
+}

--- a/runner/pkg/clickhouse/schema_test.go
+++ b/runner/pkg/clickhouse/schema_test.go
@@ -1,0 +1,310 @@
+package clickhouse
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// chStub is a ClickHouse stand-in that answers system.columns reads from a
+// column list and records the DDL it is handed.
+type chStub struct {
+	columns      []string
+	traceSrcExpr string
+	alters       []string
+	failAlter    bool
+	// columnsAfterAlter, when non-nil, is served by system.columns reads that
+	// follow an ALTER — the re-read EnsureMaterializedColumns does to confirm
+	// the statement actually landed.
+	columnsAfterAlter []string
+	altered           bool
+}
+
+func (s *chStub) server(t *testing.T) *Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		q := string(body)
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case strings.Contains(q, "ALTER TABLE"):
+			s.alters = append(s.alters, q)
+			s.altered = true
+			if s.failAlter {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte("Code: 47. DB::Exception: Unknown identifier"))
+				return
+			}
+			_, _ = w.Write([]byte(`{"meta":[],"data":[]}`))
+
+		case strings.Contains(q, "default_expression"):
+			rows := [][]any{}
+			if s.traceSrcExpr != "" {
+				rows = append(rows, []any{s.traceSrcExpr})
+			}
+			writeRows(w, "default_expression", rows)
+
+		case strings.Contains(q, "system.columns"):
+			cols := s.columns
+			if s.altered && s.columnsAfterAlter != nil {
+				cols = s.columnsAfterAlter
+			}
+			rows := make([][]any, 0, len(cols))
+			for _, c := range cols {
+				rows = append(rows, []any{c})
+			}
+			writeRows(w, "name", rows)
+
+		default:
+			t.Errorf("unexpected query: %s", q)
+			writeRows(w, "x", nil)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return New(Config{Host: strings.TrimPrefix(srv.URL, "http://"), Database: "default"})
+}
+
+func writeRows(w http.ResponseWriter, col string, rows [][]any) {
+	if rows == nil {
+		rows = [][]any{}
+	}
+	payload := map[string]any{
+		"meta": []map[string]string{{"name": col, "type": "String"}},
+		"data": rows,
+	}
+	b, _ := json.Marshal(payload)
+	_, _ = w.Write(b)
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// allMaterialized is every column this package manages.
+func allMaterialized() []string {
+	out := make([]string, 0, len(materializedColumns))
+	for name := range materializedColumns {
+		out = append(out, name)
+	}
+	return out
+}
+
+// A pre-0.156 table has no ScopeName column, so the trace_source definition
+// must not reference it — doing so fails the whole ALTER at name resolution,
+// which is the exact bug this schema work exists to stop.
+func TestTraceSourceDefinition_OmitsScopeNameWhenColumnAbsent(t *testing.T) {
+	def := traceSourceDefinition(map[string]struct{}{"SpanAttributes": {}})
+	if strings.Contains(def, scopeNameColumn) {
+		t.Errorf("definition references %s on a table without it:\n%s", scopeNameColumn, def)
+	}
+	if !strings.Contains(def, "otel.scope.name") {
+		t.Errorf("definition dropped the attribute fallback:\n%s", def)
+	}
+}
+
+// On a 0.157 table the attribute is empty on every span, so the column arm has
+// to be present or every trace is classified 'otel'.
+func TestTraceSourceDefinition_UsesScopeNameWhenColumnPresent(t *testing.T) {
+	def := traceSourceDefinition(map[string]struct{}{scopeNameColumn: {}})
+	if !strings.Contains(def, scopeNameColumn+" = '"+ebpfScopeName+"'") {
+		t.Errorf("definition missing the %s arm:\n%s", scopeNameColumn, def)
+	}
+	// Spans written before the upgrade are still in the table.
+	if !strings.Contains(def, "otel.scope.name") {
+		t.Errorf("definition dropped the attribute arm:\n%s", def)
+	}
+}
+
+// A bare OTel exporter table gets every managed column added.
+func TestEnsure_AddsAllColumnsToFreshTable(t *testing.T) {
+	s := &chStub{
+		columns:           []string{"Timestamp", "TraceId", "SpanAttributes", "ResourceAttributes", scopeNameColumn},
+		columnsAfterAlter: append([]string{"Timestamp", "TraceId", "SpanAttributes", "ResourceAttributes", scopeNameColumn}, allMaterialized()...),
+	}
+	if got := EnsureMaterializedColumns(context.Background(), s.server(t), discardLogger()); !got {
+		t.Fatal("EnsureMaterializedColumns = false; want true")
+	}
+	if len(s.alters) != 1 {
+		t.Fatalf("issued %d ALTERs; want 1", len(s.alters))
+	}
+	for name := range materializedColumns {
+		if !strings.Contains(s.alters[0], "ADD COLUMN "+name+" ") {
+			t.Errorf("ALTER missing column %q:\n%s", name, s.alters[0])
+		}
+	}
+}
+
+// Rackspace's shape: the legacy agent already created all 14. Nothing to do,
+// and the flag must come back true — reporting false is what forced installs
+// with working columns onto the recompute query shape.
+func TestEnsure_NoDDLWhenAlreadyComplete(t *testing.T) {
+	cols := append([]string{"Timestamp", "SpanAttributes"}, allMaterialized()...)
+	s := &chStub{columns: cols}
+	if got := EnsureMaterializedColumns(context.Background(), s.server(t), discardLogger()); !got {
+		t.Fatal("EnsureMaterializedColumns = false; want true")
+	}
+	if len(s.alters) != 0 {
+		t.Errorf("issued %d ALTERs on a complete table; want 0:\n%v", len(s.alters), s.alters)
+	}
+}
+
+// An install carried across the collector upgrade keeps a trace_source built
+// only from the span attribute, which the new collector no longer populates.
+// Name-presence alone can't see that, so the stored expression is compared.
+func TestEnsure_RewritesStaleTraceSource(t *testing.T) {
+	cols := append([]string{"Timestamp", "SpanAttributes", scopeNameColumn}, allMaterialized()...)
+	s := &chStub{
+		columns:      cols,
+		traceSrcExpr: "CASE WHEN toString(SpanAttributes['otel.scope.name']) = 'nudgebee-node-agent' THEN 'ebpf' ELSE 'otel' END",
+	}
+	if got := EnsureMaterializedColumns(context.Background(), s.server(t), discardLogger()); !got {
+		t.Fatal("EnsureMaterializedColumns = false; want true")
+	}
+	if len(s.alters) != 1 || !strings.Contains(s.alters[0], "MODIFY COLUMN trace_source") {
+		t.Fatalf("expected a MODIFY COLUMN trace_source; got %v", s.alters)
+	}
+	if !strings.Contains(s.alters[0], scopeNameColumn+" = '"+ebpfScopeName+"'") {
+		t.Errorf("rewritten definition missing the %s arm:\n%s", scopeNameColumn, s.alters[0])
+	}
+}
+
+// The same stale-looking definition on a table that has no ScopeName is
+// correct, not stale — rewriting it would break the install.
+func TestEnsure_LeavesTraceSourceAloneWithoutScopeName(t *testing.T) {
+	cols := append([]string{"Timestamp", "SpanAttributes"}, allMaterialized()...)
+	s := &chStub{
+		columns:      cols,
+		traceSrcExpr: "CASE WHEN toString(SpanAttributes['otel.scope.name']) = 'nudgebee-node-agent' THEN 'ebpf' ELSE 'otel' END",
+	}
+	if got := EnsureMaterializedColumns(context.Background(), s.server(t), discardLogger()); !got {
+		t.Fatal("EnsureMaterializedColumns = false; want true")
+	}
+	if len(s.alters) != 0 {
+		t.Errorf("rewrote a correct definition: %v", s.alters)
+	}
+}
+
+// The exporter creates otel_traces lazily on its first span batch, so an agent
+// that starts first sees no table. That is not an error, and it must not be
+// reported as "columns present".
+func TestEnsure_AbsentTableReportsFalseWithoutDDL(t *testing.T) {
+	s := &chStub{columns: nil}
+	if got := EnsureMaterializedColumns(context.Background(), s.server(t), discardLogger()); got {
+		t.Error("EnsureMaterializedColumns = true for a missing table; want false")
+	}
+	if len(s.alters) != 0 {
+		t.Errorf("issued DDL against a missing table: %v", s.alters)
+	}
+}
+
+// A rejected ALTER must report false: claiming the columns exist makes the
+// backend SELECT columns that aren't there, turning a slow query into a failed
+// one.
+func TestEnsure_FailedAlterReportsFalse(t *testing.T) {
+	s := &chStub{
+		columns:   []string{"Timestamp", "SpanAttributes"},
+		failAlter: true,
+	}
+	if got := EnsureMaterializedColumns(context.Background(), s.server(t), discardLogger()); got {
+		t.Error("EnsureMaterializedColumns = true after a failed ALTER; want false")
+	}
+}
+
+// A partially applied ALTER must not report success either — hence the re-read
+// rather than trusting the statement's exit status.
+func TestEnsure_PartialAlterReportsFalse(t *testing.T) {
+	s := &chStub{
+		columns:           []string{"Timestamp", "SpanAttributes"},
+		columnsAfterAlter: []string{"Timestamp", "SpanAttributes", "workload_name"},
+	}
+	if got := EnsureMaterializedColumns(context.Background(), s.server(t), discardLogger()); got {
+		t.Error("EnsureMaterializedColumns = true after a partial ALTER; want false")
+	}
+}
+
+func TestEnsure_NilClientReportsFalse(t *testing.T) {
+	if EnsureMaterializedColumns(context.Background(), nil, discardLogger()) {
+		t.Error("EnsureMaterializedColumns = true for a nil client; want false")
+	}
+}
+
+// hasAll is a set check, not a count: the legacy probe asserted `count() = 14`,
+// so adding a 15th column would have flipped every existing install to the slow
+// path until it had been altered.
+func TestHasAll_IgnoresExtraColumns(t *testing.T) {
+	required := map[string]string{"a": "", "b": ""}
+	cols := map[string]struct{}{"a": {}, "b": {}, "unrelated": {}}
+	if !hasAll(cols, required) {
+		t.Error("hasAll = false when every required column is present")
+	}
+	if hasAll(map[string]struct{}{"a": {}}, required) {
+		t.Error("hasAll = true with a required column missing")
+	}
+}
+
+// The two schemas actually in the fleet, captured from live clusters. They are
+// mutually exclusive — one has ScopeName and no materialized columns, the other
+// has the materialized columns and no ScopeName — which is why the definition
+// has to be chosen from the real column set rather than written as one static
+// expression with an OR fallback.
+var (
+	// nudgebee-agent-dev, otel-collector 0.157: the flattened exporter schema.
+	// SpanAttributes['otel.scope.name'] is empty on every span here.
+	devSchema = []string{
+		"Timestamp", "TraceId", "SpanId", "ParentSpanId", "TraceState", "SpanName", "SpanKind",
+		"ServiceName", "ResourceAttributes", "ScopeName", "ScopeVersion", "SpanAttributes",
+		"Duration", "StatusCode", "StatusMessage",
+		"Events.Timestamp", "Events.Name", "Events.Attributes",
+		"Links.TraceId", "Links.SpanId", "Links.TraceState", "Links.Attributes",
+	}
+	// nudgebee-rackspace, pre-0.156 exporter plus the 14 columns the legacy
+	// Python runner added before the Go rewrite. No ScopeName column at all.
+	rackspaceSchema = []string{
+		"Timestamp", "TraceId", "SpanId", "ParentSpanId", "TraceState", "SpanName", "SpanKind",
+		"ServiceName", "ResourceAttributes", "SpanAttributes", "Duration", "StatusCode", "StatusMessage",
+		"Events.Timestamp", "Events.Name", "Events.Attributes",
+		"Links.TraceId", "Links.SpanId", "Links.TraceState", "Links.Attributes",
+		"workload_namespace", "workload_name", "resource", "destination_workload_name",
+		"destination_workload_namespace", "destination_name", "headers", "http_status_code",
+		"request_payload", "http_response", "trace_source", "workload_zone",
+		"destination_workload_zone", "cloud_availability_zone",
+	}
+)
+
+// A fresh 0.157 install has none of the materialized columns; it must get all
+// of them, with trace_source reading the ScopeName column.
+func TestEnsure_RealDevSchema(t *testing.T) {
+	s := &chStub{columns: devSchema, columnsAfterAlter: append(append([]string{}, devSchema...), allMaterialized()...)}
+	if got := EnsureMaterializedColumns(context.Background(), s.server(t), discardLogger()); !got {
+		t.Fatal("EnsureMaterializedColumns = false; want true")
+	}
+	if len(s.alters) != 1 {
+		t.Fatalf("issued %d ALTERs; want 1", len(s.alters))
+	}
+	if !strings.Contains(s.alters[0], "ADD COLUMN trace_source") ||
+		!strings.Contains(s.alters[0], scopeNameColumn+" = '"+ebpfScopeName+"'") {
+		t.Errorf("trace_source must read the ScopeName column on this schema:\n%s", s.alters[0])
+	}
+}
+
+// Rackspace already has all 14 and no ScopeName. The correct outcome is no DDL
+// at all and a true flag — the mis-reported false is what pushed it onto the
+// recompute query shape, which then referenced a column its table lacks.
+func TestEnsure_RealRackspaceSchema(t *testing.T) {
+	s := &chStub{
+		columns:      rackspaceSchema,
+		traceSrcExpr: "CASE WHEN toString(SpanAttributes['otel.scope.name']) = 'nudgebee-node-agent' THEN 'ebpf' ELSE 'otel' END",
+	}
+	if got := EnsureMaterializedColumns(context.Background(), s.server(t), discardLogger()); !got {
+		t.Fatal("EnsureMaterializedColumns = false; want true — the columns are all present")
+	}
+	if len(s.alters) != 0 {
+		t.Errorf("issued DDL against a table that needs none: %v", s.alters)
+	}
+}

--- a/runner/pkg/telemetry/service.go
+++ b/runner/pkg/telemetry/service.go
@@ -181,6 +181,16 @@ type Datasources struct {
 	// by the caller. Empty when ClickHouse is healthy or was never probed
 	// (unconfigured / disabled). Surfaced as tracesConnectionError.
 	ClickHouseError string
+	// HasMaterializedColumns reports whether otel_traces carries the
+	// agent-added materialized columns (workload_name, trace_source, …).
+	// Reported to the backend as traceProviderConfig.hasMaterializedColumn,
+	// which selects between reading those columns directly and recomputing
+	// them from SpanAttributes/ResourceAttributes on every query.
+	//
+	// Computed by the caller via clickhouse.EnsureMaterializedColumns, which
+	// also creates the columns when they are missing. False whenever the
+	// schema could not be confirmed — the recompute shape is the safe default.
+	HasMaterializedColumns bool
 
 	// Node-agent: count of `up{job=~"...nudgebee(-.*)?-node-agent"}` from
 	// Prometheus, computed by the caller.
@@ -407,11 +417,17 @@ func (s *Service) probe(ctx context.Context, ds Datasources) ActivityStats {
 	if !out.TracesEnabled {
 		out.TracesConnectionError = ds.ClickHouseError
 	}
-	// traceProviderConfig: the legacy code queries ClickHouse for the
-	// otel_traces materialized-column flag. The agent doesn't run a
-	// local ClickHouse anymore; the backend computes this. Emit an
-	// empty dict so the field shape matches.
-	out.TraceProviderConfig = map[string]any{"hasMaterializedColumn": false}
+	// traceProviderConfig: the otel_traces materialized-column flag, which
+	// picks which of two SQL shapes the backend uses for every trace query.
+	// The caller probes the real schema (clickhouse.EnsureMaterializedColumns)
+	// and passes the answer in — this package stays free of a ClickHouse
+	// dependency, same as NodeAgentCount and the logs-provider status.
+	//
+	// This was hardcoded false for the whole of the Go rewrite, on the
+	// assumption the backend recomputed it. The backend reads the field back
+	// verbatim, so installs that did have the columns were told they didn't
+	// and were forced onto the recompute-from-attributes query shape.
+	out.TraceProviderConfig = map[string]any{"hasMaterializedColumn": ds.HasMaterializedColumns}
 
 	return out
 }

--- a/runner/pkg/telemetry/service_test.go
+++ b/runner/pkg/telemetry/service_test.go
@@ -445,7 +445,10 @@ func TestActivityStats_TracesConnectionErrorAlwaysEmitted(t *testing.T) {
 // an undrained body would open a fresh TCP connection each time.
 func TestHTTPHealth_HealthyProbeReusesConnection(t *testing.T) {
 	var conns int32
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	// Unstarted, because ConnState has to be installed before the accept loop
+	// is running: NewServer starts serving immediately and the server goroutine
+	// reads Config.ConnState, so assigning it afterwards is a data race.
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		// Larger than the 512-byte snippet limit: an undrained body of this
 		// size is what breaks connection reuse.
 		_, _ = w.Write([]byte(strings.Repeat("x", 4096)))
@@ -455,6 +458,7 @@ func TestHTTPHealth_HealthyProbeReusesConnection(t *testing.T) {
 			atomic.AddInt32(&conns, 1)
 		}
 	}
+	srv.Start()
 	defer srv.Close()
 
 	c := srv.Client()

--- a/runner/pkg/telemetry/service_test.go
+++ b/runner/pkg/telemetry/service_test.go
@@ -410,6 +410,23 @@ func TestProbe_TracesConnectionError(t *testing.T) {
 	}
 }
 
+// hasMaterializedColumn selects which of two SQL shapes the backend uses for
+// every trace query, and the backend reads this field back verbatim rather than
+// recomputing it. It was hardcoded false for the whole of the Go rewrite, so
+// installs that did have the columns were forced onto the recompute shape —
+// which on a pre-0.156 table also references a column that isn't there and
+// fails outright. Pin that it reflects the caller's probe in both directions.
+func TestProbe_HasMaterializedColumnReflectsSchema(t *testing.T) {
+	s := &Service{Logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	for _, want := range []bool{true, false} {
+		ds := Datasources{ClickHouseStatus: true, ClickHouseURL: "ch.svc", HasMaterializedColumns: want}
+		got := s.probe(context.Background(), ds).TraceProviderConfig["hasMaterializedColumn"]
+		if got != want {
+			t.Errorf("hasMaterializedColumn = %v; want %v", got, want)
+		}
+	}
+}
+
 // tracesConnectionError must survive JSON marshalling as an explicit "" rather
 // than vanishing — see the jsonb-merge note on the field.
 func TestActivityStats_TracesConnectionErrorAlwaysEmitted(t *testing.T) {


### PR DESCRIPTION
## Summary

The backend picks one of two SQL shapes for every trace query from the `hasMaterializedColumn` flag we report in the heartbeat — read the materialized columns directly, or recompute all of them from raw `SpanAttributes`/`ResourceAttributes` on every scan. Those columns aren't part of the OTel exporter's schema; the agent adds them.

The legacy Python runner did both halves — `safe_alter_clickhouse_table()` created the 14 columns at startup, `get_trace_provider_config()` probed `system.columns` to answer the flag. **Neither survived the Go rewrite.** The flag became a hardcoded `false` deferring to a backend computation that was never written, and the columns stopped being created at all.

Two regressions followed:

1. **Installs that already had the columns were told they didn't.** They get forced onto the recompute shape — which on a pre-0.156 exporter table also references `ScopeName`, a column those tables don't have. ClickHouse fails at name resolution and *every* trace read 404s. This is live on Rackspace right now: **1,284 failed trace queries / 24h**, killing the Insight-refresh cron.
2. **Fresh installs never get the columns**, so they recompute those expressions on every query forever.

This restores both halves in `EnsureMaterializedColumns`, called from the telemetry probe.

## Not a verbatim port — three deliberate changes

- **`trace_source`'s definition is chosen from the table's real column set.** The collector upgrade moved the scope name out of `SpanAttributes` into the `ScopeName` column — on 0.157 tables `SpanAttributes['otel.scope.name']` is empty on every span, on pre-0.156 tables `ScopeName` doesn't exist. No single expression works on both, and a bare reference to a missing column fails the whole `ALTER` — the same defect this fixes, relocated into DDL. (An `OR` arm can't rescue it: ClickHouse resolves identifiers before evaluating.)
- **Stale definitions get rewritten.** A `trace_source` built only from the attribute is `MODIFY`d once the table has `ScopeName`. Otherwise the new collector — which never populates that attribute — would silently classify all traffic as `'otel'`, and a name-only diff can't see it.
- **Presence is a set comparison, not `count() = 14`.** The legacy probe's hardcoded count meant adding a 15th column would flip every install to the slow path until each was altered.

## Safety

`ADD COLUMN ... MATERIALIZED` is metadata-only — no table rewrite; existing parts compute on read. Every failure path reports `false`, which costs the slower query shape rather than pointing the backend at columns that aren't there. A post-`ALTER` re-read means a partially applied statement can't report success. The check retries until confirmed, since the exporter creates `otel_traces` lazily on its first span batch.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (chart upgrade requires user action)
- [ ] Documentation only
- [ ] CI / tooling

## Chart version

- [ ] I bumped `version` in `charts/nudgebee-agent/Chart.yaml`
- [x] No version bump needed — runner Go code only, matching #580 / #574 / #512

## Test plan

`go build`, `go vet`, `gofmt` all clean. 13 tests pass under `-race`.

Fixtures are the **two real schemas in the fleet**, captured from live clusters:

| test | schema | expected |
|---|---|---|
| `TestEnsure_RealDevSchema` | `nudgebee-agent-dev`, 22-col 0.157 | one `ALTER`, all 14 added, `trace_source` reads `ScopeName` |
| `TestEnsure_RealRackspaceSchema` | `nudgebee-rackspace`, 34-col pre-0.156, columns already present | **zero DDL, flag `true`** — the mis-report that caused this |

Plus: fresh-table add, no-op when complete, stale-definition rewrite, correct-definition left alone, absent table, failed `ALTER`, partial `ALTER`, nil client.

Verified against the live clusters while diagnosing:

- Rackspace `otel_traces`: no `ScopeName`; `SpanAttributes['otel.scope.name']` present on 31,663/31,663 spans; all 14 columns `default_kind='MATERIALIZED'`; `trace_source` correctly split ebpf 27,253 / otel 1,263 — yet the agent reports `hasMaterializedColumn: false`.
- Dev `otel_traces`: `ScopeName` populated on 336,629/336,629 spans; `SpanAttributes['otel.scope.name']` on **0**.

Not run: `helm lint` / `ct lint` / `helm template` — no chart files touched.

## Known gaps

- **Rackspace isn't fixed by this PR alone.** Its agent is `0.1.3` (fleet is `0.1.18`–`0.1.20`); it won't pick this up until that upgrade. The immediate mitigation is flipping `hasMaterializedColumn` to `true` in that agent's `connection_status` — an ops action, not code.
- The api-server's non-materialized `ScopeName` expression stays latently broken for external/unmanaged ClickHouse the agent can't `ALTER`. Much rarer after this, but the same bug — separate PR.
- `pkg/observability/signoz/client.go:142` has a pre-existing gosec SSRF finding, untouched here.

## Two follow-up commits

- **`6706619`** — backtick-quote the database/table in the `ALTER`, from @gemini-code-assist's review. A hyphenated `CLICKHOUSE_DB` would be a parse error. Done via a `quoteIdent` helper rather than inline backticks, since the same name is a quoted *identifier* in the DDL but a *string literal* in the `system.columns` predicate, and one escaper can't serve both.

- **`f3ccf7f`** — unrelated pre-existing test bug that turns this PR's CI red. `TestHTTPHealth_HealthyProbeReusesConnection` assigns `srv.Config.ConnState` *after* `httptest.NewServer` has already started serving; the server goroutine reads that field, so `-race` fails the whole `telemetry` package. Fixed with `NewUnstartedServer` → set hook → `Start()`.

  It is not from this change — reproduced on a pristine worktree at `HEAD`. It stayed hidden because `runner-lint-test.yaml` is path-filtered to `runner/**`, and every push to `main` since the test landed (in #512) has been chart-only, so the Go job never ran there. **It will fail every PR that touches `runner/`,** which is why it's fixed here rather than deferred. Happy to split it out if you'd rather it land on its own.

## Related issues

Refs nudgebee/nudgebee-enterprise#36569

