### PR TITLE
fix(runner): stamp Prometheus ruleSelector labels on UI-created alert rules

### DIFF
--- a/charts/nudgebee-agent/Chart.yaml
+++ b/charts/nudgebee-agent/Chart.yaml
@@ -29,8 +29,8 @@ annotations:
 # these are set to the right value by .github/workflows/release.yaml
 # we use 0.0.1 as a placeholder for the version` because Helm wont allow `0.0.0` and we want to be able to run
 # `helm install` on development checkouts without updating this file. the version doesn't matter in that case anyway
-version: 0.1.20
-appVersion: 0.1.20
+version: 0.1.21
+appVersion: 0.1.21
 dependencies:
 - name: opencost
   version: 2.0.1

--- a/charts/nudgebee-agent/templates/runner-service-account-readonly.yaml
+++ b/charts/nudgebee-agent/templates/runner-service-account-readonly.yaml
@@ -245,6 +245,17 @@ rules:
       - get
       - list
 
+  # ruleSelector discovery: the runner reads the Prometheus CR's
+  # spec.ruleSelector.matchLabels so UI-created PrometheusRules carry the
+  # labels prometheus-operator requires before it will load them. Read-only.
+  - apiGroups:
+      - "monitoring.coreos.com"
+    resources:
+      - prometheuses
+    verbs:
+      - get
+      - list
+
   - apiGroups: ["metrics.k8s.io"]
     resources:
       - pods

--- a/charts/nudgebee-agent/templates/runner-service-account.yaml
+++ b/charts/nudgebee-agent/templates/runner-service-account.yaml
@@ -292,6 +292,17 @@ rules:
       - create
       - patch
       - update
+
+  # ruleSelector discovery: the runner reads the Prometheus CR's
+  # spec.ruleSelector.matchLabels so UI-created PrometheusRules carry the
+  # labels prometheus-operator requires before it will load them. Read-only.
+  - apiGroups:
+      - "monitoring.coreos.com"
+    resources:
+      - prometheuses
+    verbs:
+      - get
+      - list
       
   - apiGroups: ["metrics.k8s.io"]
     resources:

--- a/charts/nudgebee-agent/values.yaml
+++ b/charts/nudgebee-agent/values.yaml
@@ -65,7 +65,7 @@ runnerServiceAccount:
 runner:
   image:
     repository: ghcr.io/nudgebee/nudgebee-agent
-    tag: 2026-08-21T04-52-57_69969e0c6fe96582e280263cadf95dfd7e994ced
+    tag: 2026-08-24T09-42-04_0f10111ed800d714b84730349bd12f212adc89c1
   # Image template the pod_profiler action launches debugger pods from.
   # The agent substitutes `{}` for the variant (bpf, jvm, python, perf, ruby).
   # Surfaces as PROFILER_IMAGE; leave empty to fall back to the binary default.

--- a/runner/pkg/mutate/alertrules.go
+++ b/runner/pkg/mutate/alertrules.go
@@ -146,6 +146,10 @@ func (m *Mutator) CreateOrReplaceAlertRule(ctx context.Context, p LegacyAlertRul
 		rule["for"] = p.Duration
 	}
 
+	// Resolve once, outside the retry loop: the selector can't change between
+	// conflict retries, and each lookup is an extra apiserver call.
+	selectorLabels := m.ruleSelectorLabels(ctx)
+
 	ri := m.dynamic.Resource(prometheusRuleGVR).Namespace(m.Namespace)
 	// Shared CR + concurrent UI sessions → 409 Conflict whenever two callers
 	// land between Get and Update. RetryOnConflict re-reads + re-applies the
@@ -156,7 +160,7 @@ func (m *Mutator) CreateOrReplaceAlertRule(ctx context.Context, p LegacyAlertRul
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		existing, gerr := ri.Get(ctx, LegacyAlertRuleCRDName, metav1.GetOptions{})
 		if apierrors.IsNotFound(gerr) {
-			u := newLegacyAlertRuleCR(m.Namespace, []any{rule})
+			u := newLegacyAlertRuleCR(m.Namespace, []any{rule}, selectorLabels)
 			created, cerr := ri.Create(ctx, u, metav1.CreateOptions{})
 			if cerr != nil {
 				if apierrors.IsAlreadyExists(cerr) {
@@ -191,6 +195,11 @@ func (m *Mutator) CreateOrReplaceAlertRule(ctx context.Context, p LegacyAlertRul
 		if serr := unstructured.SetNestedSlice(existing.Object, groups, "spec", "groups"); serr != nil {
 			return serr
 		}
+		// Heal a CR created before selector labels were stamped (or after the
+		// Prometheus release was renamed): without this, every rule written
+		// into an already-mislabelled CR stays invisible to prometheus-operator
+		// forever, since labels were only ever set on create.
+		applySelectorLabels(existing, selectorLabels)
 
 		updated, uerr := ri.Update(ctx, existing, metav1.UpdateOptions{})
 		if uerr != nil {
@@ -284,20 +293,49 @@ func replaceLegacyRuleInPlace(groups []any, alert string, rule map[string]any) b
 	return false
 }
 
+// applySelectorLabels adds any missing selector labels to an existing CR.
+// Existing values are left alone: an operator who deliberately retargeted the
+// CR keeps their edit.
+func applySelectorLabels(u *unstructured.Unstructured, selectorLabels map[string]string) {
+	if len(selectorLabels) == 0 {
+		return
+	}
+	labels := u.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	changed := false
+	for k, v := range selectorLabels {
+		if _, ok := labels[k]; !ok {
+			labels[k] = v
+			changed = true
+		}
+	}
+	if changed {
+		u.SetLabels(labels)
+	}
+}
+
 // newLegacyAlertRuleCR builds a fresh canonical PrometheusRule CR with the
 // Robusta-compat labels so a parallel legacy runner can still find it via
-// the same label selector.
-func newLegacyAlertRuleCR(namespace string, rules []any) *unstructured.Unstructured {
+// the same label selector, plus selectorLabels — the Prometheus CR's
+// ruleSelector.matchLabels, without which prometheus-operator never loads
+// the rule (see ruleSelectorLabels).
+func newLegacyAlertRuleCR(namespace string, rules []any, selectorLabels map[string]string) *unstructured.Unstructured {
+	labels := map[string]any{
+		LegacyAlertRuleLabelKey: LegacyAlertRuleLabelValue,
+		"role":                  "alert-rules",
+	}
+	for k, v := range selectorLabels {
+		labels[k] = v
+	}
 	return &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "monitoring.coreos.com/v1",
 		"kind":       "PrometheusRule",
 		"metadata": map[string]any{
 			"name":      LegacyAlertRuleCRDName,
 			"namespace": namespace,
-			"labels": map[string]any{
-				LegacyAlertRuleLabelKey: LegacyAlertRuleLabelValue,
-				"role":                  "alert-rules",
-			},
+			"labels":    labels,
 		},
 		"spec": map[string]any{
 			"groups": []any{

--- a/runner/pkg/mutate/alertrules_test.go
+++ b/runner/pkg/mutate/alertrules_test.go
@@ -13,18 +13,24 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-// promRuleScheme registers PrometheusRule so the dynamic fake recognises the GVR.
+// promRuleScheme registers PrometheusRule and Prometheus so the dynamic fake
+// recognises both GVRs. Prometheus is needed by every legacy alert-rule test:
+// that path lists Prometheus CRs to derive the ruleSelector labels.
 func promRuleScheme() *runtime.Scheme {
 	s := runtime.NewScheme()
-	gvr := prometheusRuleGVR
-	s.AddKnownTypeWithName(
-		schema.GroupVersionKind{Group: gvr.Group, Version: gvr.Version, Kind: "PrometheusRule"},
-		&unstructured.Unstructured{},
-	)
-	s.AddKnownTypeWithName(
-		schema.GroupVersionKind{Group: gvr.Group, Version: gvr.Version, Kind: "PrometheusRuleList"},
-		&unstructured.UnstructuredList{},
-	)
+	for gvr, kind := range map[schema.GroupVersionResource]string{
+		prometheusRuleGVR: "PrometheusRule",
+		prometheusGVR:     "Prometheus",
+	} {
+		s.AddKnownTypeWithName(
+			schema.GroupVersionKind{Group: gvr.Group, Version: gvr.Version, Kind: kind},
+			&unstructured.Unstructured{},
+		)
+		s.AddKnownTypeWithName(
+			schema.GroupVersionKind{Group: gvr.Group, Version: gvr.Version, Kind: kind + "List"},
+			&unstructured.UnstructuredList{},
+		)
+	}
 	return s
 }
 
@@ -418,5 +424,162 @@ func TestHandleDeletePromRule_RoutesByAlertVsName(t *testing.T) {
 		"name": "standalone", "namespace": "monitoring",
 	}); err != nil {
 		t.Fatalf("manifest-shape: %v", err)
+	}
+}
+
+// --- ruleSelector label stamping ------------------------------------------
+//
+// prometheus-operator only loads a PrometheusRule whose labels match the
+// Prometheus CR's spec.ruleSelector. A CR written without them is accepted and
+// reported healthy but never evaluated, so these tests pin the labels onto both
+// the create and the update path.
+
+func newPrometheusCR(namespace, name string, matchLabels map[string]any) *unstructured.Unstructured {
+	spec := map[string]any{}
+	if matchLabels != nil {
+		spec["ruleSelector"] = map[string]any{"matchLabels": matchLabels}
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "monitoring.coreos.com/v1",
+		"kind":       "Prometheus",
+		"metadata":   map[string]any{"name": name, "namespace": namespace},
+		"spec":       spec,
+	}}
+}
+
+func crLabels(t *testing.T, dyn *dynamicfake.FakeDynamicClient, namespace string) map[string]string {
+	t.Helper()
+	got, err := dyn.Resource(prometheusRuleGVR).Namespace(namespace).Get(
+		context.Background(), LegacyAlertRuleCRDName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("read CR: %v", err)
+	}
+	return got.GetLabels()
+}
+
+func TestCreateOrReplaceAlertRule_StampsRuleSelectorLabelsOnCreate(t *testing.T) {
+	prom := newPrometheusCR("nudgebee-agent", "kube-p-prometheus",
+		map[string]any{"release": "nudgebee-prometheus"})
+	dyn := dynamicfake.NewSimpleDynamicClient(promRuleScheme(), prom)
+	m := New(fake.NewClientset(), "", nil)
+	m.SetDynamic(dyn)
+	m.SetNamespace("nudgebee-agent")
+
+	if _, err := m.CreateOrReplaceAlertRule(context.Background(), LegacyAlertRuleParams{
+		Alert: "A", Expr: "up == 0",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	labels := crLabels(t, dyn, "nudgebee-agent")
+	if labels["release"] != "nudgebee-prometheus" {
+		t.Errorf("release label = %q, want nudgebee-prometheus (rule would never be evaluated)", labels["release"])
+	}
+	// Legacy identification labels must survive — the agent finds the CR by them.
+	if labels[LegacyAlertRuleLabelKey] != LegacyAlertRuleLabelValue || labels["role"] != "alert-rules" {
+		t.Errorf("legacy labels lost: %v", labels)
+	}
+}
+
+func TestCreateOrReplaceAlertRule_HealsExistingCRMissingSelectorLabels(t *testing.T) {
+	// A CR as written before this fix: legacy labels only, no `release`.
+	pre := newLegacyCR("nudgebee-agent", []map[string]any{{"alert": "Existing", "expr": "up"}})
+	prom := newPrometheusCR("nudgebee-agent", "kube-p-prometheus",
+		map[string]any{"release": "nudgebee-prometheus"})
+	dyn := dynamicfake.NewSimpleDynamicClient(promRuleScheme(), pre, prom)
+	m := New(fake.NewClientset(), "", nil)
+	m.SetDynamic(dyn)
+	m.SetNamespace("nudgebee-agent")
+
+	if _, err := m.CreateOrReplaceAlertRule(context.Background(), LegacyAlertRuleParams{
+		Alert: "B", Expr: "up == 0",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := crLabels(t, dyn, "nudgebee-agent")["release"]; got != "nudgebee-prometheus" {
+		t.Errorf("release label = %q, want nudgebee-prometheus (existing CR not healed)", got)
+	}
+	if rules := legacyRulesFromCR(t, dyn, "nudgebee-agent"); len(rules) != 2 {
+		t.Errorf("want 2 rules after append, got %d", len(rules))
+	}
+}
+
+func TestCreateOrReplaceAlertRule_KeepsOperatorEditedSelectorLabel(t *testing.T) {
+	pre := newLegacyCR("nudgebee-agent", nil)
+	pre.SetLabels(map[string]string{
+		LegacyAlertRuleLabelKey: LegacyAlertRuleLabelValue,
+		"release":               "hand-picked",
+	})
+	prom := newPrometheusCR("nudgebee-agent", "kube-p-prometheus",
+		map[string]any{"release": "nudgebee-prometheus"})
+	dyn := dynamicfake.NewSimpleDynamicClient(promRuleScheme(), pre, prom)
+	m := New(fake.NewClientset(), "", nil)
+	m.SetDynamic(dyn)
+	m.SetNamespace("nudgebee-agent")
+
+	if _, err := m.CreateOrReplaceAlertRule(context.Background(), LegacyAlertRuleParams{
+		Alert: "C", Expr: "up == 0",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := crLabels(t, dyn, "nudgebee-agent")["release"]; got != "hand-picked" {
+		t.Errorf("release label = %q, want hand-picked (operator edit clobbered)", got)
+	}
+}
+
+func TestCreateOrReplaceAlertRule_PrefersPrometheusInAgentNamespace(t *testing.T) {
+	other := newPrometheusCR("aaa-other-ns", "other", map[string]any{"release": "wrong"})
+	local := newPrometheusCR("nudgebee-agent", "zzz-local", map[string]any{"release": "right"})
+	dyn := dynamicfake.NewSimpleDynamicClient(promRuleScheme(), other, local)
+	m := New(fake.NewClientset(), "", nil)
+	m.SetDynamic(dyn)
+	m.SetNamespace("nudgebee-agent")
+
+	if _, err := m.CreateOrReplaceAlertRule(context.Background(), LegacyAlertRuleParams{
+		Alert: "D", Expr: "up == 0",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := crLabels(t, dyn, "nudgebee-agent")["release"]; got != "right" {
+		t.Errorf("release label = %q, want right (agent-namespace Prometheus ignored)", got)
+	}
+}
+
+func TestCreateOrReplaceAlertRule_NoPrometheusCRStillWritesRule(t *testing.T) {
+	// No Prometheus CR, or no RBAC to read one: the rule must still be written
+	// (pre-existing behaviour) rather than the whole request failing.
+	dyn := dynamicfake.NewSimpleDynamicClient(promRuleScheme())
+	m := New(fake.NewClientset(), "", nil)
+	m.SetDynamic(dyn)
+	m.SetNamespace("nudgebee-agent")
+
+	if _, err := m.CreateOrReplaceAlertRule(context.Background(), LegacyAlertRuleParams{
+		Alert: "E", Expr: "up == 0",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if rules := legacyRulesFromCR(t, dyn, "nudgebee-agent"); len(rules) != 1 {
+		t.Errorf("want 1 rule, got %d", len(rules))
+	}
+}
+
+func TestCreateOrReplaceAlertRule_IgnoresExpressionOnlySelector(t *testing.T) {
+	// matchExpressions can't be satisfied by stamping labels; don't guess.
+	prom := newPrometheusCR("nudgebee-agent", "kube-p-prometheus", nil)
+	_ = unstructured.SetNestedSlice(prom.Object, []any{
+		map[string]any{"key": "release", "operator": "Exists"},
+	}, "spec", "ruleSelector", "matchExpressions")
+	dyn := dynamicfake.NewSimpleDynamicClient(promRuleScheme(), prom)
+	m := New(fake.NewClientset(), "", nil)
+	m.SetDynamic(dyn)
+	m.SetNamespace("nudgebee-agent")
+
+	if _, err := m.CreateOrReplaceAlertRule(context.Background(), LegacyAlertRuleParams{
+		Alert: "F", Expr: "up == 0",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	labels := crLabels(t, dyn, "nudgebee-agent")
+	if len(labels) != 2 {
+		t.Errorf("labels = %v, want only the two legacy labels", labels)
 	}
 }

--- a/runner/pkg/mutate/promruleselector.go
+++ b/runner/pkg/mutate/promruleselector.go
@@ -1,0 +1,82 @@
+package mutate
+
+import (
+	"context"
+	"sort"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// Prometheus CRD GVR. Read-only: we inspect spec.ruleSelector to learn which
+// labels a PrometheusRule must carry to be picked up.
+var prometheusGVR = schema.GroupVersionResource{
+	Group: "monitoring.coreos.com", Version: "v1", Resource: "prometheuses",
+}
+
+// ruleSelectorLabels returns the labels a PrometheusRule must carry for the
+// cluster's Prometheus to select it, read from the Prometheus CR's
+// spec.ruleSelector.matchLabels.
+//
+// Why this is discovered instead of hardcoded: prometheus-operator only
+// evaluates a PrometheusRule whose labels match the Prometheus CR's
+// ruleSelector. kube-prometheus-stack defaults that to
+// `release: <its own Helm release name>`, which is NOT the agent's release
+// name — the two are separate Helm releases in every install we ship. A
+// PrometheusRule written without those labels is accepted by the apiserver,
+// reported healthy, and never evaluated: the rule silently does nothing.
+//
+// A Prometheus CR in the agent's own namespace wins; otherwise the
+// cluster-wide list is used, sorted by namespace/name so the choice is
+// deterministic when several exist. Any failure (no RBAC, CRD absent, no
+// Prometheus CR, selector empty or expression-only) returns nil — the caller
+// then writes the CR without extra labels, which is the pre-existing
+// behaviour.
+func (m *Mutator) ruleSelectorLabels(ctx context.Context) map[string]string {
+	if m.dynamic == nil {
+		return nil
+	}
+	list, err := m.dynamic.Resource(prometheusGVR).Namespace(metav1.NamespaceAll).
+		List(ctx, metav1.ListOptions{})
+	if err != nil {
+		m.logger().Warn("mutate: cannot read Prometheus CRs to derive ruleSelector labels; "+
+			"alert rules may not be evaluated", "error", err)
+		return nil
+	}
+	if len(list.Items) == 0 {
+		m.logger().Warn("mutate: no Prometheus CR found; writing alert rule without " +
+			"ruleSelector labels")
+		return nil
+	}
+
+	items := list.Items
+	sort.Slice(items, func(i, j int) bool {
+		// Same-namespace CRs first, then namespace/name for determinism.
+		iLocal := items[i].GetNamespace() == m.Namespace
+		jLocal := items[j].GetNamespace() == m.Namespace
+		if iLocal != jLocal {
+			return iLocal
+		}
+		if items[i].GetNamespace() != items[j].GetNamespace() {
+			return items[i].GetNamespace() < items[j].GetNamespace()
+		}
+		return items[i].GetName() < items[j].GetName()
+	})
+
+	for i := range items {
+		raw, found, err := unstructured.NestedStringMap(items[i].Object, "spec", "ruleSelector", "matchLabels")
+		if err != nil || !found || len(raw) == 0 {
+			continue
+		}
+		m.logger().Info("mutate: derived PrometheusRule selector labels",
+			"prometheus", items[i].GetNamespace()+"/"+items[i].GetName(), "labels", raw)
+		return raw
+	}
+
+	// Every Prometheus either selects all rules (empty selector) or uses
+	// matchExpressions, which we cannot satisfy by stamping labels.
+	m.logger().Warn("mutate: no Prometheus CR exposes spec.ruleSelector.matchLabels; " +
+		"writing alert rule without ruleSelector labels")
+	return nil
+}


### PR DESCRIPTION
## Summary

Alert rules created from the UI have never been evaluated by Prometheus. The runner writes them into a `PrometheusRule` CR labelled only `release.app` + `role`, but prometheus-operator loads a rule only when its labels match the Prometheus CR's `spec.ruleSelector` — kube-prometheus-stack defaults that to `release: <its own Helm release name>`. The apiserver accepts the CR, the operator marks it validated, and the rule silently does nothing.

Found on the `abc` cluster: a user-created `PVCPendingMissingStorageClass` rule returned data in the Prometheus UI but never alerted. The CR was absent from the operator's mounted rulefiles directory.

This derives the required labels from the Prometheus CR instead of guessing them, and applies them on update as well as create so CRs already written without them heal on the next rule write.

## How a reviewer confirms it

On any cluster running the agent, create an alert rule from the UI, then:

```bash
NS=nudgebee-agent   # the agent's install namespace

# 1. The CR now carries the operator's selector label.
kubectl -n $NS get prometheusrule nudgebee-prometheus.rules -o jsonpath='{.metadata.labels}'
# want: it contains whatever ruleSelector.matchLabels the Prometheus CR asks for
kubectl -n $NS get prometheus -o jsonpath='{.items[*].spec.ruleSelector.matchLabels}'

# 2. The operator actually mounted it (this is the check that catches the bug).
kubectl -n $NS exec prometheus-<sts>-0 -c prometheus -- \
  ls /etc/prometheus/rules/prometheus-<sts>-rulefiles-0/ | grep nudgebee-prometheus.rules

# 3. Prometheus is evaluating it.
kubectl -n $NS port-forward svc/<prometheus-svc> 9090:9090
curl -s localhost:9090/api/v1/rules | jq '.data.groups[].rules[] | select(.name=="<YourAlert>")'
# want: "health": "ok" and a state of inactive/pending/firing, not an absent rule
```

Before this change, step 2 finds nothing and step 3 returns empty.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (chart upgrade requires user action)
- [ ] Documentation only
- [ ] CI / tooling

## Chart version

- [x] I bumped `version` in `charts/nudgebee-agent/Chart.yaml` (0.1.20 → 0.1.21)
- [ ] No version bump needed (docs/CI only)

## Test plan

- [x] `helm lint charts/nudgebee-agent` passes
- [ ] `ct lint --config .github/configs/ct.yaml` passes — not installed locally, covered by `helm-dev-lint`
- [x] `helm template` output reviewed (both `runner.readOnly=true` and `false`)
- [x] Verified against a real cluster — see below

## Related issues

No existing ticket found in `nudgebee/k8s-agent` or `nudgebee/nudgebee-enterprise`. Surfaced while debugging a live alert rule on `abc`.

<details>
<summary>Why the label was missing, and why the obvious fix is wrong</summary>

The Python playbook this Go path replaced set three labels:

```python
"labels": {
    "release": RELEASE_NAME,                            # selector label
    "role": "alert-rules",
    "release.app": "nudgebee-resource-management",      # identification label
},
```

The two serve different consumers. `release.app` is how the agent finds its own CR again; `release` is what prometheus-operator selects on. The port kept the first and dropped the second — nothing in the runner reads `release`, so it looked dead.

Restoring `release: RELEASE_NAME` would not have fixed it. `RELEASE_NAME` defaults to `nudgebee-agent`, but the selector wants the **Prometheus stack's** release name. On `abc` those are two different Helm releases (`nudgebee-agent` and `nudgebee-prometheus`), as they are in every install we ship. The legacy value was wrong too; dropping it only turned a conditional failure into a total one.

Hence discovery: read `spec.ruleSelector.matchLabels` off the Prometheus CR — agent namespace first, then cluster-wide in a deterministic order — and merge it in.

</details>

<details>
<summary>Rollout, RBAC, and failure behaviour</summary>

**RBAC.** The runner SA could not list `prometheuses` (`kubectl auth can-i` → `no`). Read-only `get`/`list` added to both `runner-service-account.yaml` and `runner-service-account-readonly.yaml`; the former's header asks for the two files' read rules to be kept in sync.

**Order-independent rollout.** If discovery fails — no RBAC yet, CRD absent, no Prometheus CR, or an expression-only selector — it logs a warning and falls back to the previous label set rather than failing the request. So the runner image and the chart RBAC can ship in either order without a regression.

**Healing.** Labels were previously written only in the `IsNotFound` → `Create` branch; the update branch touched `spec.groups` alone. A CR that already exists with the wrong labels could therefore never recover, no matter how many rules were added to it. `applySelectorLabels` now runs on update too. Values an operator set by hand are left alone — only missing keys are added.

**Known limitation.** A Prometheus whose `ruleNamespaceSelector` excludes the agent's namespace still will not load the rule. Labels cannot fix that; it needs a chart/values change on the Prometheus side.

</details>

<details>
<summary>Evidence from the abc cluster</summary>

Before — 35 rulefiles mounted, all `kube-p-*`, ours absent despite `prometheus-operator-validated: "true"` on the CR:

```
$ kubectl -n nudgebee-agent get prometheus -o jsonpath='{.items[*].spec.ruleSelector}'
{"matchLabels":{"release":"nudgebee-prometheus"}}

$ kubectl -n nudgebee-agent get prometheusrule nudgebee-prometheus.rules -o jsonpath='{.metadata.labels}'
{"release.app":"nudgebee-resource-management","role":"alert-rules"}
```

After stamping the missing label by hand (the same label set this PR derives automatically) — 36 rulefiles, and:

```
$ curl -s localhost:9090/api/v1/rules | ...
LOADED  state=firing health=ok for=60s
  -> firing {"alertname":"PVCPendingMissingStorageClass","namespace":"storage-lab",
             "persistentvolumeclaim":"bad-pvc","phase":"Pending","severity":"critical"}
```

**Unit coverage** (6 new tests in `alertrules_test.go`): labels stamped on create; existing CR healed on update; hand-edited label preserved; agent-namespace Prometheus preferred over another namespace's; rule still written when no Prometheus CR is readable; expression-only selector ignored rather than guessed at.

`gofmt`, `go vet ./...`, `go test ./...` and `go test -race ./pkg/mutate/` all clean. `golangci-lint` could not run locally (local binary is Go 1.25, module targets 1.26.3) — covered by `runner-lint-test`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
